### PR TITLE
Always load the midas model on predict_depths

### DIFF
--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -81,9 +81,8 @@ def render_animation(args, anim_args, parseq_args, animation_prompts, root):
     predict_depths = (anim_args.animation_mode == '3D' and anim_args.use_depth_warping) or anim_args.save_depth_maps
     if predict_depths:
         depth_model = DepthModel(root.device)
-        if anim_args.midas_weight >= 1.0:
-            depth_model.load_midas(root.models_path, root.half_precision)
-        else:
+        depth_model.load_midas(root.models_path, root.half_precision)
+        if anim_args.midas_weight < 1.0:
             depth_model.load_adabins(root.models_path)
     else:
         depth_model = None


### PR DESCRIPTION
Before, the midas model would only be loaded if the midas_weight was 1.0 or higher. With this change, we sync the logic between the main deforum-stable-diffusion v.6 repo and this one.