### PR TITLE
Adapt to a1111 change to expect sampler name rather than sampler index (fix #102)

### DIFF
--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -264,7 +264,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
         with gr.Row():
             seed = gr.Number(label="seed", value=d.seed, interactive=True, precision=0)
             from modules.sd_samplers import samplers_for_img2img
-            sampler = gr.Dropdown(label="sampler", choices=[x.name for x in samplers_for_img2img], value=samplers_for_img2img[0].name, type="index", elem_id="sampler", interactive=True)
+            sampler = gr.Dropdown(label="sampler", choices=[x.name for x in samplers_for_img2img], value=samplers_for_img2img[0].name, type="value", elem_id="sampler", interactive=True)
         with gr.Row():
             seed_enable_extras = gr.Checkbox(label="Enable extras", value=False)
             subseed = gr.Number(label="subseed", value=d.subseed, interactive=True, precision=0)
@@ -542,12 +542,12 @@ def process_args(self, p, override_settings_with_file, custom_settings_file, ani
         args.W, args.H = map(lambda x: x - x % 64, (args.W, args.H))
         args.steps = p.steps
         args.seed = p.seed
-        args.sampler = p.sampler_index
+        args.sampler = p.sampler_name
     else:
         p.width, p.height = map(lambda x: x - x % 64, (args.W, args.H))
         p.steps = args.steps
         p.seed = args.seed
-        p.sampler_index = args.sampler
+        p.sampler_name = args.sampler
         p.batch_size = args.n_batch
         p.restore_faces = args.restore_faces
         p.tiling = args.tiling

--- a/scripts/deforum_helpers/generate.py
+++ b/scripts/deforum_helpers/generate.py
@@ -119,7 +119,7 @@ def generate(args, root, frame = 0, return_sample=False):
     p.do_not_save_samples = not args.save_sample_per_step
     p.do_not_save_grid = not args.make_grid
     p.sd_model=sd_model
-    p.sampler_index = int(args.sampler)
+    p.sampler_name = args.sampler
     p.mask_blur = args.mask_overlay_blur
     p.extra_generation_params["Mask blur"] = args.mask_overlay_blur
     p.n_iter = 1
@@ -177,7 +177,7 @@ def generate(args, root, frame = 0, return_sample=False):
                 seed_resize_from_h=p.seed_resize_from_h,
                 seed_resize_from_w=p.seed_resize_from_w,
                 seed_enable_extras=None,
-                sampler_index=p.sampler_index,
+                sampler_name=p.sampler_name,
                 batch_size=p.batch_size,
                 n_iter=p.n_iter,
                 steps=p.steps,


### PR DESCRIPTION
This change in the main a1111 repo has broken most scripts & extensions: https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/cdc8020d13c5eef099c609b0a911ccf3568afc0d

Reported by Deforum users as:  https://github.com/deforum-art/deforum-for-automatic1111-webui/issues/102 .

This PR fixes the main issue.

I've also tested loading settings saved prior to this change, as well as saving+loading settings after this change – it all seems good (seems like the settings loading logic tolerates either sampler index or name in the file).