### PR TITLE
Bug fixes, QOL, deforum main sync

### DIFF
--- a/scripts/deforum_helpers/animation.py
+++ b/scripts/deforum_helpers/animation.py
@@ -163,6 +163,27 @@ def warpMatrix(W, H, theta, phi, gamma, scale, fV):
 
     return M33, sideLength
 
+def anim_frame_warp(root, prev, args, anim_args, keys, frame_idx, depth_model=None, depth=None, device='cuda'):
+    if isinstance(prev, np.ndarray):
+        prev_img_cv2 = prev
+    else:
+        prev_img_cv2 = sample_to_cv2(prev)
+
+    #TODO is this necessary here? Its assigned in render.py right before this fuction is called
+    #if this is not necessary, the arg root can also be removed
+    if anim_args.use_depth_warping:
+        if depth is None and depth_model is not None:
+            depth = depth_model.predict(prev_img_cv2, anim_args, root.half_precision) if depth_model else None
+    else:
+        depth = None
+
+    if anim_args.animation_mode == '2D':
+        prev_img = anim_frame_warp_2d(prev_img_cv2, args, anim_args, keys, frame_idx)
+    else: # '3D'
+        prev_img = anim_frame_warp_3d(device, prev_img_cv2, depth, anim_args, keys, frame_idx)
+                
+    return prev_img, depth
+
 def anim_frame_warp_2d(prev_img_cv2, args, anim_args, keys, frame_idx):
     angle = keys.angle_series[frame_idx]
     zoom = keys.zoom_series[frame_idx]
@@ -224,7 +245,10 @@ def transform_image_3d(device, prev_img_cv2, depth_tensor, rot_mat, translate, a
 
     # range of [-1,1] is important to torch grid_sample's padding handling
     y,x = torch.meshgrid(torch.linspace(-1.,1.,h,dtype=torch.float32,device=device),torch.linspace(-1.,1.,w,dtype=torch.float32,device=device))
-    z = torch.as_tensor(depth_tensor, dtype=torch.float32, device=device)
+    if depth_tensor is None:
+        z = torch.ones_like(x)
+    else:
+        z = torch.as_tensor(depth_tensor, dtype=torch.float32, device=device)
     xyz_old_world = torch.stack((x.flatten(), y.flatten(), z.flatten()), dim=1)
 
     xyz_old_cam_xy = persp_cam_old.get_full_projection_transform().transform_points(xyz_old_world)[:,0:2]

--- a/scripts/deforum_helpers/animation.py
+++ b/scripts/deforum_helpers/animation.py
@@ -9,6 +9,7 @@ import re
 import pathlib
 import os
 import pandas as pd
+import shutil
 
 def check_is_number(value):
     float_pattern = r'^(?=.)([+-]?([0-9]*)(\.([0-9]+))?)$'
@@ -32,24 +33,57 @@ def construct_RotationMatrixHomogenous(rotation_angles):
     cv2.Rodrigues(np.array(rotation_angles), RH[0:3, 0:3])
     return RH
 
-def vid2frames(video_path, video_in_frame_path, n=1, overwrite=True):      
-    input_content = os.listdir(video_in_frame_path)
-    if len(input_content) == 0 or overwrite:
-        try:
-            for f in pathlib.Path(video_path).glob('*.jpg'):
-                f.unlink()
-        except:
-            pass
-        assert os.path.exists(video_path), f"Video input {video_path} does not exist"
-          
-        vidcap = cv2.VideoCapture(video_path)
+def get_frame_name(path):
+    name = os.path.basename(path)
+    name = os.path.splitext(name)[0]
+    return name
+
+def vid2frames(video_path, video_in_frame_path, n=1, overwrite=True): 
+    #get the name of the video without the path and ext
+    name = get_frame_name(video_path)
+    print(name)
+
+    if n < 1: n = 1 #HACK Gradio interface does not currently allow min/max in gr.Number(...) 
+    if os.path.exists(video_path) != True :
+        raise RuntimeError('Video path does not exist')
+
+    input_content = []
+    if os.path.exists(video_in_frame_path) :
+        input_content = os.listdir(video_in_frame_path)
+
+    # check if existing frame is the same video, if not we need to erase it and repopulate
+    if len(input_content) > 0:
+        #get the name of the existing frame
+        content_name = get_frame_name(input_content[0])
+        print(content_name)
+        if not content_name.startswith(name):
+            overwrite = True
+
+    vidcap = cv2.VideoCapture(video_path)
+
+    # grab the frame count to check against existing directory len 
+    frame_count = int(vidcap.get(cv2.CAP_PROP_FRAME_COUNT)) 
+    
+    # raise error if the user wants to skip more frames than exist
+    if n >= frame_count : 
+        raise RuntimeError('Skipping more frames than input video contains. extract_nth_frames larger than input frames')
+    
+    expected_frame_count = math.ceil(frame_count / n) 
+
+    # Check to see if the frame count is matches the number of files in path
+    if overwrite or expected_frame_count != len(input_content):
+        shutil.rmtree(video_in_frame_path)
+        os.makedirs(video_in_frame_path, exist_ok=True) # just deleted the folder so we need to make it again
+        input_content = os.listdir(video_in_frame_path)
+    
+    if len(input_content) == 0:
         success,image = vidcap.read()
         count = 0
         t=1
         success = True
         while success:
             if count % n == 0:
-                cv2.imwrite(video_in_frame_path + os.path.sep + f"{t:05}.jpg" , image)     # save frame as JPEG file
+                cv2.imwrite(video_in_frame_path + os.path.sep + name + f"{t:05}.jpg" , image)     # save frame as JPEG file
                 t += 1
             success,image = vidcap.read()
             count += 1

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -160,9 +160,9 @@ def DeforumArgs():
     # Blur edges of final overlay mask, if used. Minimum = 0 (no blur)
     mask_overlay_blur = 5 # {type:"number"}
 
-    fill = 1 #MASKARGSEXPANSION Todo : Rename and convert to same formatting as used in img2img masked content
-    full_res_mask = True
-    full_res_mask_padding = 4
+    fill = 1 #@param {type:"number"} 0-3
+    full_res_mask = True #@param {type:"boolean"}
+    full_res_mask_padding = 4 #@param {type:"number"}
 
     n_samples = 1 # doesnt do anything
     precision = 'autocast' 
@@ -173,6 +173,7 @@ def DeforumArgs():
     timestring = ""
     init_latent = None
     init_sample = None
+    mask_image = None
     init_c = None
 
     return locals()
@@ -445,7 +446,9 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
             resume_from_timestring = gr.Checkbox(label="resume_from_timestring", value=da.resume_from_timestring, interactive=True)
             resume_timestring = gr.Textbox(label="resume_timestring", lines=1, value = da.resume_timestring, interactive=True)
         # Init settings END
-        
+   # with gr.Tab('Coherence'):
+     #   with gr.Row():
+
     with gr.Tab('Video output'):
         # Video output settings START
         i35 = gr.HTML("<p style=\"margin-bottom:0.75em\">Video output settings</p>")
@@ -488,6 +491,7 @@ def pack_args(W, H, restore_faces, tiling, enable_hr, firstphase_width, firstpha
     timestring = ""
     init_latent = None
     init_sample = None
+    mask_image = None
     init_c = None
     return locals()
     

--- a/scripts/deforum_helpers/depth.py
+++ b/scripts/deforum_helpers/depth.py
@@ -129,7 +129,7 @@ class DepthModel():
 
             # blend between MiDaS and AdaBins predictions
             if use_adabins:
-                depth_map = torch.tensor(midas_depth)*anim_args.midas_weight + adabins_depth*(1.0-anim_args.midas_weight)
+                depth_map = midas_depth*anim_args.midas_weight + adabins_depth*(1.0-anim_args.midas_weight)
             else:
                 depth_map = midas_depth
 

--- a/scripts/deforum_helpers/depth.py
+++ b/scripts/deforum_helpers/depth.py
@@ -59,7 +59,7 @@ class DepthModel():
             self.midas_model = self.midas_model.half()
         self.midas_model.to(self.device)
 
-    def predict(self, prev_img_cv2, anim_args) -> torch.Tensor:
+    def predict(self, prev_img_cv2, anim_args, half_precision) -> torch.Tensor:
         w, h = prev_img_cv2.shape[1], prev_img_cv2.shape[0]
 
         # predict depth with AdaBins    
@@ -94,6 +94,7 @@ class DepthModel():
                         torch.Size([h, w]),
                         interpolation=TF.InterpolationMode.BICUBIC
                     )
+                    adabins_depth = adabins_depth.cpu().numpy()
                 adabins_depth = adabins_depth.squeeze()
             except:
                 print(f"  exception encountered, falling back to pure MiDaS")
@@ -109,7 +110,8 @@ class DepthModel():
             sample = torch.from_numpy(img_midas_input).float().to(self.device).unsqueeze(0)
             if self.device == torch.device("cuda"):
                 sample = sample.to(memory_format=torch.channels_last)  
-                sample = sample.half()
+                if half_precision:
+                    sample = sample.half()
             with torch.no_grad():            
                 midas_depth = self.midas_model.forward(sample)
             midas_depth = torch.nn.functional.interpolate(
@@ -149,4 +151,3 @@ class DepthModel():
         temp = rearrange((depth - self.depth_min) / denom * 255, 'c h w -> h w c')
         temp = repeat(temp, 'h w 1 -> h w c', c=3)
         Image.fromarray(temp.astype(np.uint8)).save(filename)    
-

--- a/scripts/deforum_helpers/load_images.py
+++ b/scripts/deforum_helpers/load_images.py
@@ -1,0 +1,54 @@
+import requests
+from PIL import Image
+import numpy as np
+import torchvision.transforms.functional as TF
+
+def load_img(path : str, shape=None, use_alpha_as_mask=False):
+    # use_alpha_as_mask: Read the alpha channel of the image as the mask image
+    image = load_image(path)
+    if use_alpha_as_mask:
+        image = image.convert('RGBA')
+    else:
+        image = image.convert('RGB')
+
+    if shape is not None:
+        image = image.resize(shape, resample=Image.LANCZOS)
+
+    mask_image = None
+    if use_alpha_as_mask:
+        # Split alpha channel into a mask_image
+        red, green, blue, alpha = Image.Image.split(image)
+        mask_image = alpha.convert('L')
+        image = image.convert('RGB')
+        
+        # check using init image alpha as mask if mask is not blank
+        extrema = mask_image.getextrema()
+        if (extrema == (0,0)) or extrema == (255,255):
+            print("use_alpha_as_mask==True: Using the alpha channel from the init image as a mask, but the alpha channel is blank.")
+            print("ignoring alpha as mask.")
+            mask_image = None
+
+    return image, mask_image
+
+def load_image(image_path :str):
+    if image_path.startswith('http://') or image_path.startswith('https://'):
+        image = Image.open(requests.get(image_path, stream=True).raw).convert('RGB')
+    else:
+        image = Image.open(image_path).convert('RGB')
+    return image
+
+def prepare_mask(mask_input, mask_shape, mask_brightness_adjust=1.0, mask_contrast_adjust=1.0):
+    """
+    prepares mask for use in webui
+    """
+    if isinstance(mask_input, Image.Image):
+        mask = mask_input
+    else :
+        mask = load_image(mask_input)
+    mask = mask.resize(mask_shape, resample=Image.LANCZOS)
+    if mask_brightness_adjust != 1:
+        mask = TF.adjust_brightness(mask, mask_brightness_adjust)
+    if mask_contrast_adjust != 1:
+        mask = TF.adjust_contrast(mask, mask_contrast_adjust)
+    mask = mask.convert('L')
+    return mask

--- a/scripts/deforum_helpers/prompt.py
+++ b/scripts/deforum_helpers/prompt.py
@@ -1,5 +1,19 @@
 import re
 
+def parse_weight(match, frame = 0)->float:
+    import numexpr
+    w_raw = match.group("weight")
+    if w_raw == None:
+        return 1
+    if check_is_number(w_raw):
+        return float(w_raw)
+    else:
+        t = frame
+        if len(w_raw) < 3:
+            print('the value inside `-characters cannot represent a math function')
+            return 1
+        return float(numexpr.evaluate(w_raw[1:-1]))
+
 def split_weighted_subprompts(text, frame = 0):
     """
     splits the prompt based on deforum webui implementation, moved from generate.py 
@@ -10,7 +24,7 @@ def split_weighted_subprompts(text, frame = 0):
             ))
             """, re.VERBOSE)
     
-    parsed_prompt = re.sub(math_parser, lambda m: str(parse_weight(m, frame)), text)
+    parsed_prompt = re.sub(math_parser, lambda m: str(text(m, frame)), text)
 
     negative_prompts = []
     positive_prompts = []

--- a/scripts/deforum_helpers/prompt.py
+++ b/scripts/deforum_helpers/prompt.py
@@ -1,5 +1,9 @@
 import re
 
+def check_is_number(value):
+    float_pattern = r'^(?=.)([+-]?([0-9]*)(\.([0-9]+))?)$'
+    return re.match(float_pattern, value)
+
 def parse_weight(match, frame = 0)->float:
     import numexpr
     w_raw = match.group("weight")
@@ -24,7 +28,7 @@ def split_weighted_subprompts(text, frame = 0):
             ))
             """, re.VERBOSE)
     
-    parsed_prompt = re.sub(math_parser, lambda m: str(text(m, frame)), text)
+    parsed_prompt = re.sub(math_parser, lambda m: str(parse_weight(m, frame)), text)
 
     negative_prompts = []
     positive_prompts = []

--- a/scripts/deforum_helpers/prompt.py
+++ b/scripts/deforum_helpers/prompt.py
@@ -1,130 +1,28 @@
 import re
 
-def sanitize(prompt):
-    whitelist = set('abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ')
-    tmp = ''.join(filter(whitelist.__contains__, prompt))
-    return tmp.replace(' ', '_')
-
-def check_is_number(value):
-    float_pattern = r'^(?=.)([+-]?([0-9]*)(\.([0-9]+))?)$'
-    return re.match(float_pattern, value)
-
-# prompt weighting with colons and number coefficients (like 'bacon:0.75 eggs:0.25')
-# borrowed from https://github.com/kylewlacy/stable-diffusion/blob/0a4397094eb6e875f98f9d71193e350d859c4220/ldm/dream/conditioning.py
-# and https://github.com/raefu/stable-diffusion-automatic/blob/unstablediffusion/modules/processing.py
-def get_uc_and_c(prompts, model, args, frame = 0):
-    prompt = prompts[0] # they are the same in a batch anyway
-
-    # get weighted sub-prompts
-    negative_subprompts, positive_subprompts = split_weighted_subprompts(
-        prompt, frame, not args.normalize_prompt_weights
-    )
-
-    uc = get_learned_conditioning(model, negative_subprompts, "", args, -1)
-    c = get_learned_conditioning(model, positive_subprompts, prompt, args, 1)
-
-    return (uc, c)
-
-def get_learned_conditioning(model, weighted_subprompts, text, args, sign = 1):
-    if len(weighted_subprompts) < 1:
-        log_tokenization(text, model, args.log_weighted_subprompts, sign)
-        c = model.get_learned_conditioning(args.n_samples * [text])
-    else:
-        c = None
-        for subtext, subweight in weighted_subprompts:
-            log_tokenization(subtext, model, args.log_weighted_subprompts, sign * subweight)
-            if c is None:
-                c = model.get_learned_conditioning(args.n_samples * [subtext])
-                c *= subweight
-            else:
-                c.add_(model.get_learned_conditioning(args.n_samples * [subtext]), alpha=subweight)
-        
-    return c
-
-def parse_weight(match, frame = 0)->float:
-    import numexpr
-    w_raw = match.group("weight")
-    if w_raw == None:
-        return 1
-    if check_is_number(w_raw):
-        return float(w_raw)
-    else:
-        t = frame
-        if len(w_raw) < 3:
-            print('the value inside `-characters cannot represent a math function')
-            return 1
-        return float(numexpr.evaluate(w_raw[1:-1]))
-
-def normalize_prompt_weights(parsed_prompts):
-    if len(parsed_prompts) == 0:
-        return parsed_prompts
-    weight_sum = sum(map(lambda x: x[1], parsed_prompts))
-    if weight_sum == 0:
-        print(
-            "Warning: Subprompt weights add up to zero. Discarding and using even weights instead.")
-        equal_weight = 1 / max(len(parsed_prompts), 1)
-        return [(x[0], equal_weight) for x in parsed_prompts]
-    return [(x[0], x[1] / weight_sum) for x in parsed_prompts]
-
-def split_weighted_subprompts(text, frame = 0, skip_normalize=False):
+def split_weighted_subprompts(text, frame = 0):
     """
-    grabs all text up to the first occurrence of ':'
-    uses the grabbed text as a sub-prompt, and takes the value following ':' as weight
-    if ':' has no value defined, defaults to 1.0
-    repeats until no text remaining
+    splits the prompt based on deforum webui implementation, moved from generate.py 
     """
-    prompt_parser = re.compile("""
-            (?P<prompt>         # capture group for 'prompt'
-            (?:\\\:|[^:])+      # match one or more non ':' characters or escaped colons '\:'
-            )                   # end 'prompt'
-            (?:                 # non-capture group
-            :+                  # match one or more ':' characters
-            (?P<weight>((        # capture group for 'weight'
-            -?\d+(?:\.\d+)?     # match positive or negative integer or decimal number
-            )|(                 # or
-            `[\S\s]*?`# a math function
-            )))?                 # end weight capture group, make optional
-            \s*                 # strip spaces after weight
-            |                   # OR
-            $                   # else, if no ':' then match end of line
-            )                   # end non-capture group
+    math_parser = re.compile("""
+            (?P<weight>(
+            `[\S\s]*?`# a math function wrapped in `-characters
+            ))
             """, re.VERBOSE)
+    
+    parsed_prompt = re.sub(math_parser, lambda m: str(parse_weight(m, frame)), text)
+
     negative_prompts = []
     positive_prompts = []
-    for match in re.finditer(prompt_parser, text):
-        w = parse_weight(match, frame)
-        if w < 0:
-            # negating the sign as we'll feed this to uc
-            negative_prompts.append((match.group("prompt").replace("\\:", ":"), -w))
-        elif w > 0:
-            positive_prompts.append((match.group("prompt").replace("\\:", ":"), w))
 
-    if skip_normalize:
-        return (negative_prompts, positive_prompts)
-    return (normalize_prompt_weights(negative_prompts), normalize_prompt_weights(positive_prompts))
+    prompt_split = parsed_prompt.split("--neg")
+    if len(prompt_split) > 1:
+        positive_prompts, negative_prompts = parsed_prompt.split("--neg") #TODO: add --neg to vanilla Deforum for compat
+        print(f'Positive prompt:{positive_prompts}')
+        print(f'Negative prompt:{negative_prompts}')
+    else:
+        positive_prompts = prompt_split[0]
+        print(f'Positive prompt:{positive_prompts}')
+        negative_prompts = ""
 
-# shows how the prompt is tokenized
-# usually tokens have '</w>' to indicate end-of-word,
-# but for readability it has been replaced with ' '
-def log_tokenization(text, model, log=False, weight=1):
-    if not log:
-        return
-    tokens    = model.cond_stage_model.tokenizer._tokenize(text)
-    tokenized = ""
-    discarded = ""
-    usedTokens = 0
-    totalTokens = len(tokens)
-    for i in range(0, totalTokens):
-        token = tokens[i].replace('</w>', ' ')
-        # alternate color
-        s = (usedTokens % 6) + 1
-        if i < model.cond_stage_model.max_length:
-            tokenized = tokenized + f"\x1b[0;3{s};40m{token}"
-            usedTokens += 1
-        else:  # over max token length
-            discarded = discarded + f"\x1b[0;3{s};40m{token}"
-    print(f"\n>> Tokens ({usedTokens}), Weight ({weight:.2f}):\n{tokenized}\x1b[0m")
-    if discarded != "":
-        print(
-            f">> Tokens Discarded ({totalTokens-usedTokens}):\n{discarded}\x1b[0m"
-        )
+    return positive_prompts, negative_prompts

--- a/scripts/deforum_helpers/prompt.py
+++ b/scripts/deforum_helpers/prompt.py
@@ -26,3 +26,71 @@ def split_weighted_subprompts(text, frame = 0):
         negative_prompts = ""
 
     return positive_prompts, negative_prompts
+
+def interpolate_prompts(animation_prompts, max_frames):
+    # Get prompts sorted by keyframe 
+    sorted_prompts = sorted(animation_prompts.items(), key=lambda item: int(item[0]))
+
+    # Setup container for interpolated prompts
+    prompt_series = pd.Series([np.nan for a in range(max_frames)])
+
+    # For every keyframe prompt except the last
+    for i in range(0,len(sorted_prompts)-1):
+        
+        # Get current and next keyframe
+        current_frame = int(sorted_prompts[i][0])
+        next_frame = int(sorted_prompts[i+1][0])
+        
+        # Ensure there's no weird ordering issues or duplication in the animation prompts
+        # (unlikely because we sort above, and the json parser will strip dupes)
+        if current_frame>=next_frame:
+            print(f"WARNING: Sequential prompt keyframes {i}:{current_frame} and {i+1}:{next_frame} are not monotonously increasing; skipping interpolation.")
+            continue
+            
+        # Get current and next keyframes' positive and negative prompts (if any)
+        current_prompt = sorted_prompts[i][1]
+        next_prompt = sorted_prompts[i+1][1]
+        current_positive, current_negative, *_ = current_prompt.split("--neg") + [None]
+        next_positive, next_negative, *_ = next_prompt.split("--neg") + [None]
+        
+        # Calculate how much to shift the weight from current to next prompt at each frame
+        weight_step = 1/(next_frame-current_frame)
+        
+        # Apply weighted prompt interpolation for each frame between current and next keyframe
+        # using the syntax:  prompt1 :weight1 AND prompt1 :weight2 --neg nprompt1 :weight1 AND nprompt1 :weight2
+        # (See: https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Features#composable-diffusion )
+        for f in range(current_frame,next_frame):
+            next_weight = weight_step * (f-current_frame)
+            current_weight = 1 - next_weight
+            
+            # We will build the prompt incrementally depending on which prompts are present
+            prompt_series[f] = ''
+
+            # Cater for the case where neither, either or both current & next have positive prompts:
+            if current_positive:
+                prompt_series[f] += f"{current_positive} :{current_weight}"
+            if current_positive and next_positive:
+                prompt_series[f] += f" AND "
+            if next_positive:
+                prompt_series[f] += f"{next_positive} :{next_weight}"
+            
+            # Cater for the case where neither, either or both current & next have negative prompts:
+            if current_negative or next_negative:
+                prompt_series[f] += " --neg "
+                if current_negative:
+                    prompt_series[f] += f" {current_negative} :{current_weight}"
+                if current_negative and next_negative:
+                    prompt_series[f] += f" AND "
+                if next_negative:
+                    prompt_series[f] += f" {next_negative} :{next_weight}"
+    
+    # Set explicitly declared keyframe prompts (overwriting interpolated values at the keyframe idx). This ensures:
+    # - That final prompt is set, and
+    # - Gives us a chance to emit warnings if any keyframe prompts are already using composable diffusion
+    for i, prompt in animation_prompts.items():
+        prompt_series[int(i)] = prompt
+        if ' AND ' in prompt:
+            print(f"WARNING: keyframe {i}'s prompt is using composable diffusion (aka the 'AND' keyword). This will cause unexpected behaviour with interpolation.")
+    
+    # Return the filled series, in case max_frames is greater than the last keyframe or any ranges were skipped.
+    return prompt_series.ffill().bfill()

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -7,7 +7,7 @@ import numpy as np
 import pathlib
 
 from .generate import generate, add_noise
-from .animation import DeformAnimKeys, sample_from_cv2, sample_to_cv2, anim_frame_warp, vid2frames
+from .animation import DeformAnimKeys, sample_from_cv2, sample_to_cv2, anim_frame_warp, vid2frames, get_frame_name
 from .depth import DepthModel
 from .colors import maintain_colors
 from .load_images import prepare_mask
@@ -65,7 +65,7 @@ def render_animation(args, anim_args, animation_prompts, root):
     
     # load mask for first frame noise masking
     if anim_args.use_mask_video:
-        mask_frame = os.path.join(args.outdir, 'maskframes', f"{1:05}.jpg")
+        mask_frame = os.path.join(args.outdir, 'maskframes', get_frame_name(anim_args.video_mask_path) + f"{1:05}.jpg")
         args.mask_file = mask_frame
     if args.use_mask:
         args.mask_image = prepare_mask(args.mask_file, 
@@ -202,16 +202,16 @@ def render_animation(args, anim_args, animation_prompts, root):
             print(f"Tx: {keys.translation_x_series[frame_idx]} Ty: {keys.translation_y_series[frame_idx]} Tz: {keys.translation_z_series[frame_idx]}")
             print(f"Rx: {keys.rotation_3d_x_series[frame_idx]} Ry: {keys.rotation_3d_y_series[frame_idx]} Rz: {keys.rotation_3d_z_series[frame_idx]}")
             if anim_args.use_mask_video:
-                mask_frame = os.path.join(args.outdir, 'maskframes', f"{frame_idx+1:05}.jpg")
+                mask_frame = os.path.join(args.outdir, 'maskframes', get_frame_name(anim_args.video_mask_path) + f"{frame_idx+1:05}.jpg")
                 args.mask_file = mask_frame
 
         # grab init image for current frame
         if using_vid_init:
-            init_frame = os.path.join(args.outdir, 'inputframes', f"{frame_idx+1:05}.jpg")            
+            init_frame = os.path.join(args.outdir, 'inputframes', get_frame_name(anim_args.video_init_path) + f"{frame_idx+1:05}.jpg")            
             print(f"Using video init frame {init_frame}")
             args.init_image = init_frame
             if anim_args.use_mask_video:
-                mask_frame = os.path.join(args.outdir, 'maskframes', f"{frame_idx+1:05}.jpg")
+                mask_frame = os.path.join(args.outdir, 'maskframes', get_frame_name(anim_args.video_mask_path) + f"{frame_idx+1:05}.jpg")
                 args.mask_file = mask_frame
 
         # sample the diffusion model
@@ -258,6 +258,12 @@ def render_input_video(args, anim_args, animation_prompts, root):
         # save the video frames from mask video
         print(f"Exporting Video Frames (1 every {anim_args.extract_nth_frame}) frames to {mask_in_frame_path}...")
         vid2frames(anim_args.video_mask_path, mask_in_frame_path, anim_args.extract_nth_frame, anim_args.overwrite_extracted_frames)
+        max_mask_frames = len([f for f in pathlib.Path(mask_in_frame_path).glob('*.jpg')])
+
+        # limit max frames if there are less frames in the video mask compared to input video
+        if max_mask_frames < anim_args.max_frames :
+            anim_args.max_mask_frames
+            print ("Video mask contains less frames than init video, max frames limited to number of mask frames.")
         args.use_mask = True
         args.overlay_mask = True
 


### PR DESCRIPTION
Sync's more with deforum main, although features are still missing. 
Some restructuring of files to cleanup code.
* fixed the midas and adabins depth blend 
* fixed precision for midas model
* added back load_images.py
* reworked image loading as there were many unnecessary operations
* moved prompt related stuff to prompt.py
* reworked vid2frames
    * respects overwriting frames by actually removing the existing frames
    * names the frames as the filename of the video with the frame numbers appended
    * checks if the video name has changed and triggers rewrite
    * changing extract_nth_frames will trigger rewrite
    * expected framecount is calculated and if the differ from the framecount in the folder it will trigger rewrite
    * raises RuntimeError if trying to skip more frames than are in the current video
    * extract_nth_frame will be forced to 1 if less than 1
* render_input_video now adjusts args.max_frames if the mask video frame count is lower than the init_video
* frame noise is no longer added to masked areas
