### PR TITLE
make rife ffmpeg_path use ffmpeg_location

### DIFF
--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -249,7 +249,7 @@ class DeforumScript(wscripts.Script):
         # FRMAE INTERPOLATION TIME
         if video_args.frame_interpolation_x_amount != "Disabled" and not video_args.skip_video_for_run_all and not store_frames_in_ram:
             print(f"Got a request to *frame interpolate* using {frame_interpolation_engine}")
-            process_video_interpolation(video_args.frame_interpolation_engine, video_args.frame_interpolation_x_amount, video_args.frame_interpolation_slow_mo_amount, fps, root.models_path, real_audio_track, args.outdir, args.timestring, video_args.ffmpeg_crf, video_args.ffmpeg_preset, video_args.frame_interpolation_keep_imgs)
+            process_video_interpolation(video_args.frame_interpolation_engine, video_args.frame_interpolation_x_amount, video_args.frame_interpolation_slow_mo_amount, fps, root.models_path, real_audio_track, args.outdir, args.timestring, video_args.ffmpeg_location, video_args.ffmpeg_crf, video_args.ffmpeg_preset, video_args.frame_interpolation_keep_imgs)
             
         root.initial_info += "\n The animation is stored in " + args.outdir + '\n'
         root.initial_info += "Only the first frame is shown in webui not to clutter the memory"

--- a/scripts/deforum_helpers/frame_interpolation.py
+++ b/scripts/deforum_helpers/frame_interpolation.py
@@ -9,7 +9,7 @@ def extract_rife_name(string):
         raise ValueError("Input string should contain exactly 2 words, first word should be 'RIFE' and second word should start with 'v' followed by 2 numbers")
     return "RIFE"+parts[1][1:].replace('.','')
    
-def process_video_interpolation(frame_interpolation_engine=None, frame_interpolation_x_amount="Disabled", frame_interpolation_slow_mo_amount="Disabled", orig_vid_fps=None, deforum_models_path=None, real_audio_track=None, raw_output_imgs_path=None, img_batch_id=None, ffmpeg_crf=None, ffmpeg_preset=None, keep_interp_imgs=False):
+def process_video_interpolation(frame_interpolation_engine=None, frame_interpolation_x_amount="Disabled", frame_interpolation_slow_mo_amount="Disabled", orig_vid_fps=None, deforum_models_path=None, real_audio_track=None, raw_output_imgs_path=None, img_batch_id=None, ffmpeg_location=None, ffmpeg_crf=None, ffmpeg_preset=None, keep_interp_imgs=False):
 
     if frame_interpolation_x_amount != "Disabled":
         
@@ -36,5 +36,5 @@ def process_video_interpolation(frame_interpolation_engine=None, frame_interpola
                 
             # run actual interpolation and video stitching etc - the whole suite
             if actual_model_folder_name:
-                run_rife_new_video_infer(interp_x_amount=interp_amount_clean_num, slow_mo_x_amount=interp_slow_mo_clean_num, output=None, model=actual_model_folder_name, fps=fps, deforum_models_path=deforum_models_path, audio_track=real_audio_track, raw_output_imgs_path=raw_output_imgs_path, img_batch_id=img_batch_id, ffmpeg_crf=ffmpeg_crf, ffmpeg_preset=ffmpeg_preset, keep_imgs=keep_interp_imgs)
+                run_rife_new_video_infer(interp_x_amount=interp_amount_clean_num, slow_mo_x_amount=interp_slow_mo_clean_num, output=None, model=actual_model_folder_name, fps=fps, deforum_models_path=deforum_models_path, audio_track=real_audio_track, raw_output_imgs_path=raw_output_imgs_path, img_batch_id=img_batch_id, ffmpeg_location=ffmpeg_location, ffmpeg_crf=ffmpeg_crf, ffmpeg_preset=ffmpeg_preset, keep_imgs=keep_interp_imgs)
              

--- a/scripts/deforum_helpers/src/rife/inference_video.py
+++ b/scripts/deforum_helpers/src/rife/inference_video.py
@@ -27,7 +27,7 @@ def run_rife_new_video_infer(
         deforum_models_path=None,
         raw_output_imgs_path=None,
         img_batch_id=None,
-        ffmpeg_location='ffmpeg',
+        ffmpeg_location=None,
         audio_track=None,
         interp_x_amount=2,
         slow_mo_x_amount=-1,

--- a/scripts/deforum_helpers/src/rife/inference_video.py
+++ b/scripts/deforum_helpers/src/rife/inference_video.py
@@ -285,8 +285,10 @@ def stitch_video(img_batch_id, fps, img_folder_path, audio_path, ffmpeg_location
         stdout, stderr = process.communicate()
         if process.returncode != 0:
             raise RuntimeError(stderr)
+    except FileNotFoundError:
+        raise FileNotFoundError("FFmpeg not found. Plesae make sure you have a working ffmpeg path under 'ffmpeg_location' parameter. \n*Interpolated frames were SAVED as backup!*")
     except Exception as e:
-        print(f'Error stitching interpolation video. Actual error: {e}')
+        raise Exception(f'Error stitching interpolation video. Actual error: {e}')
 
     if not audio_path is None:
         try:
@@ -310,6 +312,7 @@ def stitch_video(img_batch_id, fps, img_folder_path, audio_path, ffmpeg_location
             os.replace(mp4_path+'.temp.mp4', mp4_path)
         except Exception as e:
             print(f'Error adding audio to interpolated video. Actual error: {e}')
-    # delete temp folder with interpolated frames if requested
+    # delete temp folder with interpolated frames if requested 
+    #If ffmpeg was not found we won't reach this line - and the images will be left in the interpolated folder for the user to stitch later
     if not keep_imgs:
         shutil.rmtree(img_folder_path)


### PR DESCRIPTION
It was set to static 'ffmpeg' by mistake. 
Now it will use the value from `ffmpeg_location`