### PR TITLE
Ensure parseq settings are included in the {timestamp}_settings.txt file

### DIFF
--- a/scripts/deforum_helpers/animation_modes.py
+++ b/scripts/deforum_helpers/animation_modes.py
@@ -81,7 +81,7 @@ def render_interpolation(args, anim_args, parseq_args, animation_prompts, root):
     # save settings for the batch
     settings_filename = os.path.join(args.outdir, f"{args.timestring}_settings.txt")
     with open(settings_filename, "w+", encoding="utf-8") as f:
-        s = {**dict(args.__dict__), **dict(anim_args.__dict__)}
+        s = {**dict(args.__dict__), **dict(anim_args.__dict__), **dict(parseq_args.__dict__)}
         json.dump(s, f, ensure_ascii=False, indent=4)
     
     # Compute interpolated prompts

--- a/scripts/deforum_helpers/parseq_adapter.py
+++ b/scripts/deforum_helpers/parseq_adapter.py
@@ -1,10 +1,13 @@
-from operator import itemgetter
+import copy
 import json
 import logging
-import pandas as pd
-import numpy as np
 import operator
+from operator import itemgetter
+
+import numpy as np
+import pandas as pd
 import requests
+
 from .animation_key_frames import DeformAnimKeys
 
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
@@ -22,6 +25,17 @@ class ParseqAnimKeys():
                 body = requests.get(manifestOrUrl).text
                 logging.debug(f"Loaded remote manifest: {body}")
                 self.parseq_json = json.loads(body)
+
+                # Add the parseq manifest without the detailed frame data to parseq_args.
+                # This ensures it will be saved in the settings file, so that you can always
+                # see exactly what parseq prompts and keyframes were used, even if what the URL
+                # points to changes.
+                parseq_args.fetched_parseq_manifest_summary = copy.deepcopy(self.parseq_json)
+                if parseq_args.fetched_parseq_manifest_summary['rendered_frames']:
+                    del parseq_args.fetched_parseq_manifest_summary['rendered_frames']
+                if parseq_args.fetched_parseq_manifest_summary['rendered_frames_meta']:
+                    del parseq_args.fetched_parseq_manifest_summary['rendered_frames_meta']
+
             except Exception as e:
                 logging.error(f"Unable to load Parseq manifest from URL: {manifestOrUrl}")
                 raise e

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -50,7 +50,7 @@ def render_animation(args, anim_args, parseq_args, animation_prompts, root):
     settings_filename = os.path.join(args.outdir, f"{args.timestring}_settings.txt")
     with open(settings_filename, "w+", encoding="utf-8") as f:
         args.__dict__["prompts"] = animation_prompts
-        s = {**dict(args.__dict__), **dict(anim_args.__dict__)}
+        s = {**dict(args.__dict__), **dict(anim_args.__dict__), **dict(parseq_args.__dict__)}
         json.dump(s, f, ensure_ascii=False, indent=4)
         
     # resume from timestring

--- a/scripts/deforum_helpers/render_modes.py
+++ b/scripts/deforum_helpers/render_modes.py
@@ -81,7 +81,7 @@ def render_interpolation(args, anim_args, parseq_args, animation_prompts, root):
     # save settings for the batch
     settings_filename = os.path.join(args.outdir, f"{args.timestring}_settings.txt")
     with open(settings_filename, "w+", encoding="utf-8") as f:
-        s = {**dict(args.__dict__), **dict(anim_args.__dict__)}
+        s = {**dict(args.__dict__), **dict(anim_args.__dict__), **dict(parseq_args.__dict__)}
         json.dump(s, f, ensure_ascii=False, indent=4)
     
     # Compute interpolated prompts


### PR DESCRIPTION
Ensure parseq settings are included in the {timestamp}_settings.txt file that is generated with a render begins.

If the Parseq manifest is fetched from URL, include a summary in the settings, so that you can always see exactly which parseq prompts and keyframes were used, even if the URL content changes.

Note: while making this change I noticed that `animation_modes.py` seems to be an unused duplicate of `render_modes.py`, so can possibly be deleted. I have [asked for confirmation here](https://discord.com/channels/1010951174146510939/1010951174146510942/1059985560225206462).