### PR TITLE
Pix2pix image_cfg_scale schedule addition

### DIFF
--- a/javascript/deforum-hints.js
+++ b/javascript/deforum-hints.js
@@ -24,6 +24,7 @@ deforum_titles = {
     //"save_settings": "",
     //"save_samples": "",
     "Batch name": "output images will be placed in a folder with this name, inside of the img2img output folder",
+	"Pix2Pix img CFG schedule": "*Only in use with pix2pix checkpoints!*",
     "Filename format": "specify the format of the filename for output images",
     "Seed behavior": "defines the seed behavior that is used for animations",
         "iter": "the seed value will increment by 1 for each subsequent frame of the animation",

--- a/scripts/deforum_helpers/animation_key_frames.py
+++ b/scripts/deforum_helpers/animation_key_frames.py
@@ -22,6 +22,7 @@ class DeformAnimKeys():
         self.strength_schedule_series = get_inbetweens(parse_key_frames(anim_args.strength_schedule), anim_args.max_frames)
         self.contrast_schedule_series = get_inbetweens(parse_key_frames(anim_args.contrast_schedule), anim_args.max_frames)
         self.cfg_scale_schedule_series = get_inbetweens(parse_key_frames(anim_args.cfg_scale_schedule), anim_args.max_frames)
+        self.pix2pix_img_cfg_scale_series = get_inbetweens(parse_key_frames(anim_args.pix2pix_img_cfg_scale_schedule), anim_args.max_frames)
         self.checkpoint_schedule_series = get_inbetweens(parse_key_frames(anim_args.checkpoint_schedule), anim_args.max_frames, is_single_string = True)
         self.steps_schedule_series = get_inbetweens(parse_key_frames(anim_args.steps_schedule), anim_args.max_frames)
         self.seed_schedule_series = get_inbetweens(parse_key_frames(anim_args.seed_schedule), anim_args.max_frames)

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -55,8 +55,8 @@ def DeforumAnimArgs():
     near_schedule = "0: (200)"
     far_schedule = "0: (10000)"
     seed_schedule = "0:(5), 1:(-1), 219:(-1), 220:(5)"
-    pix2pix_img_cfg_scale = "1"
-    pix2pix_img_cfg_scale_schedule = "0:(1)"
+    pix2pix_img_cfg_scale = "1.5"
+    pix2pix_img_cfg_scale_schedule = "0:(1.5)"
     
     # Sampler Scheduling
     enable_sampler_scheduling = False #@param {type:"boolean"}

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -55,6 +55,8 @@ def DeforumAnimArgs():
     near_schedule = "0: (200)"
     far_schedule = "0: (10000)"
     seed_schedule = "0:(5), 1:(-1), 219:(-1), 220:(5)"
+    pix2pix_img_cfg_scale = "1"
+    pix2pix_img_cfg_scale_schedule = "0:(1)"
     
     # Sampler Scheduling
     enable_sampler_scheduling = False #@param {type:"boolean"}
@@ -364,6 +366,8 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                     ddim_eta = gr.Number(label="DDIM ETA", value=d.ddim_eta, interactive=True)
                     tiling = gr.Checkbox(label='Tiling', value=False)
                     n_batch = gr.Number(label="N Batch", value=d.n_batch, interactive=True, precision=0, visible=False)
+                with gr.Row() as pix2pix_img_cfg_scale_row:
+                    pix2pix_img_cfg_scale_schedule = gr.Textbox(label="Pix2Pix img CFG schedule", value=da.pix2pix_img_cfg_scale_schedule, interactive=True) 
             with gr.Row(visible=False):
                 save_sample_per_step = gr.Checkbox(label="Save sample per step", value=d.save_sample_per_step, interactive=True)
                 show_sample_per_step = gr.Checkbox(label="Show sample per step", value=d.show_sample_per_step, interactive=True)
@@ -928,7 +932,7 @@ anim_args_names =   str(r'''animation_mode, max_frames, border,
                         rotation_3d_x, rotation_3d_y, rotation_3d_z,
                         enable_perspective_flip,
                         perspective_flip_theta, perspective_flip_phi, perspective_flip_gamma, perspective_flip_fv,
-                        noise_schedule, strength_schedule, contrast_schedule, cfg_scale_schedule,
+                        noise_schedule, strength_schedule, contrast_schedule, cfg_scale_schedule, pix2pix_img_cfg_scale_schedule,
                         enable_steps_scheduling, steps_schedule,
                         fov_schedule, near_schedule, far_schedule,
                         seed_schedule,

--- a/scripts/deforum_helpers/generate.py
+++ b/scripts/deforum_helpers/generate.py
@@ -194,6 +194,7 @@ def generate(args, anim_args, loop_args, root, frame = 0, return_sample=False, s
         p.image_mask = mask
 
         print(f"seed={p.seed}; subseed={p.subseed}; subseed_strength={p.subseed_strength}; denoising_strength={p.denoising_strength}; steps={p.steps}; cfg_scale={p.cfg_scale}; sampler={p.sampler_name}")
+        p.image_cfg_scale = args.pix2pix_img_cfg_scale
         processed = processing.process_images(p)
     
     if root.initial_info == None:

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -328,6 +328,9 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, animat
             args.strength = max(0.0, min(1.0, strength))
         
         args.scale = scale
+       
+        # Pix2Pix Image CFG Scale - does *nothing* with non pix2pix checkpoints
+        args.pix2pix_img_cfg_scale = float(keys.pix2pix_img_cfg_scale_series[frame_idx])
 
         # grab prompt for current frame
         args.prompt = prompt_series[frame_idx]
@@ -426,4 +429,3 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, animat
         state.current_image = image
 
         args.seed = next_seed(args)
-

--- a/scripts/deforum_helpers/render_modes.py
+++ b/scripts/deforum_helpers/render_modes.py
@@ -107,6 +107,7 @@ def render_interpolation(args, anim_args, video_args, parseq_args, loop_args, an
         args.n_samples = 1
         args.prompt = prompt_series[frame_idx]
         args.scale = keys.cfg_scale_schedule_series[frame_idx]
+        args.pix2pix_img_cfg_scale = keys.pix2pix_img_cfg_scale_series[frame_idx]
         
         if anim_args.enable_checkpoint_scheduling:
             args.checkpoint = keys.checkpoint_schedule_series[frame_idx]

--- a/scripts/deforum_helpers/webui_sd_pipeline.py
+++ b/scripts/deforum_helpers/webui_sd_pipeline.py
@@ -44,6 +44,7 @@ def get_webui_sd_pipeline(args, root, frame):
     else:
         p.denoising_strength = 1 - args.strength
     p.cfg_scale = args.scale
+    p.image_cfg_scale = args.pix2pix_img_cfg_scale
     p.outpath_samples = root.outpath_samples
     
 


### PR DESCRIPTION
Subject says it all. This param does NOTHING when in use with non pix2pix checkpoints (hints say that). 

I will probably auto-hide it when a non pix2pix ckpt is loaded, _in a later pr_. Need to figure out how to properly check the loaded model and also take ckpt_schedule into account.

The new schedule is under "Subseed controls & More" because if I add it to our extra schedules tabs we _won't_ be able to hide it/ dynamically show it at all.

Look in the UI:
![image](https://user-images.githubusercontent.com/121192995/217973580-50b6959c-07a3-4204-b9c5-7841988e2d7b.png)

Test video, wildly changing pix2pix img cfg scale values, rest is default: 
https://user-images.githubusercontent.com/121192995/217973382-32079427-3d94-4214-99c3-ef66b48923bb.mp4

Closes https://github.com/deforum-art/deforum-for-automatic1111-webui/issues/314

