### PR TITLE
fix resume issue w/ depth maps saved in output dir

### DIFF
--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -42,7 +42,9 @@ def render_animation(args, anim_args, parseq_args, animation_prompts, root):
     start_frame = 0
     if anim_args.resume_from_timestring:
         for tmp in os.listdir(args.outdir):
-            if tmp.split("_")[0] == anim_args.resume_timestring:
+            filename = tmp.split("_")
+            # don't use saved depth maps to count number of frames
+            if anim_args.resume_timestring in filename and "depth" not in filename:
                 start_frame += 1
         start_frame = start_frame - 1
 

--- a/scripts/deforum_helpers/settings.py
+++ b/scripts/deforum_helpers/settings.py
@@ -147,7 +147,9 @@ class DeforumTQDM:
         start_frame = 0
         if self._anim_args.resume_from_timestring:
             for tmp in os.listdir(self._args.outdir):
-                if tmp.split("_")[0] == self._anim_args.resume_timestring:
+                filename = tmp.split("_")
+                # don't use saved depth maps to count number of frames
+                if self._anim_args.resume_timestring in filename and "depth" not in filename:
                     start_frame += 1
             start_frame = start_frame - 1
         using_vid_init = self._anim_args.animation_mode == 'Video Input'


### PR DESCRIPTION
Before, the depth maps would interfere with counting of the number of frames. This change includes filenames that contain the resume timestring, but does not include those that are depth maps.

change also made in the main deforum repo:
https://github.com/deforum-art/deforum-stable-diffusion/pull/60