### PR TITLE
Add support for reading parseq manifest from a remote URL.

### DIFF
--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -416,7 +416,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
             </p>
             """)
             with gr.Row():
-                parseq_manifest = gr.Textbox(label="parseq_manifest", lines=4, value = dp.parseq_manifest, interactive=True)
+                parseq_manifest = gr.Textbox(label="Parseq Manifest (JSON or URL)", lines=4, value = dp.parseq_manifest, interactive=True)
             with gr.Row():
                 parseq_use_deltas = gr.Checkbox(label="Use delta values for movement parameters", value=dp.parseq_use_deltas, interactive=True)            
     


### PR DESCRIPTION
This PR allows you to enter a URL that refers to the Parseq JSON, instead of pasting in the full JSON data. 

An upcoming version of the Parseq WebUI will allow you to upload your rendered JSON manifest to a URL that is persistent even as the doc changes. By referring to the resulting URL in the Deforum extension, you no longer need to continuously copy over your JSON data for every change.