### PR TITLE
Stop saving to .txt files params that aren't visible in the UI

### DIFF
--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -121,11 +121,15 @@ def run_deforum(*args, **kwargs):
             mp4_path = os.path.join(args.outdir, f"{args.timestring}.mp4")
             max_video_frames = anim_args.max_frames
 
-        #save settings for the video
+        exclude_keys = deforum_settings.get_keys_to_exclude('video')
         video_settings_filename = os.path.join(args.outdir, f"{args.timestring}_video-settings.txt")
         with open(video_settings_filename, "w+", encoding="utf-8") as f:
-            s = {**dict(video_args.__dict__)}
+            s = {}
+            for key, value in dict(video_args.__dict__).items():
+                if key not in exclude_keys:
+                    s[key] = value
             json.dump(s, f, ensure_ascii=False, indent=4)
+
         # Stitch video using ffmpeg!
         try:
             ffmpeg_stitch_video(ffmpeg_location=video_args.ffmpeg_location, fps=video_args.fps, outmp4_path=mp4_path, stitch_from_frame=0, stitch_to_frame=max_video_frames, imgs_path=image_path, add_soundtrack=video_args.add_soundtrack, audio_path=real_audio_track, crf=video_args.ffmpeg_crf, preset=video_args.ffmpeg_preset)

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -104,7 +104,7 @@ def run_deforum(*args, **kwargs):
         
     if video_args.skip_video_for_run_all:
         print('Skipping video creation, uncheck skip_video_for_run_all if you want to run it')
-    elif video_args.output_format == 'FFMPEG mp4':
+    else: #video_args.output_format == 'FFMPEG mp4':
         import subprocess
 
         path_name_modifier = video_args.path_name_modifier
@@ -142,46 +142,6 @@ def run_deforum(*args, **kwargs):
             else:
                 print(f"** FFMPEG DID NOT STITCH ANY VIDEO ** Error: {e}")
             pass
-
-    else: # *GIF* TIME!
-        # TODO: add support for custom frame interpolation vid location?
-        path_name_modifier = video_args.path_name_modifier
-        if video_args.render_steps: # render steps from a single image
-            fname = f"{path_name_modifier}_%05d.png"
-            all_step_dirs = [os.path.join(args.outdir, d) for d in os.listdir(args.outdir) if os.path.isdir(os.path.join(args.outdir,d))]
-            newest_dir = max(all_step_dirs, key=os.path.getmtime)
-            image_path = os.path.join(newest_dir, fname)
-            print(f"Reading images from {image_path}")
-            mp4_path = os.path.join(newest_dir, f"{args.timestring}_{path_name_modifier}.gif")
-            max_video_frames = args.steps
-        else: # render images for a video
-            image_path = os.path.join(args.outdir, f"{args.timestring}_%05d.png")
-            mp4_path = os.path.join(args.outdir, f"{args.timestring}.gif")
-            max_video_frames = anim_args.max_frames
-
-        print(f"GIF created from:\n{image_path}\nTo:\n{mp4_path}")
-
-        #save settings for the video
-        video_settings_filename = os.path.join(args.outdir, f"{args.timestring}_video-settings.txt")
-        with open(video_settings_filename, "w+", encoding="utf-8") as f:
-            s = {**dict(video_args.__dict__)}
-            json.dump(s, f, ensure_ascii=False, indent=4)
-        
-        imagelist = [Image.open(os.path.join(args.outdir, image_path%d)) for d in range(max_video_frames) if os.path.exists(os.path.join(args.outdir, image_path%d))]
-        
-        imagelist[0].save(
-            mp4_path,#gif here
-            save_all=True,
-            append_images=imagelist[1:],
-            optimize=True,
-            duration=1000/video_args.fps, #????
-            loop=0
-        )
-        
-        mp4 = open(mp4_path,'rb').read()
-        data_url = "data:image/gif;base64," + b64encode(mp4).decode()
-        
-        deforum_args.i1_store = f'<p style=\"font-weight:bold;margin-bottom:0em\">Deforum v0.5-webui-beta</p><img src="{data_url}" type="image/gif"></img>'
 
     if root.initial_info is None:
         root.initial_info = "An error has occured and nothing has been generated!"

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -22,6 +22,7 @@ from .hybrid_video import hybrid_generation, hybrid_composite
 from .hybrid_video import get_matrix_for_hybrid_motion, get_matrix_for_hybrid_motion_prev, get_flow_for_hybrid_motion, get_flow_for_hybrid_motion_prev, image_transform_ransac, image_transform_optical_flow
 from .save_images import save_image
 from .composable_masks import compose_mask_with_check
+from .settings import get_keys_to_exclude
 # Webui
 from modules.shared import opts, cmd_opts, state
 
@@ -56,12 +57,17 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, animat
     print(f"Saving animation frames to:\n{args.outdir}")
 
     # save settings for the batch
+    exclude_keys = get_keys_to_exclude('general')
     settings_filename = os.path.join(args.outdir, f"{args.timestring}_settings.txt")
     with open(settings_filename, "w+", encoding="utf-8") as f:
         args.__dict__["prompts"] = animation_prompts
-        s = {**dict(args.__dict__), **dict(anim_args.__dict__), **dict(parseq_args.__dict__), **dict(loop_args.__dict__)}
+        s = {}
+        for d in [dict(args.__dict__), dict(anim_args.__dict__), dict(parseq_args.__dict__), dict(loop_args.__dict__)]:
+            for key, value in d.items():
+                if key not in exclude_keys:
+                    s[key] = value
         json.dump(s, f, ensure_ascii=False, indent=4)
-        
+
     # resume from timestring
     if anim_args.resume_from_timestring:
         args.timestring = anim_args.resume_timestring

--- a/scripts/deforum_helpers/render_modes.py
+++ b/scripts/deforum_helpers/render_modes.py
@@ -9,6 +9,7 @@ from .generate import generate
 from .animation_key_frames import DeformAnimKeys
 from .parseq_adapter import ParseqAnimKeys
 from .save_images import save_image
+from .settings import get_keys_to_exclude
 
 # Webui
 from modules.shared import opts, cmd_opts, state
@@ -80,11 +81,16 @@ def render_interpolation(args, anim_args, video_args, parseq_args, loop_args, an
     print(f"Saving interpolation animation frames to {args.outdir}")
 
     # save settings for the batch
+    exclude_keys = get_keys_to_exclude('general')
     settings_filename = os.path.join(args.outdir, f"{args.timestring}_settings.txt")
     with open(settings_filename, "w+", encoding="utf-8") as f:
-        s = {**dict(args.__dict__), **dict(anim_args.__dict__), **dict(parseq_args.__dict__)}
+        s = {}
+        for d in [dict(args.__dict__), dict(anim_args.__dict__), dict(parseq_args.__dict__)]:
+            for key, value in d.items():
+                if key not in exclude_keys:
+                    s[key] = value
         json.dump(s, f, ensure_ascii=False, indent=4)
-    
+
     # Compute interpolated prompts
     if use_parseq:
         print("Parseq prompts are assumed to already be interpolated - not doing any additional prompt interpolation")

--- a/scripts/deforum_helpers/settings.py
+++ b/scripts/deforum_helpers/settings.py
@@ -52,7 +52,7 @@ def load_args(args_dict,anim_args_dict, parseq_args_dict, loop_args_dict, custom
 
 # In gradio gui settings save/ load funs:
 def save_settings(*args, **kwargs):
-    settings_path = args[0]
+    settings_path = args[0].strip()
     data = {deforum_args.settings_component_names[i]: args[i+1] for i in range(0, len(deforum_args.settings_component_names))}
     from deforum_helpers.args import pack_args, pack_anim_args, pack_parseq_args, pack_loop_args
     args_dict = pack_args(data)
@@ -74,7 +74,7 @@ def save_settings(*args, **kwargs):
     return [""]
 
 def save_video_settings(*args, **kwargs):
-    video_settings_path = args[0]
+    video_settings_path = args[0].strip()
     data = {deforum_args.video_args_names[i]: args[i+1] for i in range(0, len(deforum_args.video_args_names))}
     from deforum_helpers.args import pack_video_args
     video_args_dict = pack_video_args(data)
@@ -86,7 +86,7 @@ def save_video_settings(*args, **kwargs):
     return [""]
 
 def load_settings(*args, **kwargs):
-    settings_path = args[0]
+    settings_path = args[0].strip()
     data = {deforum_args.settings_component_names[i]: args[i+1] for i in range(0, len(deforum_args.settings_component_names))}
     print(f"reading custom settings from {settings_path}")
     jdata = {}
@@ -161,7 +161,7 @@ def load_settings(*args, **kwargs):
     return ret
 
 def load_video_settings(*args, **kwargs):
-    video_settings_path = args[0]
+    video_settings_path = args[0].strip()
     data = {deforum_args.video_args_names[i]: args[i+1] for i in range(0, len(deforum_args.video_args_names))}
     print(f"reading custom video settings from {video_settings_path}")
     jdata = {}

--- a/scripts/deforum_helpers/settings.py
+++ b/scripts/deforum_helpers/settings.py
@@ -6,6 +6,9 @@ from .args import mask_fill_choices, DeforumArgs, DeforumAnimArgs
 from .deprecation_utils import handle_deprecated_settings
 import logging
 
+def get_keys_to_exclude():
+    return ["n_batch", "restore_faces", "seed_enable_extras", "save_samples", "display_samples", "show_sample_per_step", "filename_format", "from_img2img_instead_of_link", "scale", "subseed", "subseed_strength", "C", "f", "init_latent", "init_sample", "init_c", "noise_mask", "seed_internal"]
+
 def load_args(args_dict,anim_args_dict, parseq_args_dict, loop_args_dict, custom_settings_file, root):
     print(f"reading custom settings from {custom_settings_file}")
     if not os.path.isfile(custom_settings_file):
@@ -43,11 +46,10 @@ def load_args(args_dict,anim_args_dict, parseq_args_dict, loop_args_dict, custom
             print(anim_args_dict)
             print(parseq_args_dict)
             print(loop_args_dict)
-            
 
-import gradio as gr
- 
-# In gradio gui settings save/load
+# import gradio as gr
+
+# In gradio gui settings save
 def save_settings(*args, **kwargs):
     settings_path = args[0]
     data = {deforum_args.settings_component_names[i]: args[i+1] for i in range(0, len(deforum_args.settings_component_names))}
@@ -59,9 +61,15 @@ def save_settings(*args, **kwargs):
     args_dict["animation_prompts_positive"] = data['animation_prompts_positive']
     args_dict["animation_prompts_negative"] = data['animation_prompts_negative']
     loop_dict = pack_loop_args(data)
+    
+    combined = {**args_dict, **anim_args_dict, **parseq_dict, **loop_dict}
+    exclude_keys = get_keys_to_exclude()
+    filtered_combined = {k: v for k, v in combined.items() if k not in exclude_keys}
+    
     print(f"saving custom settings to {settings_path}")
     with open(settings_path, "w") as f:
-        f.write(json.dumps({**args_dict, **anim_args_dict, **parseq_dict, **loop_dict}, ensure_ascii=False, indent=4))
+        f.write(json.dumps(filtered_combined, ensure_ascii=False, indent=4))
+    
     return [""]
 
 def save_video_settings(*args, **kwargs):

--- a/scripts/deforum_helpers/settings.py
+++ b/scripts/deforum_helpers/settings.py
@@ -6,8 +6,11 @@ from .args import mask_fill_choices, DeforumArgs, DeforumAnimArgs
 from .deprecation_utils import handle_deprecated_settings
 import logging
 
-def get_keys_to_exclude():
-    return ["n_batch", "restore_faces", "seed_enable_extras", "save_samples", "display_samples", "show_sample_per_step", "filename_format", "from_img2img_instead_of_link", "scale", "subseed", "subseed_strength", "C", "f", "init_latent", "init_sample", "init_c", "noise_mask", "seed_internal"]
+def get_keys_to_exclude(setting_type):
+    if setting_type == 'general':
+        return ["n_batch", "restore_faces", "seed_enable_extras", "save_samples", "display_samples", "show_sample_per_step", "filename_format", "from_img2img_instead_of_link", "scale", "subseed", "subseed_strength", "C", "f", "init_latent", "init_sample", "init_c", "noise_mask", "seed_internal"]
+    else: #video
+        return ["mp4_path", "image_path", "output_format","render_steps","path_name_modifier"]
 
 def load_args(args_dict,anim_args_dict, parseq_args_dict, loop_args_dict, custom_settings_file, root):
     print(f"reading custom settings from {custom_settings_file}")
@@ -61,7 +64,7 @@ def save_settings(*args, **kwargs):
     loop_dict = pack_loop_args(data)
     
     combined = {**args_dict, **anim_args_dict, **parseq_dict, **loop_dict}
-    exclude_keys = get_keys_to_exclude()
+    exclude_keys = get_keys_to_exclude('general')
     filtered_combined = {k: v for k, v in combined.items() if k not in exclude_keys}
     
     print(f"saving custom settings to {settings_path}")
@@ -75,9 +78,11 @@ def save_video_settings(*args, **kwargs):
     data = {deforum_args.video_args_names[i]: args[i+1] for i in range(0, len(deforum_args.video_args_names))}
     from deforum_helpers.args import pack_video_args
     video_args_dict = pack_video_args(data)
+    exclude_keys = get_keys_to_exclude('video')
+    filtered_data = video_args_dict if exclude_keys is None else {k: v for k, v in video_args_dict.items() if k not in exclude_keys}
     print(f"saving video settings to {video_settings_path}")
     with open(video_settings_path, "w") as f:
-        f.write(json.dumps(video_args_dict, ensure_ascii=False, indent=4))
+        f.write(json.dumps(filtered_data, ensure_ascii=False, indent=4))
     return [""]
 
 def load_settings(*args, **kwargs):

--- a/scripts/deforum_helpers/settings.py
+++ b/scripts/deforum_helpers/settings.py
@@ -47,8 +47,6 @@ def load_args(args_dict,anim_args_dict, parseq_args_dict, loop_args_dict, custom
             print(parseq_args_dict)
             print(loop_args_dict)
 
-# import gradio as gr
-
 # In gradio gui settings save
 def save_settings(*args, **kwargs):
     settings_path = args[0]

--- a/scripts/deforum_helpers/settings.py
+++ b/scripts/deforum_helpers/settings.py
@@ -50,7 +50,7 @@ def load_args(args_dict,anim_args_dict, parseq_args_dict, loop_args_dict, custom
             print(parseq_args_dict)
             print(loop_args_dict)
 
-# In gradio gui settings save
+# In gradio gui settings save/ load funs:
 def save_settings(*args, **kwargs):
     settings_path = args[0]
     data = {deforum_args.settings_component_names[i]: args[i+1] for i in range(0, len(deforum_args.settings_component_names))}


### PR DESCRIPTION
*Non breaking PR*

Handles both general and video sett files. 

Don't think it's wise to combine this pr with the actual removal of the params from our code base.
This needs to take place in an entire diff pr, in the near future hopefully.

Also can add contextual saving of params like we have in our UI. An idea. 

Closes https://github.com/deforum-art/deforum-for-automatic1111-webui/issues/332

Also fixes a bug where you'd get errors when loading/ saving paths with leading/trailing newlines, spaces etc.

\+ Removed a bit of PIL-GIF code from deforum.py