### PR TITLE
Quick fix for batch settings not saving prompts

### DIFF
--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -701,6 +701,7 @@ def process_args(self, p, override_settings_with_file, custom_settings_file, ani
 
     import json
     
+    args_dict["prompts"] = json.loads(animation_prompts)
     root = SimpleNamespace(**Root())
     root.p = p
     #root.prompts = json.loads(prompts)#TODO make proper animation_mode=None handling


### PR DESCRIPTION
Fixes #150

Currently prompts aren't saved in the batch settings file ( as opposed to using the "Save Settings" button which works fine )

There are 2 ways to export settings which seems redundant.

For the batch settings file :
deforum-for-automatic1111-webui\scripts\deforum_helpers\render_modes.py    line 82 :

# save settings for the batch
settings_filename = os.path.join(args.outdir, f"{args.timestring}_settings.txt") with open(settings_filename, "w+", encoding="utf-8") as f:
    s = {**dict(args.__dict__), **dict(anim_args.__dict__), **dict(parseq_args.__dict__)}
    json.dump(s, f, ensure_ascii=False, indent=4)


For the "save settings" button in gradio :
deforum-for-automatic1111-webui\scripts\deforum_helpers\settings.py    line 37 with the save_settings() function

save_settings() in settings.py also seems to be redundant (in part) with process_args() in args.py and may need refactoring