### PR TITLE
Hybrid Video Update 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ kornia
 numexpr
 matplotlib
 omegaconf
-opencv-contrib-python
+opencv-python
 pandas
 pytorch_lightning
 resize-right

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -58,7 +58,7 @@ def run_deforum(*args, **kwargs):
     from launch import is_installed, run_pip
     if not is_installed("numexpr"):
         run_pip("install numexpr", "numexpr")
-    
+
     for basedir in basedirs:
         sys.path.extend([
             basedir + '/scripts/deforum_helpers/src',

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -684,7 +684,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                 with gr.Column():
                     hybrid_use_first_frame_as_init_image = gr.Checkbox(label="first_frame_as_init_image", value=False, interactive=True)
                     hybrid_motion_use_prev_img = gr.Checkbox(label="motion_use_prev_img", value=False, interactive=True)
-                hybrid_motion = gr.Dropdown(label="motion", choices=['None', 'Optical Flow', 'Perspective', 'Affine'], value=da.hybrid_motion, type="value", elem_id="hybrid_motion", interactive=True)
+                hybrid_motion = gr.Dropdown(label="hybrid_motion", choices=['None', 'Optical Flow', 'Perspective', 'Affine'], value=da.hybrid_motion, type="value", elem_id="hybrid_motion", interactive=True)
                 hybrid_flow_method = gr.Dropdown(label="flow_method", choices=['DIS Medium', 'Farneback'], value=da.hybrid_flow_method, type="value", elem_id="hybrid_flow_method", interactive=True)
             with gr.Row(equal_height=True):
                 hybrid_comp_mask_equalize = gr.Dropdown(label="comp_mask_equalize", choices=['None', 'Before', 'After', 'Both'], value=da.hybrid_comp_mask_equalize, type="value", elem_id="hybrid_comp_mask_equalize", interactive=True)

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -674,47 +674,37 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
             hybrid_html += "<a style='color:SteelBlue;' target='_blank' href='https://github.com/deforum-art/deforum-for-automatic1111-webui/wiki/Animation-Settings#hybrid-video-mode-for-2d3d-animations'>Click Here</a> for more info/ a Guide."      
             gr.HTML(hybrid_html)
         with gr.Accordion("Hybrid Settings", open=True):
-            with gr.Row():
-                with gr.Column(variant="compact"):
-                    hybrid_generate_inputframes = gr.Checkbox(label="hybrid_generate_inputframes", value=False, interactive=True)
-                with gr.Column(variant="compact"):
-                    hybrid_generate_human_masks = gr.Dropdown(label="hybrid_generate_human_masks", choices=['None', 'PNGs', 'Video', 'Both'], value=da.hybrid_generate_human_masks, type="value", elem_id="hybrid_generate_human_masks", interactive=True)
-                with gr.Column(variant="compact"):
-                    hybrid_use_first_frame_as_init_image = gr.Checkbox(label="hybrid_use_first_frame_as_init_image", value=False, interactive=True)
-            with gr.Row():
-                with gr.Column(variant="compact"):
-                    hybrid_motion = gr.Dropdown(label="hybrid_motion", choices=['None', 'Optical Flow', 'Perspective', 'Affine'], value=da.hybrid_motion, type="value", elem_id="hybrid_motion", interactive=True)
-                with gr.Column(variant="compact"):
-                    hybrid_motion_use_prev_img = gr.Checkbox(label="hybrid_motion_use_prev_img", value=False, interactive=True)
-                with gr.Column(variant="compact"):
-                    hybrid_flow_method = gr.Dropdown(label="hybrid_flow_method", choices=['DIS Medium', 'Farneback'], value=da.hybrid_flow_method, type="value", elem_id="hybrid_flow_method", interactive=True)
-            with gr.Row():
+            with gr.Row(equal_height=True):
                 with gr.Column():
+                    hybrid_generate_inputframes = gr.Checkbox(label="generate_inputframes", value=False, interactive=True)
                     hybrid_composite = gr.Checkbox(label="hybrid_composite", value=False, interactive=True)
+                hybrid_generate_human_masks = gr.Dropdown(label="generate_human_masks", choices=['None', 'PNGs', 'Video', 'Both'], value=da.hybrid_generate_human_masks, type="value", elem_id="hybrid_generate_human_masks", interactive=True)
+                
+            with gr.Row(equal_height=True):
                 with gr.Column():
-                    hybrid_comp_mask_type = gr.Dropdown(label="hybrid_comp_mask_type", choices=['None', 'Depth', 'Video Depth', 'Blend', 'Difference'], value=da.hybrid_comp_mask_type, type="value", elem_id="hybrid_comp_mask_type", interactive=True)
-            with gr.Row():
+                    hybrid_use_first_frame_as_init_image = gr.Checkbox(label="first_frame_as_init_image", value=False, interactive=True)
+                    hybrid_motion_use_prev_img = gr.Checkbox(label="motion_use_prev_img", value=False, interactive=True)
+                hybrid_motion = gr.Dropdown(label="motion", choices=['None', 'Optical Flow', 'Perspective', 'Affine'], value=da.hybrid_motion, type="value", elem_id="hybrid_motion", interactive=True)
+                hybrid_flow_method = gr.Dropdown(label="flow_method", choices=['DIS Medium', 'Farneback'], value=da.hybrid_flow_method, type="value", elem_id="hybrid_flow_method", interactive=True)
+            with gr.Row(equal_height=True):
+                hybrid_comp_mask_equalize = gr.Dropdown(label="comp_mask_equalize", choices=['None', 'Before', 'After', 'Both'], value=da.hybrid_comp_mask_equalize, type="value", elem_id="hybrid_comp_mask_equalize", interactive=True)
+                hybrid_comp_mask_type = gr.Dropdown(label="comp_mask_type", choices=['None', 'Depth', 'Video Depth', 'Blend', 'Difference'], value=da.hybrid_comp_mask_type, type="value", elem_id="hybrid_comp_mask_type", interactive=True)
+            with gr.Row(equal_height=True):
                 with gr.Column():
-                    hybrid_comp_mask_auto_contrast = gr.Checkbox(label="hybrid_comp_mask_auto_contrast", value=False, interactive=True)
-                with gr.Column():
-                    hybrid_comp_mask_inverse = gr.Checkbox(label="hybrid_comp_mask_inverse", value=False, interactive=True)
-            with gr.Row():
-                with gr.Column():
-                    hybrid_comp_mask_equalize = gr.Dropdown(label="hybrid_comp_mask_equalize", choices=['None', 'Before', 'After', 'Both'], value=da.hybrid_comp_mask_equalize, type="value", elem_id="hybrid_comp_mask_equalize", interactive=True)
-                with gr.Column():
-                    hybrid_comp_save_extra_frames = gr.Checkbox(label="hybrid_comp_save_extra_frames", value=False, interactive=True)
-
+                    hybrid_comp_mask_auto_contrast = gr.Checkbox(label="comp_mask_auto_contrast", value=False, interactive=True)
+                    hybrid_comp_mask_inverse = gr.Checkbox(label="comp_mask_inverse", value=False, interactive=True)
+                    hybrid_comp_save_extra_frames = gr.Checkbox(label="comp_save_extra_frames", value=False, interactive=True)
         with gr.Accordion("Hybrid Schedules", open=False):
             with gr.Row():
-                hybrid_comp_alpha_schedule = gr.Textbox(label="hybrid_comp_alpha_schedule", lines=1, value = da.hybrid_comp_alpha_schedule, interactive=True)
+                hybrid_comp_alpha_schedule = gr.Textbox(label="comp_alpha_schedule", lines=1, value = da.hybrid_comp_alpha_schedule, interactive=True)
             with gr.Row():
-                hybrid_comp_mask_blend_alpha_schedule = gr.Textbox(label="hybrid_comp_mask_blend_alpha_schedule", lines=1, value = da.hybrid_comp_mask_blend_alpha_schedule, interactive=True)
+                hybrid_comp_mask_blend_alpha_schedule = gr.Textbox(label="comp_mask_blend_alpha_schedule", lines=1, value = da.hybrid_comp_mask_blend_alpha_schedule, interactive=True)
             with gr.Row():
-                hybrid_comp_mask_contrast_schedule = gr.Textbox(label="hybrid_comp_mask_contrast_schedule", lines=1, value = da.hybrid_comp_mask_contrast_schedule, interactive=True)
+                hybrid_comp_mask_contrast_schedule = gr.Textbox(label="comp_mask_contrast_schedule", lines=1, value = da.hybrid_comp_mask_contrast_schedule, interactive=True)
             with gr.Row():
-                hybrid_comp_mask_auto_contrast_cutoff_high_schedule = gr.Textbox(label="hybrid_comp_mask_auto_contrast_cutoff_high_schedule", lines=1, value = da.hybrid_comp_mask_auto_contrast_cutoff_high_schedule, interactive=True)
+                hybrid_comp_mask_auto_contrast_cutoff_high_schedule = gr.Textbox(label="comp_mask_auto_contrast_cutoff_high_schedule", lines=1, value = da.hybrid_comp_mask_auto_contrast_cutoff_high_schedule, interactive=True)
             with gr.Row():
-                hybrid_comp_mask_auto_contrast_cutoff_low_schedule = gr.Textbox(label="hybrid_comp_mask_auto_contrast_cutoff_low_schedule", lines=1, value = da.hybrid_comp_mask_auto_contrast_cutoff_low_schedule, interactive=True)
+                hybrid_comp_mask_auto_contrast_cutoff_low_schedule = gr.Textbox(label="comp_mask_auto_contrast_cutoff_low_schedule", lines=1, value = da.hybrid_comp_mask_auto_contrast_cutoff_low_schedule, interactive=True)
     # VIDEO OUTPUT TAB
     with gr.Tab('Video output'):
         with gr.Accordion('Video Output Settings', open=True):

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -808,13 +808,13 @@ anim_args_names =   str(r'''animation_mode, max_frames, border,
                         video_init_path, extract_nth_frame, extract_from_frame, extract_to_frame, overwrite_extracted_frames,
                         use_mask_video, video_mask_path,
                         resume_from_timestring, resume_timestring'''
-                    ).replace("\n", "").replace(" ", "").split(',')
+                    ).replace("\n", "").replace("\r", "").replace(" ", "").split(',')
 hybrid_args_names =   str(r'''hybrid_generate_inputframes, hybrid_generate_human_masks, hybrid_use_first_frame_as_init_image,
                         hybrid_motion, hybrid_motion_use_prev_img, hybrid_flow_method, hybrid_composite, hybrid_comp_mask_type, hybrid_comp_mask_inverse,
                         hybrid_comp_mask_equalize, hybrid_comp_mask_auto_contrast, hybrid_comp_save_extra_frames,
                         hybrid_comp_alpha_schedule, hybrid_comp_mask_blend_alpha_schedule, hybrid_comp_mask_contrast_schedule,
                         hybrid_comp_mask_auto_contrast_cutoff_high_schedule, hybrid_comp_mask_auto_contrast_cutoff_low_schedule'''
-                    ).replace("\n", "").replace(" ", "").split(',')
+                    ).replace("\n", "").replace("\r", "").replace(" ", "").split(',')
 args_names =    str(r'''W, H, tiling,
                         seed, sampler,
                         seed_enable_extras, subseed, subseed_strength, seed_resize_from_w, seed_resize_from_h,
@@ -829,7 +829,7 @@ args_names =    str(r'''W, H, tiling,
                         mask_file, mask_contrast_adjust, mask_brightness_adjust, mask_overlay_blur,
                         fill, full_res_mask, full_res_mask_padding,
                         reroll_blank_frames'''
-                    ).replace("\n", "").replace(" ", "").split(',')
+                    ).replace("\n", "").replace("\r", "").replace(" ", "").split(',')
 video_args_names =  str(r'''skip_video_for_run_all,
                             fps, output_format, ffmpeg_location, ffmpeg_crf, ffmpeg_preset,
                             add_soundtrack, soundtrack_path,
@@ -838,12 +838,12 @@ video_args_names =  str(r'''skip_video_for_run_all,
                             path_name_modifier, image_path, mp4_path, store_frames_in_ram,
                             frame_interpolation_engine, frame_interpolation_x_amount, frame_interpolation_slow_mo_amount,
                             frame_interpolation_keep_imgs'''
-                    ).replace("\n", "").replace(" ", "").split(',')
+                    ).replace("\n", "").replace("\r", "").replace(" ", "").split(',')
 parseq_args_names = str(r'''parseq_manifest, parseq_use_deltas'''
-                    ).replace("\n", "").replace(" ", "").split(',')
+                    ).replace("\n", "").replace("\r", "").replace(" ", "").split(',')
 loop_args_names = str(r'''use_looper, init_images, image_strength_schedule, blendFactorMax, blendFactorSlope, 
                           tweening_frames_schedule, color_correction_factor'''
-                    ).replace("\n", "").replace(" ", "").split(',')
+                    ).replace("\n", "").replace("\r", "").replace(" ", "").split(',')
 
 component_names =   ['override_settings_with_file', 'custom_settings_file'] + anim_args_names +['animation_prompts', 'animation_prompts_positive', 'animation_prompts_negative'] + args_names + video_args_names + parseq_args_names + hybrid_args_names + loop_args_names
 settings_component_names = [name for name in component_names if name not in video_args_names]

--- a/scripts/deforum_helpers/hybrid_video.py
+++ b/scripts/deforum_helpers/hybrid_video.py
@@ -2,9 +2,15 @@ import cv2
 import os
 import pathlib
 import numpy as np
+import random
 from PIL import Image, ImageChops, ImageOps, ImageEnhance
-from .vid2frames import vid2frames, get_frame_name, get_next_frame
+from .vid2frames import vid2frames, get_frame_name
 from .human_masking import video2humanmasks
+
+def delete_all_imgs_in_folder(folder_path):
+        files = list(pathlib.Path(folder_path).glob('*.jpg'))
+        files.extend(list(pathlib.Path(folder_path).glob('*.png')))
+        for f in files: os.remove(f)
 
 def hybrid_generation(args, anim_args, root):
     video_in_frame_path = os.path.join(args.outdir, 'inputframes')
@@ -129,22 +135,45 @@ def hybrid_composite(args, anim_args, frame_idx, prev_img, depth_model, hybrid_c
     return args, prev_img
 
 def get_matrix_for_hybrid_motion(frame_idx, dimensions, inputfiles, hybrid_motion):
-    matrix = get_translation_matrix_from_images(str(inputfiles[frame_idx]), str(inputfiles[frame_idx+1]), dimensions, hybrid_motion)
+    img1 = cv2.cvtColor(get_resized_image_from_filename(str(inputfiles[frame_idx-1]), dimensions), cv2.COLOR_BGR2GRAY)
+    img2 = cv2.cvtColor(get_resized_image_from_filename(str(inputfiles[frame_idx]), dimensions), cv2.COLOR_BGR2GRAY)
+    matrix = get_transformation_matrix_from_images(img1, img2, hybrid_motion)
     print(f"Calculating {hybrid_motion} RANSAC matrix for frames {frame_idx} to {frame_idx+1}")
     return matrix
 
-def get_flow_for_hybrid_motion(frame_idx, dimensions, inputfiles, hybrid_frame_path, method, save_flow_visualization=False):
-    print(f"Calculating optical flow for frames {frame_idx} to {frame_idx+1}")
-    flow = get_flow_from_images(str(inputfiles[frame_idx]), str(inputfiles[frame_idx+1]), dimensions, method)
-    if save_flow_visualization:
-        flow_img_file = os.path.join(hybrid_frame_path, f"flow{frame_idx:05}.jpg")
-        flow_cv2 = cv2.imread(str(inputfiles[frame_idx]))
-        flow_cv2 = cv2.resize(flow_cv2, (dimensions[0], dimensions[1]), cv2.INTER_AREA)
-        flow_cv2 = cv2.cvtColor(flow_cv2,cv2.COLOR_BGR2RGB)
-        flow_cv2 = draw_flow_lines_in_grid_in_color(flow_cv2, flow)
-        flow_PIL = Image.fromarray(np.uint8(flow_cv2))
-        flow_PIL.save(flow_img_file)
-        print(f"Saved optical flow visualization: {flow_img_file}")
+def get_matrix_for_hybrid_motion_prev(frame_idx, dimensions, inputfiles, prev_img, hybrid_motion):
+    # first handle invalid images from cadence by returning default matrix
+    height, width = prev_img.shape[:2]
+    if height == 0 or width == 0 or prev_img != np.uint8:
+        return get_hybrid_motion_default_matrix(hybrid_motion)
+    else:
+        prev_img_gray = cv2.cvtColor(prev_img, cv2.COLOR_BGR2GRAY)
+        img = cv2.cvtColor(get_resized_image_from_filename(str(inputfiles[frame_idx]), dimensions), cv2.COLOR_BGR2GRAY)
+        matrix = get_transformation_matrix_from_images(prev_img_gray, img, hybrid_motion)
+        print(f"Calculating {hybrid_motion} RANSAC matrix for frames {frame_idx} to {frame_idx+1}")
+        return matrix
+
+def get_flow_for_hybrid_motion(frame_idx, dimensions, inputfiles, hybrid_frame_path, method, do_flow_visualization=False):
+    print(f"Calculating {method} optical flow for frames {frame_idx} to {frame_idx+1}")
+    i1 = get_resized_image_from_filename(str(inputfiles[frame_idx]), dimensions)
+    i2 = get_resized_image_from_filename(str(inputfiles[frame_idx+1]), dimensions)
+    flow = get_flow_from_images(i1, i2, method)
+    if do_flow_visualization:
+        save_flow_visualization(frame_idx, dimensions, flow, inputfiles, hybrid_frame_path)
+    return flow
+
+def get_flow_for_hybrid_motion_prev(frame_idx, dimensions, inputfiles, hybrid_frame_path, prev_img, method, do_flow_visualization=False):
+    print(f"Calculating {method} optical flow for frames {frame_idx} to {frame_idx+1}")
+    # first handle invalid images from cadence by returning default matrix
+    height, width = prev_img.shape[:2]   
+    if height == 0 or width == 0:
+        flow = get_hybrid_motion_default_flow(dimensions)
+    else:
+        i1 = prev_img.astype(np.uint8)
+        i2 = get_resized_image_from_filename(str(inputfiles[frame_idx]), dimensions)
+        flow = get_flow_from_images(i1, i2, method)
+    if do_flow_visualization:
+        save_flow_visualization(frame_idx, dimensions, flow, inputfiles, hybrid_frame_path)
     return flow
 
 def image_transform_ransac(image_cv2, xform, hybrid_motion, border_mode=cv2.BORDER_REPLICATE):
@@ -154,19 +183,12 @@ def image_transform_ransac(image_cv2, xform, hybrid_motion, border_mode=cv2.BORD
         return image_transform_affine(image_cv2, xform, border_mode=border_mode)
 
 def image_transform_optical_flow(img, flow, border_mode=cv2.BORDER_REPLICATE, flow_reverse=False):
-    h, w = flow.shape[:2]
     if not flow_reverse:
         flow = -flow
+    h, w = img.shape[:2]
     flow[:, :, 0] += np.arange(w)
     flow[:, :, 1] += np.arange(h)[:,np.newaxis]
-    r = cv2.remap(
-        img,
-        flow,
-        None,
-        cv2.INTER_LINEAR,
-        border_mode
-    )
-    return r
+    return remap(img, flow, border_mode)
 
 def image_transform_affine(image_cv2, xform, border_mode=cv2.BORDER_REPLICATE):
     return cv2.warpAffine(
@@ -191,12 +213,12 @@ def get_hybrid_motion_default_matrix(hybrid_motion):
         arr = np.array([[1., 0., 0.], [0., 1., 0.]])
     return arr
 
-def get_translation_matrix_from_images(i1, i2, dimensions, hybrid_motion, max_corners=200, quality_level=0.01, min_distance=30, block_size=3):
-    img1 = cv2.imread(i1, 0)
-    img2 = cv2.imread(i2, 0)
-    img1 = cv2.resize(img1, (dimensions[0], dimensions[1]), cv2.INTER_AREA)
-    img2 = cv2.resize(img2, (dimensions[0], dimensions[1]), cv2.INTER_AREA)
-    
+def get_hybrid_motion_default_flow(dimensions):
+    cols, rows = dimensions
+    flow = np.zeros((rows, cols, 2), np.float32)
+    return flow
+
+def get_transformation_matrix_from_images(img1, img2, hybrid_motion, max_corners=200, quality_level=0.01, min_distance=30, block_size=3):
     # Detect feature points in previous frame
     prev_pts = cv2.goodFeaturesToTrack(img1,
                                         maxCorners=max_corners,
@@ -204,7 +226,7 @@ def get_translation_matrix_from_images(i1, i2, dimensions, hybrid_motion, max_co
                                         minDistance=min_distance,
                                         blockSize=block_size)
 
-    if prev_pts is None or len(prev_pts) < 8:
+    if prev_pts is None or len(prev_pts) < 8 or img1 is None or img2 is None:
         return get_hybrid_motion_default_matrix(hybrid_motion)
 
     # Get optical flow
@@ -225,49 +247,84 @@ def get_translation_matrix_from_images(i1, i2, dimensions, hybrid_motion, max_co
         transformation_rigid_matrix, rigid_mask = cv2.estimateAffinePartial2D(prev_pts, curr_pts)
         return transformation_rigid_matrix
 
-def get_flow_from_images(img1, img2, dimensions, method):
-    i1 = cv2.imread(img1)
-    i2 = cv2.imread(img2)
-    i1 = cv2.resize(i1, (dimensions[0], dimensions[1]), cv2.INTER_AREA)
-    i2 = cv2.resize(i2, (dimensions[0], dimensions[1]), cv2.INTER_AREA)
-    if method == "DenseRLOF":
+def get_flow_from_images(i1, i2, method):
+    if method =="DIS Medium":
+        r = get_flow_from_images_DIS(i1, i2, cv2.DISOPTICAL_FLOW_PRESET_MEDIUM)
+    elif method =="DIS Fast":
+        r = get_flow_from_images_DIS(i1, i2, cv2.DISOPTICAL_FLOW_PRESET_FAST)
+    elif method =="DIS UltraFast":
+        r = get_flow_from_images_DIS(i1, i2, cv2.DISOPTICAL_FLOW_PRESET_ULTRAFAST)
+    elif method == "DenseRLOF": # requires running opencv-contrib-python (full opencv) INSTEAD of opencv-python
         r = get_flow_from_images_Dense_RLOF(i1, i2)
-    elif method == "SF":
+    elif method == "SF": # requires running opencv-contrib-python (full opencv) INSTEAD of opencv-python
         r = get_flow_from_images_SF(i1, i2)
-    elif method =="Farneback":
+    elif method =="Farneback Fine":
+        r = get_flow_from_images_Farneback(i1, i2, 'fine')
+    else: # Farneback Normal:
         r = get_flow_from_images_Farneback(i1, i2)
     return r
-        
-def get_flow_from_images_Farneback(img1, img2, last_flow=None, pyr_scale = 0.5, levels = 3, winsize = 15, iterations = 3, poly_n = 5, poly_sigma = 1.2):
-    i1 = cv2.cvtColor(img1, cv2.COLOR_BGR2GRAY)
-    i2 = cv2.cvtColor(img2, cv2.COLOR_BGR2GRAY)
-    flags = 0 # flags = cv2.OPTFLOW_USE_INITIAL_FLOW    
-    flow = cv2.calcOpticalFlowFarneback(i1, i2, last_flow, pyr_scale, levels, winsize, iterations, poly_n, poly_sigma, flags)
-    return flow
+
+def get_flow_from_images_DIS(i1, i2, preset):
+    i1 = cv2.cvtColor(i1, cv2.COLOR_BGR2GRAY)
+    i2 = cv2.cvtColor(i2, cv2.COLOR_BGR2GRAY)
+    dis=cv2.DISOpticalFlow_create(preset)
+    return dis.calc(i1, i2, None)
 
 def get_flow_from_images_Dense_RLOF(i1, i2, last_flow=None):
     return cv2.optflow.calcOpticalFlowDenseRLOF(i1, i2, flow = last_flow)
 
-def get_flow_from_images_SF(i1, i2, last_flow=None):
-    layers = 3
-    averaging_block_size = 2
-    max_flow = 4
+def get_flow_from_images_SF(i1, i2, last_flow=None, layers = 3, averaging_block_size = 2, max_flow = 4):
     return cv2.optflow.calcOpticalFlowSF(i1, i2, layers, averaging_block_size, max_flow)
 
-def draw_flow_lines_in_grid_in_color(img, flow, step=8, magnitude_multiplier=1, min_magnitude = 1, max_magnitude = 100):
+def get_flow_from_images_Farneback(i1, i2, preset="normal", last_flow=None, pyr_scale = 0.5, levels = 3, winsize = 15, iterations = 3, poly_n = 5, poly_sigma = 1.2, flags = 0):
+    flags = cv2.OPTFLOW_FARNEBACK_GAUSSIAN         # Specify the operation flags
+    pyr_scale = 0.5   # The image scale (<1) to build pyramids for each image
+    if preset == "fine":
+        levels = 13       # The number of pyramid layers, including the initial image
+        winsize = 77      # The averaging window size
+        iterations = 13   # The number of iterations at each pyramid level
+        poly_n = 15       # The size of the pixel neighborhood used to find polynomial expansion in each pixel
+        poly_sigma = 0.8  # The standard deviation of the Gaussian used to smooth derivatives used as a basis for the polynomial expansion
+    else: # "normal"
+        levels = 5        # The number of pyramid layers, including the initial image
+        winsize = 21      # The averaging window size
+        iterations = 5    # The number of iterations at each pyramid level
+        poly_n = 7        # The size of the pixel neighborhood used to find polynomial expansion in each pixel
+        poly_sigma = 1.2  # The standard deviation of the Gaussian used to smooth derivatives used as a basis for the polynomial expansion
+    i1 = cv2.cvtColor(i1, cv2.COLOR_BGR2GRAY)
+    i2 = cv2.cvtColor(i2, cv2.COLOR_BGR2GRAY)
+    flags = 0 # flags = cv2.OPTFLOW_USE_INITIAL_FLOW    
+    flow = cv2.calcOpticalFlowFarneback(i1, i2, last_flow, pyr_scale, levels, winsize, iterations, poly_n, poly_sigma, flags)
+    return flow
+
+def save_flow_visualization(frame_idx, dimensions, flow, inputfiles, hybrid_frame_path):
+    flow_img_file = os.path.join(hybrid_frame_path, f"flow{frame_idx:05}.jpg")
+    flow_img = cv2.imread(str(inputfiles[frame_idx]))
+    flow_img = cv2.resize(flow_img, (dimensions[0], dimensions[1]), cv2.INTER_AREA)
+    flow_img = cv2.cvtColor(flow_img, cv2.COLOR_RGB2GRAY)
+    flow_img = cv2.cvtColor(flow_img, cv2.COLOR_GRAY2BGR)
+    flow_img = draw_flow_lines_in_grid_in_color(flow_img, flow)
+    flow_img = cv2.cvtColor(flow_img, cv2.COLOR_BGR2RGB)
+    cv2.imwrite(flow_img_file, flow_img)
+    print(f"Saved optical flow visualization: {flow_img_file}")
+
+def draw_flow_lines_in_grid_in_color(img, flow, step=8, magnitude_multiplier=1, min_magnitude = 1, max_magnitude = 10000):
     flow = flow * magnitude_multiplier
     h, w = img.shape[:2]
     y, x = np.mgrid[step/2:h:step, step/2:w:step].reshape(2,-1).astype(int)
     fx, fy = flow[y,x].T
     lines = np.vstack([x, y, x+fx, y+fy]).T.reshape(-1, 2, 2)
     lines = np.int32(lines + 0.5)
-    vis = img.copy()  # Create a copy of the input image
+    vis = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    vis = cv2.cvtColor(vis, cv2.COLOR_GRAY2BGR)
+
     mag, ang = cv2.cartToPolar(flow[...,0], flow[...,1])
     hsv = np.zeros((flow.shape[0], flow.shape[1], 3), dtype=np.uint8)
     hsv[...,0] = ang*180/np.pi/2
     hsv[...,1] = 255
     hsv[...,2] = cv2.normalize(mag, None, 0, 255, cv2.NORM_MINMAX)
     bgr = cv2.cvtColor(hsv, cv2.COLOR_HSV2BGR)
+    vis = cv2.add(vis, bgr)
 
     # Iterate through the lines
     for (x1, y1), (x2, y2) in lines:
@@ -280,7 +337,44 @@ def draw_flow_lines_in_grid_in_color(img, flow, step=8, magnitude_multiplier=1, 
             g = int(bgr[y1, x1, 1])
             r = int(bgr[y1, x1, 2])
             color = (b, g, r)
-            cv2.arrowedLine(vis, (x1, y1), (x2, y2), color, thickness=1, tipLength=0.2)    
+            cv2.arrowedLine(vis, (x1, y1), (x2, y2), color, thickness=1, tipLength=0.1)    
+    return vis
+
+def draw_flow_lines_in_color(img, flow, threshold=3, magnitude_multiplier=1, min_magnitude = 0, max_magnitude = 10000):
+    # h, w = img.shape[:2]
+    vis = img.copy()  # Create a copy of the input image
+    
+    # Find the locations in the flow field where the magnitude of the flow is greater than the threshold
+    mag, ang = cv2.cartToPolar(flow[...,0], flow[...,1])
+    idx = np.where(mag > threshold)
+
+    # Create HSV image
+    hsv = np.zeros((flow.shape[0], flow.shape[1], 3), dtype=np.uint8)
+    hsv[...,0] = ang*180/np.pi/2
+    hsv[...,1] = 255
+    hsv[...,2] = cv2.normalize(mag, None, 0, 255, cv2.NORM_MINMAX)
+
+    # Convert HSV image to BGR
+    bgr = cv2.cvtColor(hsv, cv2.COLOR_HSV2BGR)
+
+    # Add color from bgr 
+    vis = cv2.add(vis, bgr)
+
+    # Draw an arrow at each of these locations to indicate the direction of the flow
+    for i, (y, x) in enumerate(zip(idx[0], idx[1])):
+        # Calculate the magnitude of the line
+        x2 = x + magnitude_multiplier * int(flow[y, x, 0])
+        y2 = y + magnitude_multiplier * int(flow[y, x, 1])
+        magnitude = np.sqrt((x2 - x)**2 + (y2 - y)**2)
+
+        # Only draw the line if it falls within the magnitude range
+        if min_magnitude <= magnitude <= max_magnitude:
+            if i % random.randint(100, 200) == 0:
+                b = int(bgr[y, x, 0])
+                g = int(bgr[y, x, 1])
+                r = int(bgr[y, x, 2])
+                color = (b, g, r)
+                cv2.arrowedLine(vis, (x, y), (x2, y2), color, thickness=1, tipLength=0.25)
 
     return vis
 
@@ -297,8 +391,46 @@ def autocontrast_grayscale(image, low_cutoff=0, high_cutoff=100):
     image = np.clip(image, 0, 255)
 
     return image
+
+def get_resized_image_from_filename(im, dimensions):
+    img = cv2.imread(im)
+    return cv2.resize(img, (dimensions[0], dimensions[1]), cv2.INTER_AREA)
+
+def remap(img, flow, border_mode = cv2.BORDER_REFLECT_101):
+    # copyMakeBorder doesn't support wrap, but supports replicate. Replaces wrap with reflect101.
+    if border_mode == cv2.BORDER_WRAP:
+        border_mode = cv2.BORDER_REFLECT_101
+    h, w = img.shape[:2]
+    displacement = int(h * 0.25), int(w * 0.25)
+    larger_img = cv2.copyMakeBorder(img, displacement[0], displacement[0], displacement[1], displacement[1], border_mode)
+    lh, lw = larger_img.shape[:2]
+    larger_flow = extend_flow(flow, lw, lh)
+    remapped_img = cv2.remap(larger_img, larger_flow, None, cv2.INTER_LINEAR, border_mode)
+    output_img = center_crop_image(remapped_img, w, h)
+    return output_img
+
+def center_crop_image(img, w, h):
+    y, x, _ = img.shape
+    width_indent = int((x - w) / 2)
+    height_indent = int((y - h) / 2)
+    cropped_img = img[height_indent:y-height_indent, width_indent:x-width_indent]
+    return cropped_img
+
+def extend_flow(flow, w, h):
+    # Get the shape of the original flow image
+    flow_h, flow_w = flow.shape[:2]
+    # Calculate the position of the image in the new image
+    x_offset = int((w - flow_w) / 2)
+    y_offset = int((h - flow_h) / 2)
+    # Generate the X and Y grids
+    x_grid, y_grid = np.meshgrid(np.arange(w), np.arange(h))
+    # Create the new flow image and set it to the X and Y grids
+    new_flow = np.dstack((x_grid, y_grid)).astype(np.float32)
+    # Shift the values of the original flow by the size of the border
+    flow[:,:,0] += x_offset
+    flow[:,:,1] += y_offset
+    # Overwrite the middle of the grid with the original flow
+    new_flow[y_offset:y_offset+flow_h, x_offset:x_offset+flow_w, :] = flow
+    # Return the extended image
+    return new_flow
     
-def delete_all_imgs_in_folder(folder_path):
-        files = list(pathlib.Path(folder_path).glob('*.jpg'))
-        files.extend(list(pathlib.Path(folder_path).glob('*.png')))
-        for f in files: os.remove(f)

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -220,26 +220,30 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, animat
                         if anim_args.hybrid_motion_use_prev_img:
                             if advance_prev:
                                 matrix = get_matrix_for_hybrid_motion_prev(tween_frame_idx, (args.W, args.H), inputfiles, turbo_prev_image, anim_args.hybrid_motion)
+                                turbo_prev_image = image_transform_ransac(turbo_prev_image, matrix, anim_args.hybrid_motion, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
                             if advance_next:
                                 matrix = get_matrix_for_hybrid_motion_prev(tween_frame_idx, (args.W, args.H), inputfiles, turbo_next_image, anim_args.hybrid_motion)
+                                turbo_next_image = image_transform_ransac(turbo_next_image, matrix, anim_args.hybrid_motion, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
                         else:
                             matrix = get_matrix_for_hybrid_motion(tween_frame_idx-1, (args.W, args.H), inputfiles, anim_args.hybrid_motion)
-                        if advance_prev:
-                            turbo_prev_image = image_transform_ransac(turbo_prev_image, matrix, anim_args.hybrid_motion, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
-                        if advance_next:
-                            turbo_next_image = image_transform_ransac(turbo_next_image, matrix, anim_args.hybrid_motion, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
+                            if advance_prev:
+                                turbo_prev_image = image_transform_ransac(turbo_prev_image, matrix, anim_args.hybrid_motion, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
+                            if advance_next:
+                                turbo_next_image = image_transform_ransac(turbo_next_image, matrix, anim_args.hybrid_motion, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
                     if anim_args.hybrid_motion in ['Optical Flow']:
                         if anim_args.hybrid_motion_use_prev_img:
                             if advance_prev:
                                 flow = get_flow_for_hybrid_motion_prev(tween_frame_idx-1, (args.W, args.H), inputfiles, hybrid_frame_path, turbo_prev_image, anim_args.hybrid_flow_method, anim_args.hybrid_comp_save_extra_frames)
+                                turbo_prev_image = image_transform_optical_flow(turbo_prev_image, flow, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
                             if advance_next:
                                 flow = get_flow_for_hybrid_motion_prev(tween_frame_idx-1, (args.W, args.H), inputfiles, hybrid_frame_path, turbo_next_image, anim_args.hybrid_flow_method, anim_args.hybrid_comp_save_extra_frames)
+                                turbo_next_image = image_transform_optical_flow(turbo_next_image, flow, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
                         else:
                             flow = get_flow_for_hybrid_motion(tween_frame_idx-1, (args.W, args.H), inputfiles, hybrid_frame_path, anim_args.hybrid_flow_method, anim_args.hybrid_comp_save_extra_frames)
-                        if advance_prev:
-                            turbo_prev_image = image_transform_optical_flow(turbo_prev_image, flow, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
-                        if advance_next:
-                            turbo_next_image = image_transform_optical_flow(turbo_next_image, flow, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
+                            if advance_prev:
+                                turbo_prev_image = image_transform_optical_flow(turbo_prev_image, flow, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
+                            if advance_next:
+                                turbo_next_image = image_transform_optical_flow(turbo_next_image, flow, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
                       
                 turbo_prev_frame_idx = turbo_next_frame_idx = tween_frame_idx
 

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -3,7 +3,7 @@ import json
 import pandas as pd
 import cv2
 import numpy as np
-from PIL import Image
+from PIL import Image, ImageOps
 
 from .generate import generate
 from .noise import add_noise
@@ -17,7 +17,8 @@ from .seed import next_seed
 from .blank_frame_reroll import blank_frame_reroll
 from .image_sharpening import unsharp_mask
 from .load_images import get_mask, load_img
-from .hybrid_video import hybrid_generation, hybrid_composite, get_matrix_for_hybrid_motion, get_flow_for_hybrid_motion, image_transform_ransac, image_transform_optical_flow
+from .hybrid_video import hybrid_generation, hybrid_composite
+from .hybrid_video import get_matrix_for_hybrid_motion, get_matrix_for_hybrid_motion_prev, get_flow_for_hybrid_motion, get_flow_for_hybrid_motion_prev, image_transform_ransac, image_transform_optical_flow
 from .save_images import save_image
 from .composable_masks import compose_mask_with_check
 # Webui
@@ -216,24 +217,41 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, animat
                 # hybrid video motion - warps turbo_prev_image or turbo_next_image to match motion
                 if tween_frame_idx > 0:
                     if anim_args.hybrid_motion in ['Affine', 'Perspective']:
-                        matrix = get_matrix_for_hybrid_motion(tween_frame_idx-1, (args.W, args.H), inputfiles, anim_args.hybrid_motion)
+                        if anim_args.hybrid_motion_use_prev_img:
+                            if advance_prev:
+                                matrix = get_matrix_for_hybrid_motion_prev(tween_frame_idx, (args.W, args.H), inputfiles, turbo_prev_image, anim_args.hybrid_motion)
+                            if advance_next:
+                                matrix = get_matrix_for_hybrid_motion_prev(tween_frame_idx, (args.W, args.H), inputfiles, turbo_next_image, anim_args.hybrid_motion)
+                        else:
+                            matrix = get_matrix_for_hybrid_motion(tween_frame_idx-1, (args.W, args.H), inputfiles, anim_args.hybrid_motion)
                         if advance_prev:
                             turbo_prev_image = image_transform_ransac(turbo_prev_image, matrix, anim_args.hybrid_motion, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
                         if advance_next:
                             turbo_next_image = image_transform_ransac(turbo_next_image, matrix, anim_args.hybrid_motion, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
                     if anim_args.hybrid_motion in ['Optical Flow']:
-                        flow = get_flow_for_hybrid_motion(tween_frame_idx-1, (args.W, args.H), inputfiles, hybrid_frame_path, anim_args.hybrid_flow_method, anim_args.hybrid_comp_save_extra_frames)
+                        if anim_args.hybrid_motion_use_prev_img:
+                            if advance_prev:
+                                flow = get_flow_for_hybrid_motion_prev(tween_frame_idx-1, (args.W, args.H), inputfiles, hybrid_frame_path, turbo_prev_image, anim_args.hybrid_flow_method, anim_args.hybrid_comp_save_extra_frames)
+                            if advance_next:
+                                flow = get_flow_for_hybrid_motion_prev(tween_frame_idx-1, (args.W, args.H), inputfiles, hybrid_frame_path, turbo_next_image, anim_args.hybrid_flow_method, anim_args.hybrid_comp_save_extra_frames)
+                        else:
+                            flow = get_flow_for_hybrid_motion(tween_frame_idx-1, (args.W, args.H), inputfiles, hybrid_frame_path, anim_args.hybrid_flow_method, anim_args.hybrid_comp_save_extra_frames)
                         if advance_prev:
                             turbo_prev_image = image_transform_optical_flow(turbo_prev_image, flow, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
                         if advance_next:
                             turbo_next_image = image_transform_optical_flow(turbo_next_image, flow, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
-
+                      
                 turbo_prev_frame_idx = turbo_next_frame_idx = tween_frame_idx
 
                 if turbo_prev_image is not None and tween < 1.0:
                     img = turbo_prev_image*(1.0-tween) + turbo_next_image*tween
                 else:
                     img = turbo_next_image
+
+                # intercept and override to grayscale
+                if anim_args.color_force_grayscale:
+                    img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+                    img = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
 
                 filename = f"{args.timestring}_{tween_frame_idx:05}.png"
                 cv2.imwrite(os.path.join(args.outdir, filename), img)
@@ -249,10 +267,16 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, animat
             # hybrid video motion - warps prev_img to match motion, usually to prepare for compositing
             if frame_idx > 0:
                 if anim_args.hybrid_motion in ['Affine', 'Perspective']:
-                    matrix = get_matrix_for_hybrid_motion(frame_idx-1, (args.W, args.H), inputfiles, anim_args.hybrid_motion)
+                    if anim_args.hybrid_motion_use_prev_img:
+                        matrix = get_matrix_for_hybrid_motion_prev(frame_idx, (args.W, args.H), inputfiles, prev_img, anim_args.hybrid_motion)
+                    else:
+                        matrix = get_matrix_for_hybrid_motion(frame_idx-1, (args.W, args.H), inputfiles, anim_args.hybrid_motion)
                     prev_img = image_transform_ransac(prev_img, matrix, anim_args.hybrid_motion, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)    
                 if anim_args.hybrid_motion in ['Optical Flow']:
-                    flow = get_flow_for_hybrid_motion(frame_idx-1, (args.W, args.H), inputfiles, hybrid_frame_path, anim_args.hybrid_flow_method, anim_args.hybrid_comp_save_extra_frames)
+                    if anim_args.hybrid_motion_use_prev_img:
+                        flow = get_flow_for_hybrid_motion_prev(frame_idx-1, (args.W, args.H), inputfiles, hybrid_frame_path, prev_img, anim_args.hybrid_flow_method, anim_args.hybrid_comp_save_extra_frames)
+                    else:
+                        flow = get_flow_for_hybrid_motion(frame_idx-1, (args.W, args.H), inputfiles, hybrid_frame_path, anim_args.hybrid_flow_method, anim_args.hybrid_comp_save_extra_frames)
                     prev_img = image_transform_optical_flow(prev_img, flow, cv2.BORDER_WRAP if anim_args.border == 'wrap' else cv2.BORDER_REPLICATE)
 
             # do hybrid video - composites video frame into prev_img (now warped if using motion)
@@ -274,6 +298,11 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, animat
                     color_match_sample = prev_img.copy()
                 else:
                     prev_img = maintain_colors(prev_img, color_match_sample, anim_args.color_coherence)
+
+            # intercept and override to grayscale
+            if anim_args.color_force_grayscale:
+                prev_img = cv2.cvtColor(prev_img, cv2.COLOR_BGR2GRAY)
+                prev_img = cv2.cvtColor(prev_img, cv2.COLOR_GRAY2BGR)
 
             # apply scaling
             contrast_image = (prev_img * contrast).round().astype(np.uint8)
@@ -338,6 +367,11 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, animat
         # sample the diffusion model
         image = generate(args, anim_args, loop_args, root, frame_idx, sampler_name=scheduled_sampler_name)
         patience = 10
+
+        # intercept and override to grayscale
+        if anim_args.color_force_grayscale:
+            image = ImageOps.grayscale(image)
+            image = ImageOps.colorize(image, black ="black", white ="white")
 
         # reroll blank frame 
         if not image.getbbox():


### PR DESCRIPTION
This update fixes remap's border behavior when applying optical flow.
  - I extended the function so it extends borders and recrops.
  - obeys wrap/replicate setting, except that wrap is replaced with reflect101

Removed optical flow options that don't work unless you run contrib version of opencv (SF and DenseRLOF)
  - functions remain for possible future use if I can figure out how to run both opencv's.

Added 'DIS Medium' optical flow, which a dense flow, similar to the two types that we can't run.

Added checkbox control for hybrid_motion_use_prev_img
  - makes all motion, whether ransac or flow, compare against previous rendered frame rather than previous video frame

Added color_coherence_force_grayscale
  - forces grayscale before and after generation, so that color coherence mode can still be used (like color matching against video), but the image will be forced to grayscale. (NOTE: actual image file is still RGB)