### PR TITLE
remove moviepy from req.txt - not in actual use

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ matplotlib
 pandas
 av
 pims
-moviepy
 imageio_ffmpeg
 prettytable


### PR DESCRIPTION
Old remnant from non-production versions. It's not in use in the entire code-base. 