### PR TITLE
Add interpolation animation mode

### DIFF
--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -60,7 +60,7 @@ class DeforumScript(wscripts.Script):
         gc.collect()
         torch.cuda.empty_cache()
         
-        from scripts.deforum_helpers.render import render_animation, render_input_video, render_animation_with_video_mask
+        from scripts.deforum_helpers.render import render_animation, render_input_video, render_animation_with_video_mask, render_interpolation
 
         tqdm_backup = shared.total_tqdm
         shared.total_tqdm = deforum_settings.DeforumTQDM(args, anim_args)
@@ -73,6 +73,8 @@ class DeforumScript(wscripts.Script):
                     render_animation(args, anim_args, root.animation_prompts, root)
             elif anim_args.animation_mode == 'Video Input':
                 render_input_video(args, anim_args, root.animation_prompts, root)#TODO: prettify code
+            elif anim_args.animation_mode == 'Interpolation':
+                render_interpolation(args, anim_args, root.animation_prompts, root)
             else:
                 print('Other modes are not available yet!')
         finally:

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -306,7 +306,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
         #TODO make a some sort of the original dictionary parsing
         i9 = gr.HTML("<p style=\"font-weight:bold;margin-bottom:0.75em\">Animation settings</p>")
         with gr.Row():
-            animation_mode = gr.Dropdown(label="animation_mode", choices=['2D', '3D', 'Video Input'], value=da.animation_mode, type="value", elem_id="animation_mode", interactive=True)
+            animation_mode = gr.Dropdown(label="animation_mode", choices=['2D', '3D', 'Video Input', 'Interpolation'], value=da.animation_mode, type="value", elem_id="animation_mode", interactive=True)
             max_frames = gr.Number(label="max_frames", value=da.max_frames, interactive=True, precision=0)
             border = gr.Dropdown(label="border", choices=['replicate', 'wrap'], value=da.border, type="value", elem_id="border", interactive=True)
         

--- a/scripts/deforum_helpers/generate.py
+++ b/scripts/deforum_helpers/generate.py
@@ -163,7 +163,7 @@ def generate(args, root, frame = 0, return_sample=False):
                                           shape=(args.W, args.H),  
                                           use_alpha_as_mask=args.use_alpha_as_mask)
     else:
-        # sometimes my genius... is almost frightening
+        print(f"Not using an init image (doing pure txt2img) - seed:{p.seed}; subseed:{p.subseed}; subseed_strength:{p.subseed_strength}; cfg_scale:{p.cfg_scale}; steps:{p.steps}")
         p_txt = StableDiffusionProcessingTxt2Img(
                 sd_model=sd_model,
                 outpath_samples=p.outpath_samples,
@@ -187,7 +187,7 @@ def generate(args, root, frame = 0, return_sample=False):
                 restore_faces=p.restore_faces,
                 tiling=p.tiling,
                 enable_hr=None,
-                denoising_strength=None,#for initial image
+                denoising_strength=None,
             )
         processed = processing.process_images(p_txt)
     

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -333,7 +333,7 @@ def render_interpolation(args, anim_args, animation_prompts, root):
 
 def interpolate_prompts(animation_prompts, max_frames):
     # Get prompts sorted by keyframe 
-    sorted_prompts = sorted(animation_prompts.items())
+    sorted_prompts = sorted(animation_prompts.items(), key=lambda item: int(item[0]))
 
     # Setup container for interpolated prompts
     prompt_series = pd.Series([np.nan for a in range(max_frames)])


### PR DESCRIPTION
Adds **Interpolation** animation mode similar to the original Deforum. The purpose is to blend between prompts using pure txt2img (no image input). Works best with a fixed seed. 

Example output with the following animation prompts and a fixed seed:
```
{
    "0": "(scenic countryside:1.0)",
    "60": "a beautiful (((banana))), trending on Artstation",
    "80": "a beautiful coconut --neg photo, realistic",
    "100": "a beautiful durian, trending on Artstation"
}

```

https://user-images.githubusercontent.com/74455/203445060-83d94601-3846-4943-a8b7-fffb9af97a3b.mp4


Notes:
- Motion parameters and cadence are deliberately ignored in this animation mode (they don't make sense without an input image).
- Prompt interpolation uses a1111's [composable diffusion feature](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Features#composable-diffusion), which IMO is the right thing to do in this extension, but IIUC is not the same approach as the original Deforum implementation, so results may differ.
- An implication is that if the animation prompts already use composable diffusion (i.e. the AND keyword), results will be unexpected because only part of the prompt will be interpolated. A warning is emitted in these cases.
- Unlike the original Deforum implementation, this implementation does not force the seed to be fixed when using Interpolation mode. The reason is, this mode can also be used for [seed travelling](https://github.com/yownas/seed_travel), which will be possible with the parseq integration (or without parseq if we add direct support for subseed and subseed_stregth schedules).
