### PR TITLE
Fix for vid2frames QOL

### DIFF
--- a/scripts/deforum_helpers/animation.py
+++ b/scripts/deforum_helpers/animation.py
@@ -11,6 +11,9 @@ import os
 import pandas as pd
 import shutil
 
+# Webui
+from modules.shared import state
+
 def check_is_number(value):
     float_pattern = r'^(?=.)([+-]?([0-9]*)(\.([0-9]+))?)$'
     return re.match(float_pattern, value)
@@ -83,6 +86,8 @@ def vid2frames(video_path, video_in_frame_path, n=1, overwrite=True):
         t=1
         success = True
         while success:
+            if state.interrupted:
+                return
             if count % n == 0:
                 cv2.imwrite(video_in_frame_path + os.path.sep + name + f"{t:05}.jpg" , image)     # save frame as JPEG file
                 t += 1

--- a/scripts/deforum_helpers/animation.py
+++ b/scripts/deforum_helpers/animation.py
@@ -32,24 +32,58 @@ def construct_RotationMatrixHomogenous(rotation_angles):
     cv2.Rodrigues(np.array(rotation_angles), RH[0:3, 0:3])
     return RH
 
-def vid2frames(video_path, video_in_frame_path, n=1, overwrite=True):      
-    input_content = os.listdir(video_in_frame_path)
-    if len(input_content) == 0 or overwrite:
-        try:
-            for f in pathlib.Path(video_path).glob('*.jpg'):
-                f.unlink()
-        except:
-            pass
-        assert os.path.exists(video_path), f"Video input {video_path} does not exist"
-          
-        vidcap = cv2.VideoCapture(video_path)
+def get_frame_name(path):
+    name = os.path.basename(path)
+    name = os.path.splitext(name)[0]
+    return name
+
+def vid2frames(video_path, video_in_frame_path, n=1, overwrite=True): 
+    #get the name of the video without the path and ext
+    name = get_frame_name(video_path)
+    if n < 1: n = 1 #HACK Gradio interface does not currently allow min/max in gr.Number(...) 
+
+    if video_path.startswith('http://') or video_path.startswith('https://'):
+        response = requests.head(video_path)
+        if response.status_code == 404 or response.status_code != 200:
+            raise ConnectionError("Init video url or mask video url is not valid")
+    else:
+        if not os.path.exists(video_path):
+            raise RuntimeError("Init video path or mask video path is not valid")
+
+    input_content = []
+    if os.path.exists(video_in_frame_path) :
+        input_content = os.listdir(video_in_frame_path)
+
+    # check if existing frame is the same video, if not we need to erase it and repopulate
+    if len(input_content) > 0:
+        #get the name of the existing frame
+        content_name = get_frame_name(input_content[0])
+        if not content_name.startswith(name):
+            overwrite = True
+    vidcap = cv2.VideoCapture(video_path)
+
+    # grab the frame count to check against existing directory len 
+    frame_count = int(vidcap.get(cv2.CAP_PROP_FRAME_COUNT)) 
+    
+    # raise error if the user wants to skip more frames than exist
+    if n >= frame_count : 
+        raise RuntimeError('Skipping more frames than input video contains. extract_nth_frames larger than input frames')
+    
+    expected_frame_count = math.ceil(frame_count / n) 
+    # Check to see if the frame count is matches the number of files in path
+    if overwrite or expected_frame_count != len(input_content):
+        shutil.rmtree(video_in_frame_path)
+        os.makedirs(video_in_frame_path, exist_ok=True) # just deleted the folder so we need to make it again
+        input_content = os.listdir(video_in_frame_path)
+    
+    if len(input_content) == 0:
         success,image = vidcap.read()
         count = 0
         t=1
         success = True
         while success:
             if count % n == 0:
-                cv2.imwrite(video_in_frame_path + os.path.sep + f"{t:05}.jpg" , image)     # save frame as JPEG file
+                cv2.imwrite(video_in_frame_path + os.path.sep + name + f"{t:05}.jpg" , image)     # save frame as JPEG file
                 t += 1
             success,image = vidcap.read()
             count += 1

--- a/scripts/deforum_helpers/animation.py
+++ b/scripts/deforum_helpers/animation.py
@@ -9,6 +9,7 @@ import re
 import pathlib
 import os
 import pandas as pd
+import shutil
 
 def check_is_number(value):
     float_pattern = r'^(?=.)([+-]?([0-9]*)(\.([0-9]+))?)$'

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -196,23 +196,23 @@ def render_animation(args, anim_args, animation_prompts, root):
             args.seed = int(keys.seed_schedule_series[frame_idx])
         
         print(f"{args.prompt} {args.seed}")
-        if not using_vid_init:
+         if not using_vid_init:
             print(f"Angle: {keys.angle_series[frame_idx]} Zoom: {keys.zoom_series[frame_idx]}")
             print(f"Tx: {keys.translation_x_series[frame_idx]} Ty: {keys.translation_y_series[frame_idx]} Tz: {keys.translation_z_series[frame_idx]}")
             print(f"Rx: {keys.rotation_3d_x_series[frame_idx]} Ry: {keys.rotation_3d_y_series[frame_idx]} Rz: {keys.rotation_3d_z_series[frame_idx]}")
             if anim_args.use_mask_video:
-                mask_frame = os.path.join(args.outdir, 'maskframes', f"{frame_idx+1:05}.jpg")
+                mask_frame = os.path.join(args.outdir, 'maskframes', get_frame_name(anim_args.video_mask_path) + f"{frame_idx+1:05}.jpg")
                 args.mask_file = mask_frame
 
         # grab init image for current frame
         if using_vid_init:
-            init_frame = os.path.join(args.outdir, 'inputframes', f"{frame_idx+1:05}.jpg")            
+            init_frame = os.path.join(args.outdir, 'inputframes', get_frame_name(anim_args.video_init_path) + f"{frame_idx+1:05}.jpg")            
             print(f"Using video init frame {init_frame}")
             args.init_image = init_frame
             if anim_args.use_mask_video:
-                mask_frame = os.path.join(args.outdir, 'maskframes', f"{frame_idx+1:05}.jpg")
+                mask_frame = os.path.join(args.outdir, 'maskframes', get_frame_name(anim_args.video_mask_path) + f"{frame_idx+1:05}.jpg")
                 args.mask_file = mask_frame
-
+                
         # sample the diffusion model
         sample, image = generate(args, anim_args, root, frame_idx, return_sample=True)
         if not using_vid_init:

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -196,7 +196,7 @@ def render_animation(args, anim_args, animation_prompts, root):
             args.seed = int(keys.seed_schedule_series[frame_idx])
         
         print(f"{args.prompt} {args.seed}")
-         if not using_vid_init:
+        if not using_vid_init:
             print(f"Angle: {keys.angle_series[frame_idx]} Zoom: {keys.zoom_series[frame_idx]}")
             print(f"Tx: {keys.translation_x_series[frame_idx]} Ty: {keys.translation_y_series[frame_idx]} Tz: {keys.translation_z_series[frame_idx]}")
             print(f"Rx: {keys.rotation_3d_x_series[frame_idx]} Ry: {keys.rotation_3d_y_series[frame_idx]} Rz: {keys.rotation_3d_z_series[frame_idx]}")

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -12,7 +12,7 @@ import torchvision.transforms as T
 
 from .generate import generate, add_noise
 from .prompt import sanitize
-from .animation import DeformAnimKeys, sample_from_cv2, sample_to_cv2, anim_frame_warp_2d, anim_frame_warp_3d, vid2frames
+from .animation import DeformAnimKeys, sample_from_cv2, sample_to_cv2, anim_frame_warp_2d, anim_frame_warp_3d, vid2frames, get_frame_name
 from .depth import DepthModel
 from .colors import maintain_colors
 

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -239,7 +239,7 @@ def render_input_video(args, anim_args, animation_prompts, root):
     # create a folder for the video input frames to live in
     video_in_frame_path = os.path.join(args.outdir, 'inputframes') 
     os.makedirs(video_in_frame_path, exist_ok=True)
-    
+
     # save the video frames from input video
     print(f"Exporting Video Frames (1 every {anim_args.extract_nth_frame}) frames to {video_in_frame_path}...")
     vid2frames(anim_args.video_init_path, video_in_frame_path, anim_args.extract_nth_frame, anim_args.overwrite_extracted_frames)
@@ -257,6 +257,12 @@ def render_input_video(args, anim_args, animation_prompts, root):
         # save the video frames from mask video
         print(f"Exporting Video Frames (1 every {anim_args.extract_nth_frame}) frames to {mask_in_frame_path}...")
         vid2frames(anim_args.video_mask_path, mask_in_frame_path, anim_args.extract_nth_frame, anim_args.overwrite_extracted_frames)
+        max_mask_frames = len([f for f in pathlib.Path(mask_in_frame_path).glob('*.jpg')])
+
+        # limit max frames if there are less frames in the video mask compared to input video
+        if max_mask_frames < anim_args.max_frames :
+            anim_args.max_mask_frames
+            print ("Video mask contains less frames than init video, max frames limited to number of mask frames.")
         args.use_mask = True
         args.overlay_mask = True
 


### PR DESCRIPTION
This fix allows for vid2frame to report errors.
Changes the way frames and mask frames are named.
Checks for interrupt in state when user clicks interrupt. (long waits to be avoided)
Checks the nth frame against what is currently saved
Checks path integrity on video and mask inputs
Checks that the video name is the same and overwrites if it is not.
Throws error if nth frame is larger than current input video frames
Does not allow nth frames to be < 1