### PR TITLE
a patch to generate.py to address masking not working

### DIFF
--- a/scripts/deforum/generate.py
+++ b/scripts/deforum/generate.py
@@ -1,4 +1,5 @@
 import torch
+import PIL #HOTFIXISSUE#33 needed for instruction to generate negative mask. 
 from PIL import Image, ImageOps
 import requests
 import numpy as np

--- a/scripts/deforum/generate.py
+++ b/scripts/deforum/generate.py
@@ -194,11 +194,15 @@ def generate(args, root, frame = 0, return_sample=False):
             assert args.mask_file is not None or mask_image is not None, "use_mask==True: An mask image is required for a mask. Please enter a mask_file or use an init image with an alpha channel"
             assert args.use_init, "use_mask==True: use_init is required for a mask"
 
-
+            # this is meant to be a specific work around to tackle image and video masking not working at all
             mask = prepare_mask(args.mask_file if mask_image is None else mask_image, 
-                                init_image.shape, 
-                                args.mask_contrast_adjust, 
-                                args.mask_brightness_adjust,
+                                # should this be the shape of init_latent or latent diffuse? 
+                                #init_image.shape
+                                (args.W, args.H), #this is a workaround as mentioned by OP of issue #33. #HOTFIXISSUE#33
+                                1, # contrast mask needs to be addressed in args and other places. #HOTFIXISSUE#33
+                                1, # brightness also needs specification in order to work.#HOTFIXISSUE#33
+                                #args.mask_contrast_adjust, 
+                                #args.mask_brightness_adjust,
                                 args.invert_mask)
             
             #if (torch.all(mask == 0) or torch.all(mask == 1)) and args.use_alpha_as_mask:
@@ -211,8 +215,11 @@ def generate(args, root, frame = 0, return_sample=False):
         assert not ( (args.use_mask and args.overlay_mask) and (args.init_sample is None and init_image is None)), "Need an init image when use_mask == True and overlay_mask == True"
         
         p.init_images = [init_image]
-        p.mask = mask
         
+        # there may be more functionality that is availabe in other forms of masking such as latent space masking, however the issue #33 specified video mask not working.
+        # consequent issues found both image and video masking were not working.
+        # p.mask = mask # what was being returned is an Image, take the image_mask pathway to masking =). 
+        p.image_mask = mask #HOTFIXISSUE#33
         processed = processing.process_images(p)
     
     if root.initial_info == None:


### PR DESCRIPTION
Addresses issue#33 and masking portion of issue#40
Some comments left in generate.py. This "patch" may not address all of the issues that could be present with masking, if any. This addresses being able to use image and video masks and to allow negative images.

This does not fix or address issues with passing the mask_brightness_adjust and mask_contrast_adjust arguments to the prepare_mask(...) function.  That functionality has been essentially disabled in this patch as some declarations and setup is required in other files. 

As of now, the default values of brightness and contrast are 1.0, which should result in unchanged masks. A future work around to tighten up masking arguments can be tackled in a separate branch as the issues are not exactly related.

The negative image patch was included in this patch as it was very simple add and only affects a single file. ( generate.py )