### PR TITLE
FAST ncnn-vulkan upscaling for generated videos (no upload atm)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2445,3 +2445,50 @@ reviewing courts shall apply local law that most closely approximates
 an absolute waiver of all civil liability in connection with the
 Program, unless a warranty or assumption of liability accompanies a
 copy of the Program in return for a fee.
+
+REALESRGAN/ REALESRGAN-NCNN-VULKAN:
+MIT License (MIT)
+
+Copyright (c) 2021 Xintao Wang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------
+The following is the License of realsr-ncnn-vulkan
+
+The MIT License (MIT)
+
+Copyright (c) 2019 nihui
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/javascript/deforum-hints.js
+++ b/javascript/deforum-hints.js
@@ -118,6 +118,9 @@ deforum_titles = {
     //Video Output
     "Skip video for run all": "when checked, do not output a video",
 	"Make GIF": "create a gif in addition to .mp4 file. supports up to 30 fps, will self-disable at higher fps values",
+	"Upscale":"upscale the images of the next run once it's finished + make a video out of them",
+	"Upscale model":"model of the upscaler to use. animevideov3 is much faster but yields smoother, less detailed results. the other models only do x4",
+	"Upscale factor":"how many times to upscale, actual options depend on the chosen upscale model",
     "FPS": "The frames per second that the video will run at",
     "Output format": "select the type of video file to output",
         "PIL gif": "create an animated GIF",

--- a/javascript/deforum-hints.js
+++ b/javascript/deforum-hints.js
@@ -136,7 +136,7 @@ deforum_titles = {
 	"Engine": "choose the frame interpolation engine and version",
 	"Interp x":"how many times to interpolate the source video. e.g source video fps of 12 and a value of x2 will yield a 24fps interpolated video",
 	"Slow-Mo x":"how many times to slow-down the video. *Naturally affects output fps as well",
-	"Keep Imgs": "delete or keep raw interpolated png imgs. Default: False which means delete",
+	"Keep Imgs": "delete or keep raw affected (interpolated/ upscaled depending on the UI section) png imgs. Default: False which means delete",
 	"Interpolate an existing video":"This feature allows you to interpolate any video with a dedicated button. Video could be completly unrelated to deforum",
 	"In Frame Count": "uploaded video total frame count",
 	"In FPS":"uploaded video FPS",

--- a/javascript/deforum-hints.js
+++ b/javascript/deforum-hints.js
@@ -119,7 +119,7 @@ deforum_titles = {
     "Skip video for run all": "when checked, do not output a video",
 	"Make GIF": "create a gif in addition to .mp4 file. supports up to 30 fps, will self-disable at higher fps values",
 	"Upscale":"upscale the images of the next run once it's finished + make a video out of them",
-	"Upscale model":"model of the upscaler to use. animevideov3 is much faster but yields smoother, less detailed results. the other models only do x4",
+	"Upscale model":"model of the upscaler to use. 'realesr-animevideov3' is much faster but yields smoother, less detailed results. the other models only do x4",
 	"Upscale factor":"how many times to upscale, actual options depend on the chosen upscale model",
     "FPS": "The frames per second that the video will run at",
     "Output format": "select the type of video file to output",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ av
 pims
 imageio_ffmpeg
 prettytable
+rich

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -17,7 +17,7 @@ for basedir in basedirs:
 import deforum_helpers.args as deforum_args
 import deforum_helpers.settings as deforum_settings
 from deforum_helpers.save_images import dump_frames_cache, reset_frames_cache
-from deforum_helpers.frame_interpolation import process_video_interpolation
+from deforum_helpers.frame_interpolation import process_video_interpolation, extract_number
 
 import modules.scripts as wscripts
 from modules import script_callbacks
@@ -157,7 +157,12 @@ def run_deforum(*args, **kwargs):
     if video_args.make_gif and not video_args.skip_video_for_run_all and not video_args.store_frames_in_ram:
         make_gifski_gif(imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, models_folder = root.models_path, current_user_os = root.current_user_os)
     
-    make_upscale_v2(imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, deforum_models_path = root.models_path, current_user_os = root.current_user_os)
+    # Upscale video once generation is done:
+    if video_args.r_upscale_video:
+        
+        clean_num_r_up_factor = extract_number(video_args.r_upscale_factor)
+
+        make_upscale_v2(upscale_factor = clean_num_r_up_factor, upscale_model = video_args.r_upscale_model, imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, deforum_models_path = root.models_path, current_user_os = root.current_user_os)
         
     root.initial_info += "\n The animation is stored in " + args.outdir + '\n'
     root.initial_info += "Only the first frame is shown in webui not to clutter the memory"

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -26,7 +26,7 @@ import json
 
 from modules.processing import Processed, StableDiffusionProcessingImg2Img, process_images
 from PIL import Image
-from deforum_helpers.video_audio_utilities import ffmpeg_stitch_video, make_gifski_gif
+from deforum_helpers.video_audio_utilities import ffmpeg_stitch_video, make_gifski_gif, make_upscale_v2
 import gc
 import torch
 from webui import wrap_gradio_gpu_call
@@ -156,6 +156,8 @@ def run_deforum(*args, **kwargs):
     
     if video_args.make_gif and not video_args.skip_video_for_run_all and not video_args.store_frames_in_ram:
         make_gifski_gif(imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, models_folder = root.models_path, current_user_os = root.current_user_os)
+    
+    make_upscale_v2()
         
     root.initial_info += "\n The animation is stored in " + args.outdir + '\n'
     root.initial_info += "Only the first frame is shown in webui not to clutter the memory"

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -157,7 +157,7 @@ def run_deforum(*args, **kwargs):
     if video_args.make_gif and not video_args.skip_video_for_run_all and not video_args.store_frames_in_ram:
         make_gifski_gif(imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, models_folder = root.models_path, current_user_os = root.current_user_os)
     
-    make_upscale_v2()
+    make_upscale_v2(imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, deforum_models_path = root.models_path, current_user_os = root.current_user_os)
         
     root.initial_info += "\n The animation is stored in " + args.outdir + '\n'
     root.initial_info += "Only the first frame is shown in webui not to clutter the memory"

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -17,7 +17,7 @@ for basedir in basedirs:
 import deforum_helpers.args as deforum_args
 import deforum_helpers.settings as deforum_settings
 from deforum_helpers.save_images import dump_frames_cache, reset_frames_cache
-from deforum_helpers.frame_interpolation import process_video_interpolation, extract_number
+from deforum_helpers.frame_interpolation import process_video_interpolation
 
 import modules.scripts as wscripts
 from modules import script_callbacks
@@ -160,10 +160,8 @@ def run_deforum(*args, **kwargs):
     # Upscale video once generation is done:
     if video_args.r_upscale_video and not video_args.skip_video_for_run_all and not video_args.store_frames_in_ram:
         
-        clean_num_r_up_factor = extract_number(video_args.r_upscale_factor)
-
         # out mp4 path is defined in make_upscale func
-        make_upscale_v2(upscale_factor = clean_num_r_up_factor, upscale_model = video_args.r_upscale_model, keep_imgs = video_args.r_upscale_keep_imgs, imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, deforum_models_path = root.models_path, current_user_os = root.current_user_os, ffmpeg_location=video_args.ffmpeg_location, stitch_from_frame=0, stitch_to_frame=max_video_frames, ffmpeg_crf=video_args.ffmpeg_crf, ffmpeg_preset=video_args.ffmpeg_preset, add_soundtrack = video_args.add_soundtrack ,audio_path=real_audio_track)
+        make_upscale_v2(upscale_factor = video_args.r_upscale_factor, upscale_model = video_args.r_upscale_model, keep_imgs = video_args.r_upscale_keep_imgs, imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, deforum_models_path = root.models_path, current_user_os = root.current_user_os, ffmpeg_location=video_args.ffmpeg_location, stitch_from_frame=0, stitch_to_frame=max_video_frames, ffmpeg_crf=video_args.ffmpeg_crf, ffmpeg_preset=video_args.ffmpeg_preset, add_soundtrack = video_args.add_soundtrack ,audio_path=real_audio_track)
         
     root.initial_info += "\n The animation is stored in " + args.outdir + '\n'
     root.initial_info += "Only the first frame is shown in webui not to clutter the memory"

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -162,7 +162,7 @@ def run_deforum(*args, **kwargs):
         
         clean_num_r_up_factor = extract_number(video_args.r_upscale_factor)
 
-        make_upscale_v2(upscale_factor = clean_num_r_up_factor, upscale_model = video_args.r_upscale_model, imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, deforum_models_path = root.models_path, current_user_os = root.current_user_os)
+        make_upscale_v2(upscale_factor = clean_num_r_up_factor, upscale_model = video_args.r_upscale_model, keep_imgs = video_args.r_upscale_keep_imgs, imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, deforum_models_path = root.models_path, current_user_os = root.current_user_os)
         
     root.initial_info += "\n The animation is stored in " + args.outdir + '\n'
     root.initial_info += "Only the first frame is shown in webui not to clutter the memory"

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -158,7 +158,7 @@ def run_deforum(*args, **kwargs):
         make_gifski_gif(imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, models_folder = root.models_path, current_user_os = root.current_user_os)
     
     # Upscale video once generation is done:
-    if video_args.r_upscale_video:
+    if video_args.r_upscale_video and not video_args.skip_video_for_run_all and not video_args.store_frames_in_ram:
         
         clean_num_r_up_factor = extract_number(video_args.r_upscale_factor)
 

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -162,7 +162,8 @@ def run_deforum(*args, **kwargs):
         
         clean_num_r_up_factor = extract_number(video_args.r_upscale_factor)
 
-        make_upscale_v2(upscale_factor = clean_num_r_up_factor, upscale_model = video_args.r_upscale_model, keep_imgs = video_args.r_upscale_keep_imgs, imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, deforum_models_path = root.models_path, current_user_os = root.current_user_os)
+        # out mp4 path is defined in make_upscale func
+        make_upscale_v2(upscale_factor = clean_num_r_up_factor, upscale_model = video_args.r_upscale_model, keep_imgs = video_args.r_upscale_keep_imgs, imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, deforum_models_path = root.models_path, current_user_os = root.current_user_os, ffmpeg_location=video_args.ffmpeg_location, stitch_from_frame=0, stitch_to_frame=max_video_frames, ffmpeg_crf=video_args.ffmpeg_crf, ffmpeg_preset=video_args.ffmpeg_preset, add_soundtrack = video_args.add_soundtrack ,audio_path=real_audio_track)
         
     root.initial_info += "\n The animation is stored in " + args.outdir + '\n'
     root.initial_info += "Only the first frame is shown in webui not to clutter the memory"

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -942,12 +942,12 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
     # Gradio's Change functions - hiding and renaming elements based on other elements
     if dr.current_user_os in ["Windows", "Linux"]: # duplicate ifs to enable changes only to GIFski by adding Mac to one of them
         fps.change(fn=change_gif_button_visibility, inputs=fps, outputs=make_gif)
-    if dr.current_user_os in ["Windows", "Linux"]: # mac removed 15-2 until fix is found
+    if dr.current_user_os in ["Windows", "Linux", "Mac"]: # mac removed 15-2 until fix is found
         r_upscale_model.change(fn=update_r_upscale_factor, inputs=r_upscale_model, outputs=r_upscale_factor)
         ncnn_upscale_model.change(fn=update_r_upscale_factor, inputs=ncnn_upscale_model, outputs=ncnn_upscale_factor)
-    ncnn_upscale_model.change(update_upscale_out_res_by_model_name, inputs=[ncnn_upscale_in_vid_res, ncnn_upscale_model], outputs=ncnn_upscale_out_vid_res)
-    ncnn_upscale_factor.change(update_upscale_out_res, inputs=[ncnn_upscale_in_vid_res, ncnn_upscale_factor], outputs=ncnn_upscale_out_vid_res)
-    vid_to_upscale_chosen_file.change(vid_upscale_gradio_update_stats,inputs=[vid_to_upscale_chosen_file, ncnn_upscale_factor],outputs=[ncnn_upscale_in_vid_fps_ui_window, ncnn_upscale_in_vid_frame_count_window, ncnn_upscale_in_vid_res, ncnn_upscale_out_vid_res])
+        ncnn_upscale_model.change(update_upscale_out_res_by_model_name, inputs=[ncnn_upscale_in_vid_res, ncnn_upscale_model], outputs=ncnn_upscale_out_vid_res)
+        ncnn_upscale_factor.change(update_upscale_out_res, inputs=[ncnn_upscale_in_vid_res, ncnn_upscale_factor], outputs=ncnn_upscale_out_vid_res)
+        vid_to_upscale_chosen_file.change(vid_upscale_gradio_update_stats,inputs=[vid_to_upscale_chosen_file, ncnn_upscale_factor],outputs=[ncnn_upscale_in_vid_fps_ui_window, ncnn_upscale_in_vid_frame_count_window, ncnn_upscale_in_vid_res, ncnn_upscale_out_vid_res])
         
     animation_mode.change(fn=change_max_frames_visibility, inputs=animation_mode, outputs=max_frames)
     animation_mode.change(fn=change_diffusion_cadence_visibility, inputs=animation_mode, outputs=diffusion_cadence_column)

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -279,6 +279,7 @@ def DeforumOutputArgs():
     r_upscale_factor = 'x2' # ['2x', 'x3', 'x4']
     # **model below** - 'realesr-animevideov3' (default of realesrgan engine, does 2-4x), the rest does only 4x: 'realesrgan-x4plus', 'realesrgan-x4plus-anime'
     r_upscale_model = 'realesr-animevideov3' 
+    r_upscale_keep_imgs = True
     
     render_steps = False  #@param {type: 'boolean'}
     path_name_modifier = "x0_pred" #@param ["x0_pred","x"]
@@ -768,6 +769,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                     r_upscale_video = gr.Checkbox(label="Upscale", value=dv.r_upscale_video, interactive=True)
                     r_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
                     r_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
+                    r_upscale_keep_imgs = gr.Checkbox(label="Keep imgs", value=dv.r_upscale_keep_imgs, interactive=True)
                 
                 if dr.current_user_os in ["Windows", "Apple"]:
                     r_upscale_model.change(fn=gfs, inputs=r_upscale_model, outputs=r_upscale_factor)    
@@ -994,7 +996,7 @@ args_names =    str(r'''W, H, tiling, restore_faces,
 video_args_names =  str(r'''skip_video_for_run_all,
                             fps, make_gif, output_format, ffmpeg_location, ffmpeg_crf, ffmpeg_preset,
                             add_soundtrack, soundtrack_path,
-                            r_upscale_video, r_upscale_model, r_upscale_factor,
+                            r_upscale_video, r_upscale_model, r_upscale_factor, r_upscale_keep_imgs,
                             render_steps,
                             path_name_modifier, image_path, mp4_path, store_frames_in_ram,
                             frame_interpolation_engine, frame_interpolation_x_amount, frame_interpolation_slow_mo_amount,

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -948,7 +948,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
         return f"{int(in_res.split('*')[0]) * factor}*{int(in_res.split('*')[1]) * factor}"
 
     # Gradio's Change functions - hiding and renaming elements based on other elements
-    if dr.current_user_os in ["Windows", "Linux"]: # duplicate ifs to enable changes only to GIFski by adding Mac to one of them
+    if dr.current_user_os in ["Windows", "Linux"]:
         fps.change(fn=change_gif_button_visibility, inputs=fps, outputs=make_gif)
     if dr.current_user_os in ["Windows", "Linux", "Mac"]: # mac removed 15-2 until fix is found
         r_upscale_model.change(fn=update_r_upscale_factor, inputs=r_upscale_model, outputs=r_upscale_factor)

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -267,7 +267,6 @@ def DeforumOutputArgs():
     skip_video_for_run_all = False #@param {type: 'boolean'}
     fps = 15 #@param {type:"number"}
     make_gif = False
-    #@markdown **Manual Settings**
     image_path = "C:/SD/20230124234916_%05d.png" #@param {type:"string"}
     mp4_path = "testvidmanualsettings.mp4" #@param {type:"string"}
     ffmpeg_location = find_ffmpeg_binary()
@@ -275,6 +274,12 @@ def DeforumOutputArgs():
     ffmpeg_preset = 'slow'
     add_soundtrack = 'None' #@param ["File","Init Video"]
     soundtrack_path = "https://freetestdata.com/wp-content/uploads/2021/09/Free_Test_Data_1MB_MP3.mp3"
+    # End-Run upscaling
+    r_upscale_video = False
+    r_upscale_factor = 'x2' # ['2x', 'x3', 'x4']
+    # **model below** - 'realesr-animevideov3' (default of realesrgan engine, does 2-4x), the rest does only 4x: 'realesrgan-x4plus', 'realesrgan-x4plus-anime'
+    r_upscale_model = 'realesr-animevideov3' 
+    
     render_steps = False  #@param {type: 'boolean'}
     path_name_modifier = "x0_pred" #@param ["x0_pred","x"]
     # max_video_frames = 200 #@param {type:"string"}
@@ -735,7 +740,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
         # OUTPUT TAB
         with gr.Tab('Output'):
             # VID OUTPUT ACCORD
-            with gr.Accordion('Video Output Settings - FFmpeg', open=True):
+            with gr.Accordion('Video Output Settings', open=True):
                 with gr.Row(variant='compact') as fps_out_format_row:
                     fps = gr.Slider(label="FPS", value=dv.fps, minimum=1, maximum=240, step=1)
                     # NOT VISIBLE AS OF 11-02-23 moving to ffmpeg-only!
@@ -754,6 +759,10 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         save_depth_maps = gr.Checkbox(label="Save depth maps", value=da.save_depth_maps, interactive=True)
                         # the following param only shows for windows and linux users!
                         make_gif = gr.Checkbox(label="Make GIF", value=dv.make_gif, interactive=True, visible = (True if dr.current_user_os in ["Windows", "Linux"] else False))
+                with gr.Row(equal_height=True, variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux"] else False)) as r_upscale_row:
+                    r_upscale_video = gr.Checkbox(label="Upscale", value=dv.r_upscale_video, interactive=True)
+                    r_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
+                    r_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
             # RIFE TAB
             with gr.Tab('RIFE') as rife_accord:
                 with gr.Accordion('Important notes and Help', open=False):
@@ -977,6 +986,7 @@ args_names =    str(r'''W, H, tiling, restore_faces,
 video_args_names =  str(r'''skip_video_for_run_all,
                             fps, make_gif, output_format, ffmpeg_location, ffmpeg_crf, ffmpeg_preset,
                             add_soundtrack, soundtrack_path,
+                            r_upscale_video, r_upscale_model, r_upscale_factor,
                             render_steps,
                             path_name_modifier, image_path, mp4_path, store_frames_in_ram,
                             frame_interpolation_engine, frame_interpolation_x_amount, frame_interpolation_slow_mo_amount,

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -863,7 +863,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                             # Non interactive textbox showing uploaded input resolution
                             ncnn_upscale_in_vid_res = gr.Textbox(label="In Res", lines=1, interactive=False, value='---')
                             # Non interactive textbox showing expected output resolution
-                            ncnn_upscale_out_vid_res = gr.Textbox(label="Out Rez", value='---')
+                            ncnn_upscale_out_vid_res = gr.Textbox(label="Out Res", value='---')
                         with gr.Column():
                             with gr.Row(variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux"] else False)) as ncnn_actual_upscale_row:
                                 ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -859,7 +859,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                  <p style="margin-top:0em">
                     Important Notes:
                     <ul style="list-style-type:circle; margin-left:1em; margin-bottom:0.25em">
-                        <li>Enter relative to webui folder or Full-Absolute path, and make sure it ends with something like this: '20230124234916_%05d.png', just replace 20230124234916 with your batch ID</li>
+                        <li>Enter relative to webui folder or Full-Absolute path, and make sure it ends with something like this: '20230124234916_%05d.png', just replace 20230124234916 with your batch ID. The %05d is important, don't forget it!</li>
                         <li>Working FFMPEG under 'Location' (above ^) is required to stitch a video in this mode!</li>
                     </ul>
                     """)

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -759,10 +759,18 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         save_depth_maps = gr.Checkbox(label="Save depth maps", value=da.save_depth_maps, interactive=True)
                         # the following param only shows for windows and linux users!
                         make_gif = gr.Checkbox(label="Make GIF", value=dv.make_gif, interactive=True, visible = (True if dr.current_user_os in ["Windows", "Linux"] else False))
+                def gfs(choice):
+                    if choice != 'realesr-animevideov3':
+                        return gr.update(value='x4', choices = ['x4'])
+                    else:
+                        return gr.update(choices = ['x2', 'x3', 'x4'])
                 with gr.Row(equal_height=True, variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux"] else False)) as r_upscale_row:
                     r_upscale_video = gr.Checkbox(label="Upscale", value=dv.r_upscale_video, interactive=True)
                     r_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
                     r_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
+                
+                if dr.current_user_os in ["Windows", "Apple"]:
+                    r_upscale_model.change(fn=gfs, inputs=r_upscale_model, outputs=r_upscale_factor)    
             # RIFE TAB
             with gr.Tab('RIFE') as rife_accord:
                 with gr.Accordion('Important notes and Help', open=False):

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -6,7 +6,7 @@ import modules.paths as ph
 import os
 from .frame_interpolation import set_interp_out_fps, gradio_f_interp_get_fps_and_fcount, process_rife_vid_upload_logic
 from .upscaling import process_upscale_vid_upload_logic
-from .video_audio_utilities import find_ffmpeg_binary, ffmpeg_stitch_video, direct_stitch_vid_from_frames
+from .video_audio_utilities import find_ffmpeg_binary, ffmpeg_stitch_video, direct_stitch_vid_from_frames, get_quick_vid_info
 from .gradio_funcs import *
 from .general_utils import get_os
 
@@ -855,8 +855,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                             upscale_btn.click(upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, selected_tab, upscaling_resize, upscaling_resize_w, upscaling_resize_h, upscaling_crop, extras_upscaler_1, extras_upscaler_2, extras_upscaler_2_visibility, upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
                      # NCNN UPSCALE TAB
                     with gr.Tab('Upscale V2') as ncnn_upscale_tab:
-                        # vid_to_ncnn_upscale_chosen_file = gr.File(label="Video to Upscale", interactive=True, file_count="single", file_types=["video"], elem_id="vid_to_ncnn_upscale_chosen_file")
-                        with gr.Row(variant='compact'):
+                        with gr.Row(variant='compact') as ncnn_upload_vid_stats_row:
                             # Non interactive textbox showing uploaded input vid total Frame Count
                             ncnn_upscale_in_vid_frame_count_window = gr.Textbox(label="In Frame Count", lines=1, interactive=False, value='---')
                             # Non interactive textbox showing uploaded input vid FPS
@@ -866,10 +865,15 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                             # Non interactive textbox showing expected output resolution
                             ncnn_upscale_out_vid_res = gr.Textbox(label="Out Rez", value='---')
                         with gr.Column():
-                            with gr.Row(variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux"] else False)) as ncnn_upscale_row:
+                            with gr.Row(variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux"] else False)) as ncnn_actual_upscale_row:
                                 ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
                                 ncnn_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
                                 r_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=dv.r_upscale_keep_imgs, interactive=True)
+                def vid_upscale_gradio_update_stats(vid_path):
+                    fps, fcount, resolution = get_quick_vid_info(vid_path.name)
+                    
+                    return fps, fcount, resolution, '256*256'
+                vid_to_upscale_chosen_file.change(vid_upscale_gradio_update_stats,inputs=[vid_to_upscale_chosen_file],outputs=[ncnn_upscale_in_vid_fps_ui_window, ncnn_upscale_in_vid_frame_count_window, ncnn_upscale_in_vid_res, ncnn_upscale_out_vid_res])
             # STITCH FRAMES TO VID TAB
             with gr.Tab('Frames to Video') as stitch_imgs_to_vid_row:
                 with gr.Row(visible=False):

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -820,6 +820,11 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                             vid_to_rife_chosen_file.change(gradio_f_interp_get_fps_and_fcount,inputs=[vid_to_rife_chosen_file, frame_interpolation_x_amount, frame_interpolation_slow_mo_amount],outputs=[in_vid_fps_ui_window,in_vid_frame_count_window, out_interp_vid_estimated_fps])
             # TODO: add upscalers parameters to the settings and make them a part of the pipeline
             # VIDEO UPSCALE TAB
+            def ncnn_upload_vid_to_upscale(vid_path, upscale_model, upscale_factor, keep_imgs, f_location, f_crf, f_preset):
+                if vid_path is None:
+                    print("Please upload a video :)")
+                    return
+                
             with gr.Tab('Video Upscaling'):
                 
                 vid_to_upscale_chosen_file = gr.File(label="Video to Upscale", interactive=True, file_count="single", file_types=["video"], elem_id="vid_to_upscale_chosen_file")
@@ -840,8 +845,9 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                             with gr.Row(variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux"] else False)) as ncnn_actual_upscale_row:
                                 ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
                                 ncnn_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
-                                r_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=dv.r_upscale_keep_imgs, interactive=True)
+                                ncnn_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=dv.r_upscale_keep_imgs, interactive=True) # fix value
                         ncnn_upscale_btn = gr.Button(value="*Upscale uploaded video*")
+                        ncnn_upscale_btn.click(ncnn_upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, ncnn_upscale_model, ncnn_upscale_factor, r_upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
                     with gr.Tab('Upscale V1'):
                         with gr.Column():
                             selected_tab = gr.State(value=0)
@@ -1179,3 +1185,4 @@ def upload_vid_to_upscale(vid_to_upscale_chosen_file, selected_tab, upscaling_re
         return print("Please upload a video :)")
     
     process_upscale_vid_upload_logic(vid_to_upscale_chosen_file, selected_tab, upscaling_resize, upscaling_resize_w, upscaling_resize_h, upscaling_crop, extras_upscaler_1, extras_upscaler_2, extras_upscaler_2_visibility, vid_to_upscale_chosen_file.orig_name, upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset)
+

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -279,7 +279,7 @@ def DeforumOutputArgs():
     r_upscale_factor = 'x2' # ['2x', 'x3', 'x4']
     # **model below** - 'realesr-animevideov3' (default of realesrgan engine, does 2-4x), the rest does only 4x: 'realesrgan-x4plus', 'realesrgan-x4plus-anime'
     r_upscale_model = 'realesr-animevideov3' 
-    r_upscale_keep_imgs = True
+    r_upscale_keep_imgs = False
     
     render_steps = False  #@param {type: 'boolean'}
     path_name_modifier = "x0_pred" #@param ["x0_pred","x"]
@@ -760,19 +760,13 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         save_depth_maps = gr.Checkbox(label="Save depth maps", value=da.save_depth_maps, interactive=True)
                         # the following param only shows for windows and linux users!
                         make_gif = gr.Checkbox(label="Make GIF", value=dv.make_gif, interactive=True, visible = (True if dr.current_user_os in ["Windows", "Linux"] else False))
-                def gfs(choice):
-                    if choice != 'realesr-animevideov3':
-                        return gr.update(value='x4', choices = ['x4'])
-                    else:
-                        return gr.update(choices = ['x2', 'x3', 'x4'])
                 with gr.Row(equal_height=True, variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux"] else False)) as r_upscale_row:
                     r_upscale_video = gr.Checkbox(label="Upscale", value=dv.r_upscale_video, interactive=True)
                     r_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
                     r_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
                     r_upscale_keep_imgs = gr.Checkbox(label="Keep imgs", value=dv.r_upscale_keep_imgs, interactive=True)
-                
                 if dr.current_user_os in ["Windows", "Apple"]:
-                    r_upscale_model.change(fn=gfs, inputs=r_upscale_model, outputs=r_upscale_factor)    
+                    r_upscale_model.change(fn=update_r_upscale_factor, inputs=r_upscale_model, outputs=r_upscale_factor)    
             # RIFE TAB
             with gr.Tab('RIFE') as rife_accord:
                 with gr.Accordion('Important notes and Help', open=False):

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -760,7 +760,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         save_depth_maps = gr.Checkbox(label="Save depth maps", value=da.save_depth_maps, interactive=True)
                         # the following param only shows for windows and linux users!
                         make_gif = gr.Checkbox(label="Make GIF", value=dv.make_gif, interactive=True, visible = (True if dr.current_user_os in ["Windows", "Linux"] else False))
-                with gr.Row(equal_height=True, variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux"] else False)) as r_upscale_row:
+                with gr.Row(equal_height=True, variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux", "Apple"] else False)) as r_upscale_row:
                     r_upscale_video = gr.Checkbox(label="Upscale", value=dv.r_upscale_video, interactive=True)
                     r_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
                     r_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -765,8 +765,6 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                     r_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
                     r_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
                     r_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=dv.r_upscale_keep_imgs, interactive=True)
-                if dr.current_user_os in ["Windows", "Linux"]:
-                    r_upscale_model.change(fn=update_r_upscale_factor, inputs=r_upscale_model, outputs=r_upscale_factor)    
             # RIFE TAB
             with gr.Tab('RIFE') as rife_accord:
                 with gr.Accordion('Important notes and Help', open=False):
@@ -906,6 +904,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
     # Gradio's Change functions - hiding and renaming elements based on other elements
     if dr.current_user_os in ["Windows", "Apple"]:
         fps.change(fn=change_gif_button_visibility, inputs=fps, outputs=make_gif)
+        r_upscale_model.change(fn=update_r_upscale_factor, inputs=r_upscale_model, outputs=r_upscale_factor)    
     animation_mode.change(fn=change_max_frames_visibility, inputs=animation_mode, outputs=max_frames)
     animation_mode.change(fn=change_diffusion_cadence_visibility, inputs=animation_mode, outputs=diffusion_cadence_column)
     animation_mode.change(fn=disble_3d_related_stuff, inputs=animation_mode, outputs=depth_3d_warping_accord)

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -760,7 +760,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         save_depth_maps = gr.Checkbox(label="Save depth maps", value=da.save_depth_maps, interactive=True)
                         # the following param only shows for windows and linux users!
                         make_gif = gr.Checkbox(label="Make GIF", value=dv.make_gif, interactive=True, visible = (True if dr.current_user_os in ["Windows", "Linux"] else False))
-                with gr.Row(equal_height=True, variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux"] else False)) as r_upscale_row:
+                with gr.Row(equal_height=True, variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux", "Mac"] else False)) as r_upscale_row:
                     r_upscale_video = gr.Checkbox(label="Upscale", value=dv.r_upscale_video, interactive=True)
                     r_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
                     r_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
@@ -842,7 +842,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                             # Non interactive textbox showing expected output resolution
                             ncnn_upscale_out_vid_res = gr.Textbox(label="Out Res", value='---')
                         with gr.Column():
-                            with gr.Row(variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux"] else False)) as ncnn_actual_upscale_row:
+                            with gr.Row(variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux", "Mac"] else False)) as ncnn_actual_upscale_row:
                                 ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
                                 ncnn_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
                                 ncnn_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=dv.r_upscale_keep_imgs, interactive=True) # fix value

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -760,7 +760,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         save_depth_maps = gr.Checkbox(label="Save depth maps", value=da.save_depth_maps, interactive=True)
                         # the following param only shows for windows and linux users!
                         make_gif = gr.Checkbox(label="Make GIF", value=dv.make_gif, interactive=True, visible = (True if dr.current_user_os in ["Windows", "Linux"] else False))
-                with gr.Row(equal_height=True, variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux", "Mac"] else False)) as r_upscale_row:
+                with gr.Row(equal_height=True, variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux"] else False)) as r_upscale_row:
                     r_upscale_video = gr.Checkbox(label="Upscale", value=dv.r_upscale_video, interactive=True)
                     r_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
                     r_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
@@ -904,7 +904,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
     # Gradio's Change functions - hiding and renaming elements based on other elements
     if dr.current_user_os in ["Windows", "Linux"]:
         fps.change(fn=change_gif_button_visibility, inputs=fps, outputs=make_gif)
-    if dr.current_user_os in ["Windows", "Linux", "Mac"]:
+    if dr.current_user_os in ["Windows", "Linux"]: # mac removed 15-2 until fix is found
         r_upscale_model.change(fn=update_r_upscale_factor, inputs=r_upscale_model, outputs=r_upscale_factor)    
     animation_mode.change(fn=change_max_frames_visibility, inputs=animation_mode, outputs=max_frames)
     animation_mode.change(fn=change_diffusion_cadence_visibility, inputs=animation_mode, outputs=diffusion_cadence_column)

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -827,7 +827,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                 root_params = Root()
                 f_models_path = root_params['models_path']
                 # using vid_path.name actually
-                process_ncnn_upscale_vid_upload_logic(vid_path, in_vid_fps, in_vid_res, out_vid_res, f_models_path, upscale_model, upscale_factor, keep_imgs, f_location, f_crf, f_preset)
+                process_ncnn_upscale_vid_upload_logic(vid_path, in_vid_fps, in_vid_res, out_vid_res, f_models_path, upscale_model, upscale_factor, keep_imgs, f_location, f_crf, f_preset, dr.current_user_os)
                 
                 
             with gr.Tab('Video Upscaling'):
@@ -848,11 +848,11 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                             ncnn_upscale_out_vid_res = gr.Textbox(label="Out Res", value='---')
                         with gr.Column():
                             with gr.Row(variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux", "Mac"] else False)) as ncnn_actual_upscale_row:
-                                ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
-                                ncnn_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
-                                ncnn_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=dv.r_upscale_keep_imgs, interactive=True) # fix value
+                                ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = "realesr-animevideov3", type="value")
+                                ncnn_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value="x2", type="value")
+                                ncnn_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=True, interactive=True) # fix value
                         ncnn_upscale_btn = gr.Button(value="*Upscale uploaded video*")
-                        ncnn_upscale_btn.click(ncnn_upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, ncnn_upscale_in_vid_fps_ui_window, ncnn_upscale_in_vid_res, ncnn_upscale_out_vid_res, ncnn_upscale_model, ncnn_upscale_factor, r_upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
+                        ncnn_upscale_btn.click(ncnn_upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, ncnn_upscale_in_vid_fps_ui_window, ncnn_upscale_in_vid_res, ncnn_upscale_out_vid_res, ncnn_upscale_model, ncnn_upscale_factor, ncnn_upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
                     with gr.Tab('Upscale V1'):
                         with gr.Column():
                             selected_tab = gr.State(value=0)

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -5,7 +5,7 @@ import modules.shared as sh
 import modules.paths as ph
 import os
 from .frame_interpolation import set_interp_out_fps, gradio_f_interp_get_fps_and_fcount, process_rife_vid_upload_logic
-from .upscaling import process_upscale_vid_upload_logic
+from .upscaling import process_upscale_vid_upload_logic, process_ncnn_upscale_vid_upload_logic
 from .video_audio_utilities import find_ffmpeg_binary, ffmpeg_stitch_video, direct_stitch_vid_from_frames, get_quick_vid_info, extract_number
 from .gradio_funcs import *
 from .general_utils import get_os
@@ -391,7 +391,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         with gr.Column(scale=1, min_width=185) as diffusion_cadence_column:
                             diffusion_cadence = gr.Slider(label="Cadence", minimum=1, maximum=50, step=1, value=da.diffusion_cadence, interactive=True)
                         with gr.Column(scale=2, min_width=185):
-                            max_frames = gr.Slider(label="Max frames", minimum=2, maximum=9999, step=1, value=da.max_frames, interactive=True)
+                            max_frames = gr.Slider(label="Max frames", minimum=2, maximum=99999, step=1, value=da.max_frames, interactive=True)
             # GUIDED IMAGES ACCORD
             with gr.Accordion('Guided Images', open=False, elem_id='guided_images_accord') as guided_images_accord:
                 # GUIDED IMAGES INFO ACCORD
@@ -820,10 +820,15 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                             vid_to_rife_chosen_file.change(gradio_f_interp_get_fps_and_fcount,inputs=[vid_to_rife_chosen_file, frame_interpolation_x_amount, frame_interpolation_slow_mo_amount],outputs=[in_vid_fps_ui_window,in_vid_frame_count_window, out_interp_vid_estimated_fps])
             # TODO: add upscalers parameters to the settings and make them a part of the pipeline
             # VIDEO UPSCALE TAB
-            def ncnn_upload_vid_to_upscale(vid_path, upscale_model, upscale_factor, keep_imgs, f_location, f_crf, f_preset):
+            def ncnn_upload_vid_to_upscale(vid_path, in_vid_fps, in_vid_res, out_vid_res, upscale_model, upscale_factor, keep_imgs, f_location, f_crf, f_preset):
                 if vid_path is None:
                     print("Please upload a video :)")
                     return
+                root_params = Root()
+                f_models_path = root_params['models_path']
+                # using vid_path.name actually
+                process_ncnn_upscale_vid_upload_logic(vid_path, in_vid_fps, in_vid_res, out_vid_res, f_models_path, upscale_model, upscale_factor, keep_imgs, f_location, f_crf, f_preset)
+                
                 
             with gr.Tab('Video Upscaling'):
                 
@@ -847,7 +852,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                                 ncnn_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
                                 ncnn_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=dv.r_upscale_keep_imgs, interactive=True) # fix value
                         ncnn_upscale_btn = gr.Button(value="*Upscale uploaded video*")
-                        ncnn_upscale_btn.click(ncnn_upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, ncnn_upscale_model, ncnn_upscale_factor, r_upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
+                        ncnn_upscale_btn.click(ncnn_upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, ncnn_upscale_in_vid_fps_ui_window, ncnn_upscale_in_vid_res, ncnn_upscale_out_vid_res, ncnn_upscale_model, ncnn_upscale_factor, r_upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
                     with gr.Tab('Upscale V1'):
                         with gr.Column():
                             selected_tab = gr.State(value=0)

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -936,12 +936,8 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
     def update_upscale_out_res_by_model_name(in_res, upscale_model_name):
         if not upscale_model_name:
             return '---'
-        if upscale_model_name == 'realesr-animevideov3':
-            factor = 2
-        else:
-            factor = 4
-        w, h = [int(x) * factor for x in in_res.split('*')]
-        return f"{w}*{h}"
+        factor = 2 if upscale_model_name == 'realesr-animevideov3' else 4
+        return f"{int(in_res.split('*')[0]) * factor}*{int(in_res.split('*')[1]) * factor}"
 
     # Gradio's Change functions - hiding and renaming elements based on other elements
     if dr.current_user_os in ["Windows", "Linux"]: # duplicate ifs to enable changes only to GIFski by adding Mac to one of them

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -760,7 +760,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         save_depth_maps = gr.Checkbox(label="Save depth maps", value=da.save_depth_maps, interactive=True)
                         # the following param only shows for windows and linux users!
                         make_gif = gr.Checkbox(label="Make GIF", value=dv.make_gif, interactive=True, visible = (True if dr.current_user_os in ["Windows", "Linux"] else False))
-                with gr.Row(equal_height=True, variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux", "Apple"] else False)) as r_upscale_row:
+                with gr.Row(equal_height=True, variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux", "Mac"] else False)) as r_upscale_row:
                     r_upscale_video = gr.Checkbox(label="Upscale", value=dv.r_upscale_video, interactive=True)
                     r_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
                     r_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
@@ -904,7 +904,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
     # Gradio's Change functions - hiding and renaming elements based on other elements
     if dr.current_user_os in ["Windows", "Linux"]:
         fps.change(fn=change_gif_button_visibility, inputs=fps, outputs=make_gif)
-    if dr.current_user_os in ["Windows", "Linux", "Apple"]:
+    if dr.current_user_os in ["Windows", "Linux", "Mac"]:
         r_upscale_model.change(fn=update_r_upscale_factor, inputs=r_upscale_model, outputs=r_upscale_factor)    
     animation_mode.change(fn=change_max_frames_visibility, inputs=animation_mode, outputs=max_frames)
     animation_mode.change(fn=change_diffusion_cadence_visibility, inputs=animation_mode, outputs=diffusion_cadence_column)

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -858,11 +858,13 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         # vid_to_ncnn_upscale_chosen_file = gr.File(label="Video to Upscale", interactive=True, file_count="single", file_types=["video"], elem_id="vid_to_ncnn_upscale_chosen_file")
                         with gr.Row(variant='compact'):
                             # Non interactive textbox showing uploaded input vid total Frame Count
-                            in_vid_frame_count_window = gr.Textbox(label="In Frame Count", lines=1, interactive=False, value='---')
+                            ncnn_upscale_in_vid_frame_count_window = gr.Textbox(label="In Frame Count", lines=1, interactive=False, value='---')
                             # Non interactive textbox showing uploaded input vid FPS
-                            in_vid_fps_ui_window = gr.Textbox(label="In FPS", lines=1, interactive=False, value='---')
-                            # Non interactive textbox showing expected output interpolated video FPS
-                            out_interp_vid_estimated_fps = gr.Textbox(label="Interpolated Vid FPS", value='---')
+                            ncnn_upscale_in_vid_fps_ui_window = gr.Textbox(label="In FPS", lines=1, interactive=False, value='---')
+                            # Non interactive textbox showing uploaded input resolution
+                            ncnn_upscale_in_vid_res = gr.Textbox(label="In Res", lines=1, interactive=False, value='---')
+                            # Non interactive textbox showing expected output resolution
+                            ncnn_upscale_out_vid_res = gr.Textbox(label="Out Rez", value='---')
                         with gr.Column():
                             with gr.Row(variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux"] else False)) as ncnn_upscale_row:
                                 ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -764,7 +764,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                     r_upscale_video = gr.Checkbox(label="Upscale", value=dv.r_upscale_video, interactive=True)
                     r_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
                     r_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
-                    r_upscale_keep_imgs = gr.Checkbox(label="Keep imgs", value=dv.r_upscale_keep_imgs, interactive=True)
+                    r_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=dv.r_upscale_keep_imgs, interactive=True)
                 if dr.current_user_os in ["Windows", "Linux"]:
                     r_upscale_model.change(fn=update_r_upscale_factor, inputs=r_upscale_model, outputs=r_upscale_factor)    
             # RIFE TAB

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -6,7 +6,7 @@ import modules.paths as ph
 import os
 from .frame_interpolation import set_interp_out_fps, gradio_f_interp_get_fps_and_fcount, process_rife_vid_upload_logic
 from .upscaling import process_upscale_vid_upload_logic
-from .video_audio_utilities import find_ffmpeg_binary, ffmpeg_stitch_video, direct_stitch_vid_from_frames, get_quick_vid_info
+from .video_audio_utilities import find_ffmpeg_binary, ffmpeg_stitch_video, direct_stitch_vid_from_frames, get_quick_vid_info, extract_number
 from .gradio_funcs import *
 from .general_utils import get_os
 
@@ -869,11 +869,17 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                                 ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
                                 ncnn_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
                                 r_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=dv.r_upscale_keep_imgs, interactive=True)
-                def vid_upscale_gradio_update_stats(vid_path):
+                # todo: move this func from here
+                def vid_upscale_gradio_update_stats(vid_path, upscale_factor):
+                    if not vid_path:
+                        return '---', '---', '---', '---'
+                    factor = extract_number(upscale_factor)
                     fps, fcount, resolution = get_quick_vid_info(vid_path.name)
-                    
-                    return fps, fcount, resolution, '256*256'
-                vid_to_upscale_chosen_file.change(vid_upscale_gradio_update_stats,inputs=[vid_to_upscale_chosen_file],outputs=[ncnn_upscale_in_vid_fps_ui_window, ncnn_upscale_in_vid_frame_count_window, ncnn_upscale_in_vid_res, ncnn_upscale_out_vid_res])
+                    in_res_str = f"{resolution[0]}*{resolution[1]}"
+                    out_res_str = f"{resolution[0] * factor}*{resolution[1] * factor}"
+                    return fps, fcount, in_res_str, out_res_str
+
+                vid_to_upscale_chosen_file.change(vid_upscale_gradio_update_stats,inputs=[vid_to_upscale_chosen_file, ncnn_upscale_factor],outputs=[ncnn_upscale_in_vid_fps_ui_window, ncnn_upscale_in_vid_frame_count_window, ncnn_upscale_in_vid_res, ncnn_upscale_out_vid_res])
             # STITCH FRAMES TO VID TAB
             with gr.Tab('Frames to Video') as stitch_imgs_to_vid_row:
                 with gr.Row(visible=False):

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -902,8 +902,9 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                 show_sample_per_step = gr.Checkbox(label="Show sample per step", value=d.show_sample_per_step, interactive=True)
 
     # Gradio's Change functions - hiding and renaming elements based on other elements
-    if dr.current_user_os in ["Windows", "Apple"]:
+    if dr.current_user_os in ["Windows", "Linux"]:
         fps.change(fn=change_gif_button_visibility, inputs=fps, outputs=make_gif)
+    if dr.current_user_os in ["Windows", "Linux", "Apple"]:
         r_upscale_model.change(fn=update_r_upscale_factor, inputs=r_upscale_model, outputs=r_upscale_factor)    
     animation_mode.change(fn=change_max_frames_visibility, inputs=animation_mode, outputs=max_frames)
     animation_mode.change(fn=change_diffusion_cadence_visibility, inputs=animation_mode, outputs=diffusion_cadence_column)

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -779,7 +779,6 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                      <p style="margin-top:1em">
                         Important notes:
                         <ul style="list-style-type:circle; margin-left:1em; margin-bottom:1em">
-                            <li>Working FFMPEG is required to get an output interpolated video. No ffmepg will leave you with just the interpolated imgs.</li>
                             <li>Frame Interpolation will *not* run if any of the following are enabled: 'Store frames in ram' / 'Skip video for run all'.</li>
                             <li>Audio (if provided) will *not* be transferred to the interpolated video if Slow-Mo is enabled.</li>
                             <li>'add_soundtrack' and 'soundtrack_path' aren't being honoured in "Interpolate an existing video" mode. Original vid audio will be used instead with the same slow-mo rules above.</li>
@@ -822,35 +821,53 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
             # TODO: add upscalers parameters to the settings and make them a part of the pipeline
             # VIDEO UPSCALE TAB
             with gr.Tab('Video Upscaling'):
+                
                 vid_to_upscale_chosen_file = gr.File(label="Video to Upscale", interactive=True, file_count="single", file_types=["video"], elem_id="vid_to_upscale_chosen_file")
                 with gr.Column():
-                    selected_tab = gr.State(value=0)
-                    with gr.Tabs(elem_id="extras_resize_mode"):
-                        with gr.TabItem('Scale by', elem_id="extras_scale_by_tab") as tab_scale_by:
-                            upscaling_resize = gr.Slider(minimum=1.0, maximum=8.0, step=0.05, label="Resize", value=2, elem_id="extras_upscaling_resize")
-                        with gr.TabItem('Scale to', elem_id="extras_scale_to_tab") as tab_scale_to:
+                    with gr.Tab('Upscale V1'):
+                        with gr.Column():
+                            selected_tab = gr.State(value=0)
+                            with gr.Tabs(elem_id="extras_resize_mode"):
+                                with gr.TabItem('Scale by', elem_id="extras_scale_by_tab") as tab_scale_by:
+                                    upscaling_resize = gr.Slider(minimum=1.0, maximum=8.0, step=0.05, label="Resize", value=2, elem_id="extras_upscaling_resize")
+                                with gr.TabItem('Scale to', elem_id="extras_scale_to_tab") as tab_scale_to:
+                                    with FormRow():
+                                        upscaling_resize_w = gr.Slider(label="Width", minimum=1, maximum=7680, step=1, value=512, elem_id="extras_upscaling_resize_w")
+                                        upscaling_resize_h = gr.Slider(label="Height", minimum=1, maximum=7680, step=1, value=512, elem_id="extras_upscaling_resize_h")
+                                        upscaling_crop = gr.Checkbox(label='Crop to fit', value=True, elem_id="extras_upscaling_crop")
                             with FormRow():
-                                upscaling_resize_w = gr.Slider(label="Width", minimum=1, maximum=7680, step=1, value=512, elem_id="extras_upscaling_resize_w")
-                                upscaling_resize_h = gr.Slider(label="Height", minimum=1, maximum=7680, step=1, value=512, elem_id="extras_upscaling_resize_h")
-                                upscaling_crop = gr.Checkbox(label='Crop to fit', value=True, elem_id="extras_upscaling_crop")
-                    with FormRow():
-                        extras_upscaler_1 = gr.Dropdown(label='Upscaler 1', elem_id="extras_upscaler_1", choices=[x.name for x in sh.sd_upscalers], value=sh.sd_upscalers[3].name)
-                        extras_upscaler_2 = gr.Dropdown(label='Upscaler 2', elem_id="extras_upscaler_2", choices=[x.name for x in sh.sd_upscalers], value=sh.sd_upscalers[0].name)
-                    with FormRow():
-                        with gr.Column(scale=3):
-                            extras_upscaler_2_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Upscaler 2 visibility", value=0.0, elem_id="extras_upscaler_2_visibility")
-                        with gr.Column(scale=1, min_width=80):
-                            upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", elem_id="upscale_keep_imgs", value=True, interactive=True)
+                                extras_upscaler_1 = gr.Dropdown(label='Upscaler 1', elem_id="extras_upscaler_1", choices=[x.name for x in sh.sd_upscalers], value=sh.sd_upscalers[3].name)
+                                extras_upscaler_2 = gr.Dropdown(label='Upscaler 2', elem_id="extras_upscaler_2", choices=[x.name for x in sh.sd_upscalers], value=sh.sd_upscalers[0].name)
+                            with FormRow():
+                                with gr.Column(scale=3):
+                                    extras_upscaler_2_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Upscaler 2 visibility", value=0.0, elem_id="extras_upscaler_2_visibility")
+                                with gr.Column(scale=1, min_width=80):
+                                    upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", elem_id="upscale_keep_imgs", value=True, interactive=True)
 
-                    tab_scale_by.select(fn=lambda: 0, inputs=[], outputs=[selected_tab])
-                    tab_scale_to.select(fn=lambda: 1, inputs=[], outputs=[selected_tab])
+                            tab_scale_by.select(fn=lambda: 0, inputs=[], outputs=[selected_tab])
+                            tab_scale_to.select(fn=lambda: 1, inputs=[], outputs=[selected_tab])
 
-                    # This is the actual button that's pressed to initiate the Upscaling:
-                    upscale_btn = gr.Button(value="*Upscale uploaded video*")
-                    # Show a text about CLI outputs:
-                    gr.HTML("* check your CLI for outputs")
-                    # make the function call when the UPSCALE button is clicked
-                    upscale_btn.click(upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, selected_tab, upscaling_resize, upscaling_resize_w, upscaling_resize_h, upscaling_crop, extras_upscaler_1, extras_upscaler_2, extras_upscaler_2_visibility, upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
+                            # This is the actual button that's pressed to initiate the Upscaling:
+                            upscale_btn = gr.Button(value="*Upscale uploaded video*")
+                            # Show a text about CLI outputs:
+                            gr.HTML("* check your CLI for outputs")
+                            # make the function call when the UPSCALE button is clicked
+                            upscale_btn.click(upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, selected_tab, upscaling_resize, upscaling_resize_w, upscaling_resize_h, upscaling_crop, extras_upscaler_1, extras_upscaler_2, extras_upscaler_2_visibility, upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
+                     # NCNN UPSCALE TAB
+                    with gr.Tab('Upscale V2') as ncnn_upscale_tab:
+                        # vid_to_ncnn_upscale_chosen_file = gr.File(label="Video to Upscale", interactive=True, file_count="single", file_types=["video"], elem_id="vid_to_ncnn_upscale_chosen_file")
+                        with gr.Row(variant='compact'):
+                            # Non interactive textbox showing uploaded input vid total Frame Count
+                            in_vid_frame_count_window = gr.Textbox(label="In Frame Count", lines=1, interactive=False, value='---')
+                            # Non interactive textbox showing uploaded input vid FPS
+                            in_vid_fps_ui_window = gr.Textbox(label="In FPS", lines=1, interactive=False, value='---')
+                            # Non interactive textbox showing expected output interpolated video FPS
+                            out_interp_vid_estimated_fps = gr.Textbox(label="Interpolated Vid FPS", value='---')
+                        with gr.Column():
+                            with gr.Row(variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux"] else False)) as ncnn_upscale_row:
+                                ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
+                                ncnn_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
+                                r_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=dv.r_upscale_keep_imgs, interactive=True)
             # STITCH FRAMES TO VID TAB
             with gr.Tab('Frames to Video') as stitch_imgs_to_vid_row:
                 with gr.Row(visible=False):
@@ -860,7 +877,6 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                     Important Notes:
                     <ul style="list-style-type:circle; margin-left:1em; margin-bottom:0.25em">
                         <li>Enter relative to webui folder or Full-Absolute path, and make sure it ends with something like this: '20230124234916_%05d.png', just replace 20230124234916 with your batch ID. The %05d is important, don't forget it!</li>
-                        <li>Working FFMPEG under 'Location' (above ^) is required to stitch a video in this mode!</li>
                     </ul>
                     """)
                 with gr.Row(variant='compact'):

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -824,6 +824,24 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                 
                 vid_to_upscale_chosen_file = gr.File(label="Video to Upscale", interactive=True, file_count="single", file_types=["video"], elem_id="vid_to_upscale_chosen_file")
                 with gr.Column():
+                    
+                     # NCNN UPSCALE TAB
+                    with gr.Tab('Upscale V2') as ncnn_upscale_tab:
+                        with gr.Row(variant='compact') as ncnn_upload_vid_stats_row:
+                            # Non interactive textbox showing uploaded input vid total Frame Count
+                            ncnn_upscale_in_vid_frame_count_window = gr.Textbox(label="In Frame Count", lines=1, interactive=False, value='---')
+                            # Non interactive textbox showing uploaded input vid FPS
+                            ncnn_upscale_in_vid_fps_ui_window = gr.Textbox(label="In FPS", lines=1, interactive=False, value='---')
+                            # Non interactive textbox showing uploaded input resolution
+                            ncnn_upscale_in_vid_res = gr.Textbox(label="In Res", lines=1, interactive=False, value='---')
+                            # Non interactive textbox showing expected output resolution
+                            ncnn_upscale_out_vid_res = gr.Textbox(label="Out Res", value='---')
+                        with gr.Column():
+                            with gr.Row(variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux"] else False)) as ncnn_actual_upscale_row:
+                                ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
+                                ncnn_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
+                                r_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=dv.r_upscale_keep_imgs, interactive=True)
+                        ncnn_upscale_btn = gr.Button(value="*Upscale uploaded video*")
                     with gr.Tab('Upscale V1'):
                         with gr.Column():
                             selected_tab = gr.State(value=0)
@@ -853,22 +871,6 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                             gr.HTML("* check your CLI for outputs")
                             # make the function call when the UPSCALE button is clicked
                             upscale_btn.click(upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, selected_tab, upscaling_resize, upscaling_resize_w, upscaling_resize_h, upscaling_crop, extras_upscaler_1, extras_upscaler_2, extras_upscaler_2_visibility, upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
-                     # NCNN UPSCALE TAB
-                    with gr.Tab('Upscale V2') as ncnn_upscale_tab:
-                        with gr.Row(variant='compact') as ncnn_upload_vid_stats_row:
-                            # Non interactive textbox showing uploaded input vid total Frame Count
-                            ncnn_upscale_in_vid_frame_count_window = gr.Textbox(label="In Frame Count", lines=1, interactive=False, value='---')
-                            # Non interactive textbox showing uploaded input vid FPS
-                            ncnn_upscale_in_vid_fps_ui_window = gr.Textbox(label="In FPS", lines=1, interactive=False, value='---')
-                            # Non interactive textbox showing uploaded input resolution
-                            ncnn_upscale_in_vid_res = gr.Textbox(label="In Res", lines=1, interactive=False, value='---')
-                            # Non interactive textbox showing expected output resolution
-                            ncnn_upscale_out_vid_res = gr.Textbox(label="Out Res", value='---')
-                        with gr.Column():
-                            with gr.Row(variant='compact', visible=(True if dr.current_user_os in ["Windows", "Linux"] else False)) as ncnn_actual_upscale_row:
-                                ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
-                                ncnn_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
-                                r_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=dv.r_upscale_keep_imgs, interactive=True)
             # STITCH FRAMES TO VID TAB
             with gr.Tab('Frames to Video') as stitch_imgs_to_vid_row:
                 with gr.Row(visible=False):
@@ -934,7 +936,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
         w, h = [int(x) * factor for x in in_res.split('*')]
         return f"{w}*{h}"
     def update_upscale_out_res_by_model_name(in_res, upscale_model_name):
-        if not upscale_model_name:
+        if not upscale_model_name or in_res == '---':
             return '---'
         factor = 2 if upscale_model_name == 'realesr-animevideov3' else 4
         return f"{int(in_res.split('*')[0]) * factor}*{int(in_res.split('*')[1]) * factor}"

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -925,7 +925,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
     color_coherence.change(fn=change_color_coherence_video_every_N_frames_visibility, inputs=color_coherence, outputs=color_coherence_video_every_N_frames_row)
     noise_type.change(fn=change_perlin_visibility, inputs=noise_type, outputs=perlin_row)
     hybrid_comp_mask_type.change(fn=change_comp_mask_x_visibility, inputs=hybrid_comp_mask_type, outputs=hybrid_comp_mask_row)
-    outputs = [fps_out_format_row, soundtrack_row, ffmpeg_set_row, store_frames_in_ram, make_gif]
+    outputs = [fps_out_format_row, soundtrack_row, ffmpeg_set_row, store_frames_in_ram, make_gif, r_upscale_row]
 
     for output in outputs:
         skip_video_for_run_all.change(fn=change_visibility_from_skip_video, inputs=skip_video_for_run_all, outputs=output)  

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -765,7 +765,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                     r_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
                     r_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
                     r_upscale_keep_imgs = gr.Checkbox(label="Keep imgs", value=dv.r_upscale_keep_imgs, interactive=True)
-                if dr.current_user_os in ["Windows", "Apple"]:
+                if dr.current_user_os in ["Windows", "Linux"]:
                     r_upscale_model.change(fn=update_r_upscale_factor, inputs=r_upscale_model, outputs=r_upscale_factor)    
             # RIFE TAB
             with gr.Tab('RIFE') as rife_accord:

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -277,7 +277,7 @@ def DeforumOutputArgs():
     # End-Run upscaling
     r_upscale_video = False
     r_upscale_factor = 'x2' # ['2x', 'x3', 'x4']
-    # **model below** - 'realesr-animevideov3' (default of realesrgan engine, does 2-4x), the rest does only 4x: 'realesrgan-x4plus', 'realesrgan-x4plus-anime'
+    # **model below** - 'realesr-animevideov3' (default of realesrgan engine, does 2-4x), the rest do only 4x: 'realesrgan-x4plus', 'realesrgan-x4plus-anime'
     r_upscale_model = 'realesr-animevideov3' 
     r_upscale_keep_imgs = False
     

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -869,7 +869,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                                 ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
                                 ncnn_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
                                 r_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=dv.r_upscale_keep_imgs, interactive=True)
-                # todo: move this func from here
+                # todo: move these funcs from here
                 def vid_upscale_gradio_update_stats(vid_path, upscale_factor):
                     if not vid_path:
                         return '---', '---', '---', '---'
@@ -878,7 +878,14 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                     in_res_str = f"{resolution[0]}*{resolution[1]}"
                     out_res_str = f"{resolution[0] * factor}*{resolution[1] * factor}"
                     return fps, fcount, in_res_str, out_res_str
+                def update_upscale_out_res(in_res, upscale_factor):
+                    if not in_res:
+                        return '---'
+                    factor = extract_number(upscale_factor)
+                    w, h = [int(x) * factor for x in in_res.split('*')]
+                    return f"{w}*{h}"
 
+                ncnn_upscale_factor.change(update_upscale_out_res, inputs=[ncnn_upscale_in_vid_res, ncnn_upscale_factor], outputs=ncnn_upscale_out_vid_res)
                 vid_to_upscale_chosen_file.change(vid_upscale_gradio_update_stats,inputs=[vid_to_upscale_chosen_file, ncnn_upscale_factor],outputs=[ncnn_upscale_in_vid_fps_ui_window, ncnn_upscale_in_vid_frame_count_window, ncnn_upscale_in_vid_res, ncnn_upscale_out_vid_res])
             # STITCH FRAMES TO VID TAB
             with gr.Tab('Frames to Video') as stitch_imgs_to_vid_row:

--- a/scripts/deforum_helpers/frame_interpolation.py
+++ b/scripts/deforum_helpers/frame_interpolation.py
@@ -1,11 +1,7 @@
 import os
 from pathlib import Path
 from rife.inference_video import run_rife_new_video_infer
-from .video_audio_utilities import get_quick_vid_info, vid2frames, media_file_has_audio
-
-# e.g gets 'x2' returns just 2 as int
-def extract_number(string):
-    return int(string[1:]) if len(string) > 1 and string[1:].isdigit() else -1
+from .video_audio_utilities import get_quick_vid_info, vid2frames, media_file_has_audio, extract_number
    
 # gets 'RIFE v4.3', returns: 'RIFE43'   
 def extract_rife_name(string):

--- a/scripts/deforum_helpers/general_utils.py
+++ b/scripts/deforum_helpers/general_utils.py
@@ -9,3 +9,21 @@ def checksum(filename, hash_factory=hashlib.blake2b, chunk_num_blocks=128):
 def get_os():
     import platform
     return {"Windows": "Windows", "Linux": "Linux", "Darwin": "Mac"}.get(platform.system(), "Unknown")
+
+# used in src/rife/inference_video.py and more, soon
+def duplicate_pngs_from_folder(from_folder, to_folder, img_batch_id, orig_vid_name):
+    import os, cv2, shutil #, subprocess
+    #TODO: don't copy-paste at all if the input is a video (now it copy-pastes, and if input is deforum run is also converts to make sure no errors rise cuz of 24-32 bit depth differences)
+    temp_convert_raw_png_path = os.path.join(from_folder, to_folder)
+    if not os.path.exists(temp_convert_raw_png_path):
+                os.makedirs(temp_convert_raw_png_path)
+                
+    for f in os.listdir(from_folder):
+        if ('png' in f or 'jpg' in f) and '-' not in f and '_depth_' not in f and ((img_batch_id is not None and f.startswith(img_batch_id) or img_batch_id is None)):
+            original_img_path = os.path.join(from_folder, f)
+            if orig_vid_name is not None:
+                shutil.copy(original_img_path, temp_convert_raw_png_path)
+            else:
+                image = cv2.imread(original_img_path)
+                new_path = os.path.join(temp_convert_raw_png_path, f)
+                cv2.imwrite(new_path, image, [cv2.IMWRITE_PNG_COMPRESSION, 0])

--- a/scripts/deforum_helpers/gradio_funcs.py
+++ b/scripts/deforum_helpers/gradio_funcs.py
@@ -3,8 +3,8 @@ import gradio as gr
 def change_visibility_from_skip_video(choice):
     return gr.update(visible=False) if choice else gr.update(visible=True) 
 
-# def hide_by_gif(choice):
-    # return gr.update(visible=False) if choice == 'PIL gif' else gr.update(visible=True)
+def update_r_upscale_factor(choice):
+    return gr.update(value='x4', choices = ['x4']) if choice != 'realesr-animevideov3' else gr.update(value='x2', choices = ['x2', 'x3', 'x4'])
 
 def change_perlin_visibility(choice):
     return gr.update(visible=choice=="perlin")

--- a/scripts/deforum_helpers/rich.py
+++ b/scripts/deforum_helpers/rich.py
@@ -1,0 +1,2 @@
+from rich.console import Console
+console = Console()

--- a/scripts/deforum_helpers/src/rife/inference_video.py
+++ b/scripts/deforum_helpers/src/rife/inference_video.py
@@ -16,6 +16,7 @@ from .model.pytorch_msssim import ssim_matlab
 
 sys.path.append('../../')
 from deforum_helpers.video_audio_utilities import ffmpeg_stitch_video
+from deforum_helpers.general_utils import duplicate_pngs_from_folder
 
 warnings.filterwarnings("ignore")
 
@@ -198,22 +199,6 @@ def run_rife_new_video_infer(
     except Exception as e:
         print(f'Video stitching gone wrong. *Interpolated frames were saved to HD as backup!*. Actual error: {e}')
 
-def duplicate_pngs_from_folder(from_folder, to_folder, img_batch_id, orig_vid_name):
-    #TODO: don't copy-paste at all if the input is a video (now it copy-pastes, and if input is deforum run is also converts to make sure no errors rise cuz of 24-32 bit depth differences)
-    temp_convert_raw_png_path = os.path.join(from_folder, to_folder)
-    if not os.path.exists(temp_convert_raw_png_path):
-                os.makedirs(temp_convert_raw_png_path)
-                
-    for f in os.listdir(from_folder):
-        if ('png' in f or 'jpg' in f) and '-' not in f and '_depth_' not in f and ((img_batch_id is not None and f.startswith(img_batch_id) or img_batch_id is None)):
-            original_img_path = os.path.join(from_folder, f)
-            if orig_vid_name is not None:
-                shutil.copy(original_img_path, temp_convert_raw_png_path)
-            else:
-                image = cv2.imread(original_img_path)
-                new_path = os.path.join(temp_convert_raw_png_path, f)
-                cv2.imwrite(new_path, image, [cv2.IMWRITE_PNG_COMPRESSION, 0])
-    
 def clear_write_buffer(user_args, write_buffer, custom_interp_path):
     cnt = 0
 

--- a/scripts/deforum_helpers/upscaling.py
+++ b/scripts/deforum_helpers/upscaling.py
@@ -11,7 +11,11 @@ from queue import Queue, Empty
 import modules.scripts as scr
 from .frame_interpolation import clean_folder_name
 from .general_utils import duplicate_pngs_from_folder
-from .video_audio_utilities import get_quick_vid_info, vid2frames, ffmpeg_stitch_video
+# TODO: move some funcs to this file?
+from .video_audio_utilities import get_quick_vid_info, vid2frames, ffmpeg_stitch_video, extract_number, check_and_download_realesrgan_ncnn
+from .rich import console
+import time
+import subprocess
 
 def process_upscale_vid_upload_logic(file, selected_tab, upscaling_resize, upscaling_resize_w, upscaling_resize_h, upscaling_crop, extras_upscaler_1, extras_upscaler_2, extras_upscaler_2_visibility, vid_file_name, keep_imgs, f_location, f_crf, f_preset):
     print("got a request to *upscale* an existing video.")
@@ -116,7 +120,7 @@ def stitch_video(img_batch_id, fps, img_folder_path, audio_path, ffmpeg_location
     return mp4_path
 
 # NCNN Upscale section:
-def process_ncnn_upscale_vid_upload_logic(vid_path, in_vid_fps, in_vid_res, out_vid_res, models_path, upscale_model, upscale_factor, keep_imgs, f_location, f_crf, f_preset):
+def process_ncnn_upscale_vid_upload_logic(vid_path, in_vid_fps, in_vid_res, out_vid_res, models_path, upscale_model, upscale_factor, keep_imgs, f_location, f_crf, f_preset, current_user_os):
     print(f"got a request to *upscale* a video using {upscale_model} at {upscale_factor}")
 
     folder_name = clean_folder_name(Path(vid_path.orig_name).stem)
@@ -131,4 +135,46 @@ def process_ncnn_upscale_vid_upload_logic(vid_path, in_vid_fps, in_vid_res, out_
     
     vid2frames(video_path=vid_path.name, video_in_frame_path=outdir, overwrite=True, extract_from_frame=0, extract_to_frame=-1, numeric_files_output=True, out_img_format='png')
     
-    # process_video_upscaling(selected_tab, upscaling_resize, upscaling_resize_w, upscaling_resize_h, upscaling_crop, extras_upscaler_1, extras_upscaler_2, extras_upscaler_2_visibility, orig_vid_fps=in_vid_fps, real_audio_track=file.name, raw_output_imgs_path=outdir, img_batch_id=None, ffmpeg_location=f_location, ffmpeg_crf=f_crf, ffmpeg_preset=f_preset, keep_upscale_imgs=keep_imgs, orig_vid_name=folder_name)
+    process_ncnn_video_upscaling(vid_path, outdir, in_vid_fps, in_vid_res, out_vid_res, models_path, upscale_model, upscale_factor, keep_imgs, f_location, f_crf, f_preset, current_user_os)
+    
+def process_ncnn_video_upscaling(vid_path, outdir, in_vid_fps, in_vid_res, out_vid_res, models_path, upscale_model, upscale_factor, keep_imgs, f_location, f_crf, f_preset, current_user_os):
+    
+    # get clean number from 'x2, x3' etc
+    clean_num_r_up_factor = extract_number(upscale_factor)
+    
+    # set paths
+    realesrgan_ncnn_location = os.path.join(models_path, 'realesrgan_ncnn', 'realesrgan-ncnn-vulkan' + ('.exe' if current_user_os == 'Windows' else ''))
+    upscaled_folder_path = os.path.join(os.path.dirname(outdir), 'Upscaled_frames')
+    
+    os.makedirs(upscaled_folder_path, exist_ok=True)
+    
+
+    out_upscaled_mp4_path = os.path.join(os.path.dirname(outdir), f"{vid_path.orig_name}_Upscaled_{upscale_factor}.mp4")
+    # download upscaling model if needed
+    check_and_download_realesrgan_ncnn(models_path, current_user_os)
+
+    # set dynamic cmd command
+    cmd = [realesrgan_ncnn_location, '-i', outdir, '-o', upscaled_folder_path, '-s', str(clean_num_r_up_factor), '-n', upscale_model]
+    # msg to print - need it to hide that text later on (!)
+    msg_to_print = f"Upscaling raw output PNGs using {upscale_model} at {upscale_factor}..."
+    # blink the msg in the cli until action is done
+    console.print(msg_to_print, style="blink yellow", end="") 
+    start_time = time.time()
+    # make call to ncnn upscaling executble
+    process = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    print("\r" + " " * len(msg_to_print), end="", flush=True)
+    print(f"\r{msg_to_print}", flush=True)
+    print(f"\rUpscaling \033[0;32mdone\033[0m in {time.time() - start_time:.2f} seconds!", flush=True)
+    # set custom path for ffmpeg func below
+    
+    # return
+    upscaled_imgs_path_for_ffmpeg = os.path.join(upscaled_folder_path, "%05d.png")
+
+    # stitch video from upscaled pngs 
+    ffmpeg_stitch_video(ffmpeg_location=f_location, fps=in_vid_fps, outmp4_path=out_upscaled_mp4_path, stitch_from_frame=0, stitch_to_frame=-1, imgs_path=upscaled_imgs_path_for_ffmpeg, add_soundtrack='File', audio_path=vid_path, crf=f_crf, preset=f_preset)
+
+    # delete the raw video pngs
+    shutil.rmtree(outdir)
+
+    if not keep_imgs:
+        shutil.rmtree(upscaled_folder_path)

--- a/scripts/deforum_helpers/upscaling.py
+++ b/scripts/deforum_helpers/upscaling.py
@@ -10,7 +10,7 @@ import shutil
 from queue import Queue, Empty
 import modules.scripts as scr
 from .frame_interpolation import clean_folder_name
-from rife.inference_video import duplicate_pngs_from_folder
+from .general_utils import duplicate_pngs_from_folder
 from .video_audio_utilities import get_quick_vid_info, vid2frames, ffmpeg_stitch_video
 
 def process_upscale_vid_upload_logic(file, selected_tab, upscaling_resize, upscaling_resize_w, upscaling_resize_h, upscaling_crop, extras_upscaler_1, extras_upscaler_2, extras_upscaler_2_visibility, vid_file_name, keep_imgs, f_location, f_crf, f_preset):

--- a/scripts/deforum_helpers/upscaling.py
+++ b/scripts/deforum_helpers/upscaling.py
@@ -114,3 +114,21 @@ def stitch_video(img_batch_id, fps, img_folder_path, audio_path, ffmpeg_location
         shutil.move(img_folder_path, grandparent_folder)
 
     return mp4_path
+
+# NCNN Upscale section:
+def process_ncnn_upscale_vid_upload_logic(vid_path, in_vid_fps, in_vid_res, out_vid_res, models_path, upscale_model, upscale_factor, keep_imgs, f_location, f_crf, f_preset):
+    print(f"got a request to *upscale* a video using {upscale_model} at {upscale_factor}")
+
+    folder_name = clean_folder_name(Path(vid_path.orig_name).stem)
+    outdir_no_tmp = os.path.join(os.getcwd(), 'outputs', 'frame-upscaling', folder_name)
+    i = 1
+    while os.path.exists(outdir_no_tmp):
+        outdir_no_tmp = os.path.join(os.getcwd(), 'outputs', 'frame-upscaling', folder_name + '_' + str(i))
+        i += 1
+
+    outdir = os.path.join(outdir_no_tmp, 'tmp_input_frames')
+    os.makedirs(outdir, exist_ok=True)
+    
+    vid2frames(video_path=vid_path.name, video_in_frame_path=outdir, overwrite=True, extract_from_frame=0, extract_to_frame=-1, numeric_files_output=True, out_img_format='png')
+    
+    # process_video_upscaling(selected_tab, upscaling_resize, upscaling_resize_w, upscaling_resize_h, upscaling_crop, extras_upscaler_1, extras_upscaler_2, extras_upscaler_2_visibility, orig_vid_fps=in_vid_fps, real_audio_track=file.name, raw_output_imgs_path=outdir, img_batch_id=None, ffmpeg_location=f_location, ffmpeg_crf=f_crf, ffmpeg_preset=f_preset, keep_upscale_imgs=keep_imgs, orig_vid_name=folder_name)

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -329,7 +329,7 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
         # delete the zip file
         os.remove(realesrgan_zip_path)
         # chmod 755 the exec if we're in a linux machine, otherwise we'd get permission errors
-        if current_user_os == 'Linux':
+        if current_user_os in ['Linux', 'Mac'']:
             os.chmod(realesrgan_exec_path, 0o755)
     except Exception as e:
         raise Exception(f"Error while downloading {realesrgan_zip_path}. Please download from: {download_url}, and extract its contents into: {models_folder}/realesrgan_ncnn")

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -172,6 +172,8 @@ def ffmpeg_stitch_video(ffmpeg_location=None, fps=None, outmp4_path=None, stitch
             process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = process.communicate()
             if process.returncode != 0:
+                print("\r" + " " * len(msg_to_print), end="", flush=True)
+                print(f"\r{msg_to_print}", flush=True)
                 raise RuntimeError(stderr)
             os.replace(outmp4_path+'.temp.mp4', outmp4_path)
             print("\r" + " " * len(msg_to_print), end="", flush=True)
@@ -276,6 +278,8 @@ def make_gifski_gif(imgs_raw_path, imgs_batch_id, fps, models_folder, current_us
         input_img_pattern_for_gifski = os.path.join(imgs_raw_path, imgs_batch_id + '_0*.png')
         cmd = [gifski_location, '-o', final_gif_path, input_img_pattern_for_gifski, '--fps', str(fps), '--quality', str(95)]
     else: # should never this else as we check before, but just in case
+        print("\r" + " " * len(msg_to_print), end="", flush=True)
+        print(f"\r{msg_to_print}", flush=True)
         raise Exception(f"No support for OS type: {current_user_os}")
         
     check_and_download_gifski(models_folder, current_user_os)
@@ -284,6 +288,8 @@ def make_gifski_gif(imgs_raw_path, imgs_batch_id, fps, models_folder, current_us
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE) 
         stdout, stderr = process.communicate()
         if process.returncode != 0:
+            print("\r" + " " * len(msg_to_print), end="", flush=True)
+            print(f"\r{msg_to_print}", flush=True)
             print(stderr)
             raise RuntimeError(stderr)
         print("\r" + " " * len(msg_to_print), end="", flush=True)

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -9,7 +9,6 @@ from pkg_resources import resource_filename
 from modules.shared import state
 from .general_utils import checksum, duplicate_pngs_from_folder
 from basicsr.utils.download_util import load_file_from_url
-# move these from here?
 from .rich import console
 
 

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -346,7 +346,8 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
             os.chmod(realesrgan_exec_path, 0o755)
             # enable running the exec for mac users
             if current_user_os == 'Mac':
-                subprocess.run(['xattr', '-d', 'com.apple.quarantine', f'./{realesrgan_exec_path}'])
+                os.system(f'xattr -d com.apple.quarantine "{path}"')
+                # subprocess.run(['xattr', '-d', 'com.apple.quarantine', f'./{realesrgan_exec_path}'])
 
     except Exception as e:
         raise Exception(f"Error while downloading {realesrgan_zip_path}. Please download from: {download_url}, and extract its contents into: {models_folder}/realesrgan_ncnn")

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -308,10 +308,12 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
         os.remove(realesrgan_zip_path)
        
 def make_upscale_v2(upscale_factor, upscale_model, keep_imgs, imgs_raw_path, imgs_batch_id, deforum_models_path, current_user_os, ffmpeg_location, ffmpeg_crf, ffmpeg_preset, fps, stitch_from_frame, stitch_to_frame, audio_path, add_soundtrack):
-
+    
     clean_num_r_up_factor = extract_number(upscale_factor)
+
     # set paths
-    realesrgan_ncnn_location = os.path.join(deforum_models_path, 'realesrgan_ncnn', 'realesrgan-ncnn-vulkan.exe')
+    realesrgan_ncnn_location = os.path.join(deforum_models_path, 'realesrgan_ncnn', 'realesrgan-ncnn-vulkan' + ('.exe' if current_user_os == 'Windows' else ''))
+    final_gif_path = os.path.join(imgs_raw_path, imgs_batch_id + '.gif')
     upscaled_folder_path = os.path.join(imgs_raw_path, f"{imgs_batch_id}_upscaled")
     temp_folder_to_keep_raw_ims = os.path.join(upscaled_folder_path, 'temp_raw_imgs_to_upscale')
     out_upscaled_mp4_path = os.path.join(imgs_raw_path, f"{imgs_batch_id}_Upscaled_{upscale_factor}.mp4")

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -329,7 +329,7 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
         # delete the zip file
         os.remove(realesrgan_zip_path)
         # chmod 755 the exec if we're in a linux machine, otherwise we'd get permission errors
-        if current_user_os in ['Linux', 'Mac'']:
+        if current_user_os in ['Linux', 'Mac']:
             os.chmod(realesrgan_exec_path, 0o755)
     except Exception as e:
         raise Exception(f"Error while downloading {realesrgan_zip_path}. Please download from: {download_url}, and extract its contents into: {models_folder}/realesrgan_ncnn")

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -293,6 +293,14 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
         executble_name = 'realesrgan-ncnn-vulkan'
         zip_checksum_value = 'df44c4e9a1ff66331079795f018a67fbad8ce37c4472929a56b5a38440cf96982d6e164a086b438c3d26d269025290dd6498bd50846bda8691521ecf8f0fafdf'
         download_url = 'https://github.com/hithereai/Real-ESRGAN/releases/download/real-esrgan-ncnn-linux/realesrgan-ncnn-linux.zip'
+    elif current_user_os = 'Apple':
+        zip_file_name = 'realesrgan-ncnn-mac.zip'
+        executble_name = 'realesrgan-ncnn-vulkan'
+        zip_checksum_value = '65f09472025b55b18cf6ba64149ede8cded90c20e18d35a9edb1ab60715b383a6ffbf1be90d973fc2075cf99d4cc1411fbdc459411af5c904f544b8656111469'
+        download_url = 'https://github.com/hithereai/Real-ESRGAN/releases/download/real-esrgan-ncnn-mac/realesrgan-ncnn-mac.zip'
+        
+    else: # who are you then?
+        raise Exception(f"No support for OS type: {current_user_os}")
 
     # set paths
     realesrgan_ncnn_folder = os.path.join(models_folder, 'realesrgan_ncnn')
@@ -311,11 +319,12 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
         # wrong hash, file is probably broken/ download interrupted 
         if file_hash != zip_checksum_value:
             raise Exception(f"Error while downloading {realesrgan_zip_path}. Please download from: {download_url}, and extract its contents into: {models_folder}/realesrgan_ncnn")
-
+        # hash ok, extract zip contents into our folder
         with zipfile.ZipFile(realesrgan_zip_path, 'r') as zip_ref:
             zip_ref.extractall(realesrgan_ncnn_folder)
-        
+        # delete the zip file
         os.remove(realesrgan_zip_path)
+        # chmod 755 the exec if we're in a linux machine, otherwise we'd get permission errors
         if current_user_os == 'Linux':
             os.chmod(realesrgan_exec_path, 0o755)
     except Exception as e:

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -315,7 +315,6 @@ def make_upscale_v2(upscale_factor, upscale_model, keep_imgs, imgs_raw_path, img
 
     # set paths
     realesrgan_ncnn_location = os.path.join(deforum_models_path, 'realesrgan_ncnn', 'realesrgan-ncnn-vulkan' + ('.exe' if current_user_os == 'Windows' else ''))
-    final_gif_path = os.path.join(imgs_raw_path, imgs_batch_id + '.gif')
     upscaled_folder_path = os.path.join(imgs_raw_path, f"{imgs_batch_id}_upscaled")
     temp_folder_to_keep_raw_ims = os.path.join(upscaled_folder_path, 'temp_raw_imgs_to_upscale')
     out_upscaled_mp4_path = os.path.join(imgs_raw_path, f"{imgs_batch_id}_Upscaled_{upscale_factor}.mp4")

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -291,7 +291,7 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
 
         os.remove(realesrgan_zip_path)
 
-def make_upscale_v2(imgs_raw_path, imgs_batch_id, fps, deforum_models_path, current_user_os):
+def make_upscale_v2(upscale_factor, upscale_model, imgs_raw_path, imgs_batch_id, fps, deforum_models_path, current_user_os):
 
     print(f"\033[0;33mUpscaling raw output images using realesrgan\033[0m")
 
@@ -302,11 +302,12 @@ def make_upscale_v2(imgs_raw_path, imgs_batch_id, fps, deforum_models_path, curr
         
     check_and_download_realesrgan_ncnn(deforum_models_path, current_user_os)
     
-    duplicate_pngs_from_folder(from_folder=imgs_raw_path, to_folder=temp_folder_to_keep_raw_ims, img_batch_id=imgs_batch_id, orig_vid_name='Dummy') # keep dummy?
+    duplicate_pngs_from_folder(from_folder=imgs_raw_path, to_folder=temp_folder_to_keep_raw_ims, img_batch_id=imgs_batch_id, orig_vid_name='Dummy')
+    #  ^^ keep dummy so it doesn't actually convert or find a diff way? ^^
     
-    cmd = [realesrgan_ncnn_location, '-i', 'D:/D-SD/realesrgan/f' ,'-o', 'D:/D-SD/realesrgan/output_xrplus', '-s', '2']
+    # todo: handle models, upscale factor
+    cmd = [realesrgan_ncnn_location, '-i', temp_folder_to_keep_raw_ims ,'-o', upscaled_folder_path, '-s', str(upscale_factor), '-n', upscale_model]
    
-    print(cmd)
     try:
         start_time = time.time()
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -274,35 +274,28 @@ def make_gifski_gif(imgs_raw_path, imgs_batch_id, fps, models_folder, current_us
     except Exception as e:
         print(f"GIF stitching *failed* with error:\n{e}")
         
-# def make_upscale_v2(imgs_raw_path, imgs_batch_id, fps, models_folder, current_user_os):
-def make_upscale_v2(imgs_raw_path, imgs_batch_id, fps, models_folder, current_user_os):
-    # import glob
-    # print(f"\033[0;33mStitching *gif* from frames using Gifski:\033[0m")
-    # start_time = time.time()
+def check_and_download_realesrgan_ncnn():
+    pass
     
-    # gifski_location = os.path.join(models_folder, 'gifski' + ('.exe' if current_user_os == 'Windows' else ''))
-    # final_gif_path = os.path.join(imgs_raw_path, imgs_batch_id + '.gif')
-    # if current_user_os == "Linux":
-        # input_img_pattern = imgs_batch_id + '_0*.png'
-        # input_img_files = [os.path.join(imgs_raw_path, file) for file in sorted(glob.glob(os.path.join(imgs_raw_path, input_img_pattern)))]
-        # cmd = [gifski_location, '-o', final_gif_path] + input_img_files + ['--fps', str(fps), '--quality', str(95)]
-    # elif current_user_os == "Windows":
-        # input_img_pattern_for_gifski = os.path.join(imgs_raw_path, imgs_batch_id + '_0*.png')
-        # cmd = [gifski_location, '-o', final_gif_path, input_img_pattern_for_gifski, '--fps', str(fps), '--quality', str(95)]
-    # else: # should never this else as we check before, but just in case
-        # raise Exception(f"No support for OS type: {current_user_os}")
+# def make_upscale_v2(imgs_raw_path, imgs_batch_id, fps, models_folder, current_user_os):
+def make_upscale_v2(imgs_raw_path, imgs_batch_id, fps, deforum_models_path, current_user_os):
+
+    print(f"\033[0;33mUpscaling raw output images using realesrgan\033[0m")
+    
+   
+    realesrgan_ncnn_location = os.path.join(deforum_models_path, 'realesrgan_ncnn', 'realesrgan-ncnn-vulkan.exe')
+    upscaled_folder_path = os.path.join(imgs_raw_path, imgs_batch_id + '.gif')
         
-    # check_and_download_gifski(models_folder, current_user_os)
-    start_time = time.time()
-    # cmd = ['realesrgan-ncnn-vulkan', '-i', 'D:/D-SD/realsrfan/f' ,'-o', 'D:/D-SD/realsrfan/output_xrplus', '-s', '2']
-    cmd = ['realesrgan-ncnn-vulkan', '-i', 'D:/D-SD/realsrfan/f' ,'-o', 'D:/D-SD/realsrfan/output_xrplus', '-s', '2']
+    # check_and_download_realesrgan_ncnn(models_folder, current_user_os)
+    cmd = [realesrgan_ncnn_location, '-i', 'D:/D-SD/realesrgan/f' ,'-o', 'D:/D-SD/realesrgan/output_xrplus', '-s', '2']
     # print(cmd)
     try:
+        start_time = time.time()
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = process.communicate()
         if process.returncode != 0:
             print(stderr)
             raise RuntimeError(stderr)
-        print(f"GIF stitching done in {time.time() - start_time:.2f} seconds!")
+        print(f"Video upscaling done in {time.time() - start_time:.2f} seconds!")
     except Exception as e:
-        print(f"GIF stitching *failed* with error:\n{e}")
+        print(f"Video upscaling *failed* with error:\n{e}")

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -281,14 +281,14 @@ def check_and_download_realesrgan_ncnn():
 def make_upscale_v2(imgs_raw_path, imgs_batch_id, fps, deforum_models_path, current_user_os):
 
     print(f"\033[0;33mUpscaling raw output images using realesrgan\033[0m")
-    
-   
+
     realesrgan_ncnn_location = os.path.join(deforum_models_path, 'realesrgan_ncnn', 'realesrgan-ncnn-vulkan.exe')
     upscaled_folder_path = os.path.join(imgs_raw_path, imgs_batch_id + '.gif')
         
     # check_and_download_realesrgan_ncnn(models_folder, current_user_os)
     cmd = [realesrgan_ncnn_location, '-i', 'D:/D-SD/realesrgan/f' ,'-o', 'D:/D-SD/realesrgan/output_xrplus', '-s', '2']
-    # print(cmd)
+   
+    print(cmd)
     try:
         start_time = time.time()
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -169,14 +169,11 @@ def ffmpeg_stitch_video(ffmpeg_location=None, fps=None, outmp4_path=None, stitch
                 raise RuntimeError(stderr)
             os.replace(outmp4_path+'.temp.mp4', outmp4_path)
             print(f"Adding audio to video took {time.time() - audio_add_start_time:.2f} seconds.")
-            # print(f"FFmpeg Video+Audio stitching done in {time.time() - start_time:.2f} seconds!")
             print(f"\rFFmpeg Video+Audio stitching \033[0;32mdone\033[0m in {time.time() - start_time:.2f} seconds!")
         except Exception as e:
             print(f'Error adding audio to video. Actual error: {e}')
-            # print(f"FFMPEG Video (sorry, no audio) stitching done in {time.time() - start_time:.2f} seconds!")
             print(f"FFMPEG Video (sorry, no audio) stitching \033[33mdone\033[0m in {time.time() - start_time:.2f} seconds!")
     else:
-        # print(f"Video stitching done in {time.time() - start_time:.2f} seconds!")
         print(f"\rVideo stitching \033[0;32mdone\033[0m in {time.time() - start_time:.2f} seconds!")
         
 

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -294,7 +294,6 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
         download_url = 'https://github.com/hithereai/Real-ESRGAN/releases/download/real-esrgan-ncnn-linux/realesrgan-ncnn-linux.zip'
 
     realesrgan_ncnn_folder = os.path.join(models_folder, 'realesrgan_ncnn')
-    realesrgan_exe_path = os.path.join(realesrgan_ncnn_folder, 'realesrgan-ncnn-vulkan.exe')
     realesrgan_exec_path = os.path.join(realesrgan_ncnn_folder, executble_name)
     realesrgan_zip_path = os.path.join(realesrgan_ncnn_folder, zip_file_name)
     download_url = 'https://github.com/hithereai/Real-ESRGAN/releases/download/real-esrgan-ncnn-windows/realesrgan-ncnn-windows.zip'
@@ -304,6 +303,9 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
 
         with zipfile.ZipFile(realesrgan_zip_path, 'r') as zip_ref:
             zip_ref.extractall(os.path.dirname(realesrgan_zip_path))
+            
+        if current_user_os == 'Linux':
+            os.chmod(realesrgan_exec_path, 0o755)
 
         os.remove(realesrgan_zip_path)
        

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -281,12 +281,24 @@ def make_gifski_gif(imgs_raw_path, imgs_batch_id, fps, models_folder, current_us
 def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
     import zipfile
     from basicsr.utils.download_util import load_file_from_url
+    
+    if current_user_os == 'Windows':
+        zip_file_name = 'realesrgan-ncnn-windows.zip'
+        executble_name = 'realesrgan-ncnn-vulkan.exe'
+        zip_checksum_value = '1d073f520a4a3f6438a500fea88407964da6d4a87489719bedfa7445b76c019fdd95a5c39576ca190d7ac22c906b33d5250a6f48cb7eda2b6af3e86ec5f09dfc'
+        download_url = 'https://github.com/hithereai/Real-ESRGAN/releases/download/real-esrgan-ncnn-windows/realesrgan-ncnn-windows.zip'
+    elif current_user_os == 'Linux':
+        zip_file_name = 'realesrgan-ncnn-linux.zip'
+        executble_name = 'realesrgan-ncnn-vulkan'
+        zip_checksum_value = 'df44c4e9a1ff66331079795f018a67fbad8ce37c4472929a56b5a38440cf96982d6e164a086b438c3d26d269025290dd6498bd50846bda8691521ecf8f0fafdf'
+        download_url = 'https://github.com/hithereai/Real-ESRGAN/releases/download/real-esrgan-ncnn-linux/realesrgan-ncnn-linux.zip'
 
     realesrgan_ncnn_folder = os.path.join(models_folder, 'realesrgan_ncnn')
     realesrgan_exe_path = os.path.join(realesrgan_ncnn_folder, 'realesrgan-ncnn-vulkan.exe')
-    realesrgan_zip_path = os.path.join(realesrgan_ncnn_folder, 'realesrgan_ncnn_windows.zip')
-    download_url = 'https://github.com/hithereai/Real-ESRGAN/releases/download/real-esrgan-ncnn-windows/realesrgan_ncnn_windows.zip'
-    if not os.path.exists(realesrgan_exe_path): # todo: change logic to check folder content
+    realesrgan_exec_path = os.path.join(realesrgan_ncnn_folder, executble_name)
+    realesrgan_zip_path = os.path.join(realesrgan_ncnn_folder, zip_file_name)
+    download_url = 'https://github.com/hithereai/Real-ESRGAN/releases/download/real-esrgan-ncnn-windows/realesrgan-ncnn-windows.zip'
+    if not os.path.exists(realesrgan_exec_path): # todo: change logic to check folder content
         os.makedirs(realesrgan_ncnn_folder)
         load_file_from_url(download_url, realesrgan_ncnn_folder)
 

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -169,12 +169,16 @@ def ffmpeg_stitch_video(ffmpeg_location=None, fps=None, outmp4_path=None, stitch
                 raise RuntimeError(stderr)
             os.replace(outmp4_path+'.temp.mp4', outmp4_path)
             print(f"Adding audio to video took {time.time() - audio_add_start_time:.2f} seconds.")
-            print(f"FFMPEG Video+Audio stitching done in {time.time() - start_time:.2f} seconds!")
+            # print(f"FFmpeg Video+Audio stitching done in {time.time() - start_time:.2f} seconds!")
+            print(f"\rFFmpeg Video+Audio stitching \033[0;32mdone\033[0m in {time.time() - start_time:.2f} seconds!")
         except Exception as e:
             print(f'Error adding audio to video. Actual error: {e}')
-            print(f"FFMPEG Video (sorry, no audio) stitching done in {time.time() - start_time:.2f} seconds!")
+            # print(f"FFMPEG Video (sorry, no audio) stitching done in {time.time() - start_time:.2f} seconds!")
+            print(f"FFMPEG Video (sorry, no audio) stitching \033[33mdone\033[0m in {time.time() - start_time:.2f} seconds!")
     else:
-        print(f"Video stitching done in {time.time() - start_time:.2f} seconds!")
+        # print(f"Video stitching done in {time.time() - start_time:.2f} seconds!")
+        print(f"\rVideo stitching \033[0;32mdone\033[0m in {time.time() - start_time:.2f} seconds!")
+        
 
 def get_frame_name(path):
     name = os.path.basename(path)

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -120,7 +120,9 @@ def get_quick_vid_info(vid_path):
 def ffmpeg_stitch_video(ffmpeg_location=None, fps=None, outmp4_path=None, stitch_from_frame=0, stitch_to_frame=None, imgs_path=None, add_soundtrack=None, audio_path=None, crf=17, preset='veryslow'):
     start_time = time.time()
 
-    print(f"\033[0;33mStitching *video* from frames using FFmpeg:\n\033[0m{imgs_path}\nTo Video:\n{outmp4_path}")
+    print(f"Got a request to stitch frames to video using FFmpeg.\nFrames:\n{imgs_path}\nTo Video:\n{outmp4_path}")
+    msg_to_print = f"Stitching *video*..."
+    console.print(msg_to_print, style="blink yellow", end="") 
     if stitch_to_frame == -1:
         stitch_to_frame = 9999999
     try:
@@ -147,9 +149,8 @@ def ffmpeg_stitch_video(ffmpeg_location=None, fps=None, outmp4_path=None, stitch
         raise FileNotFoundError("FFmpeg not found. Please make sure you have a working ffmpeg path under 'ffmpeg_location' parameter.")
     except Exception as e:
         raise Exception(f'Error stitching frames to video. Actual runtime error:{e}')
-
+    
     if add_soundtrack != 'None':
-        print("Adding audio to video...")
         audio_add_start_time = time.time()
         try:
             cmd = [
@@ -167,17 +168,20 @@ def ffmpeg_stitch_video(ffmpeg_location=None, fps=None, outmp4_path=None, stitch
             process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = process.communicate()
             if process.returncode != 0:
-                print(stderr)
                 raise RuntimeError(stderr)
             os.replace(outmp4_path+'.temp.mp4', outmp4_path)
-            print(f"Adding audio to video took {time.time() - audio_add_start_time:.2f} seconds.")
-            print(f"\rFFmpeg Video+Audio stitching \033[0;32mdone\033[0m in {time.time() - start_time:.2f} seconds!")
+            print("\r" + " " * len(msg_to_print), end="", flush=True)
+            print(f"\r{msg_to_print}", flush=True)
+            print(f"\rFFmpeg Video+Audio stitching \033[0;32mdone\033[0m in {time.time() - start_time:.2f} seconds!", flush=True)
         except Exception as e:
-            print(f'Error adding audio to video. Actual error: {e}')
-            print(f"FFMPEG Video (sorry, no audio) stitching \033[33mdone\033[0m in {time.time() - start_time:.2f} seconds!")
+            print("\r" + " " * len(msg_to_print), end="", flush=True)
+            print(f"\r{msg_to_print}", flush=True)
+            print(f'\rError adding audio to video. Actual error: {e}', flush=True)
+            print(f"FFMPEG Video (sorry, no audio) stitching \033[33mdone\033[0m in {time.time() - start_time:.2f} seconds!", flush=True)
     else:
-        print(f"\rVideo stitching \033[0;32mdone\033[0m in {time.time() - start_time:.2f} seconds!")
-        
+        print("\r" + " " * len(msg_to_print), end="", flush=True)
+        print(f"\r{msg_to_print}", flush=True)
+        print(f"\rVideo stitching \033[0;32mdone\033[0m in {time.time() - start_time:.2f} seconds!", flush=True)
 
 def get_frame_name(path):
     name = os.path.basename(path)
@@ -348,7 +352,7 @@ def make_upscale_v2(upscale_factor, upscale_model, keep_imgs, imgs_raw_path, img
     # msg to print - need it to hide that text later on (!)
     msg_to_print = f"Upscaling raw output PNGs using {upscale_model} at {upscale_factor}"
     # blink the msg in the cli until action is done
-    console.print(msg_to_print, style="blink", end="") 
+    console.print(msg_to_print, style="blink yellow", end="") 
     start_time = time.time()
     # make call to ncnn upscaling executble
     process = subprocess.run(cmd, capture_output=True, check=True, text=True)

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -296,7 +296,6 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
     realesrgan_ncnn_folder = os.path.join(models_folder, 'realesrgan_ncnn')
     realesrgan_exec_path = os.path.join(realesrgan_ncnn_folder, executble_name)
     realesrgan_zip_path = os.path.join(realesrgan_ncnn_folder, zip_file_name)
-    download_url = 'https://github.com/hithereai/Real-ESRGAN/releases/download/real-esrgan-ncnn-windows/realesrgan-ncnn-windows.zip'
     if not os.path.exists(realesrgan_exec_path): # todo: change logic to check folder content
         os.makedirs(realesrgan_ncnn_folder)
         load_file_from_url(download_url, realesrgan_ncnn_folder)

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -346,7 +346,7 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
             os.chmod(realesrgan_exec_path, 0o755)
             # enable running the exec for mac users
             if current_user_os == 'Mac':
-                os.system(f'xattr -d com.apple.quarantine "{path}"')
+                os.system(f'xattr -d com.apple.quarantine "{realesrgan_exec_path}"')
                 # subprocess.run(['xattr', '-d', 'com.apple.quarantine', f'./{realesrgan_exec_path}'])
 
     except Exception as e:

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -293,7 +293,7 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
         executble_name = 'realesrgan-ncnn-vulkan'
         zip_checksum_value = 'df44c4e9a1ff66331079795f018a67fbad8ce37c4472929a56b5a38440cf96982d6e164a086b438c3d26d269025290dd6498bd50846bda8691521ecf8f0fafdf'
         download_url = 'https://github.com/hithereai/Real-ESRGAN/releases/download/real-esrgan-ncnn-linux/realesrgan-ncnn-linux.zip'
-    elif current_user_os = 'Apple':
+    elif current_user_os == 'Apple':
         zip_file_name = 'realesrgan-ncnn-mac.zip'
         executble_name = 'realesrgan-ncnn-vulkan'
         zip_checksum_value = '65f09472025b55b18cf6ba64149ede8cded90c20e18d35a9edb1ab60715b383a6ffbf1be90d973fc2075cf99d4cc1411fbdc459411af5c904f544b8656111469'

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -273,3 +273,36 @@ def make_gifski_gif(imgs_raw_path, imgs_batch_id, fps, models_folder, current_us
         print(f"GIF stitching done in {time.time() - start_time:.2f} seconds!")
     except Exception as e:
         print(f"GIF stitching *failed* with error:\n{e}")
+        
+# def make_upscale_v2(imgs_raw_path, imgs_batch_id, fps, models_folder, current_user_os):
+def make_upscale_v2(imgs_raw_path, imgs_batch_id, fps, models_folder, current_user_os):
+    # import glob
+    # print(f"\033[0;33mStitching *gif* from frames using Gifski:\033[0m")
+    # start_time = time.time()
+    
+    # gifski_location = os.path.join(models_folder, 'gifski' + ('.exe' if current_user_os == 'Windows' else ''))
+    # final_gif_path = os.path.join(imgs_raw_path, imgs_batch_id + '.gif')
+    # if current_user_os == "Linux":
+        # input_img_pattern = imgs_batch_id + '_0*.png'
+        # input_img_files = [os.path.join(imgs_raw_path, file) for file in sorted(glob.glob(os.path.join(imgs_raw_path, input_img_pattern)))]
+        # cmd = [gifski_location, '-o', final_gif_path] + input_img_files + ['--fps', str(fps), '--quality', str(95)]
+    # elif current_user_os == "Windows":
+        # input_img_pattern_for_gifski = os.path.join(imgs_raw_path, imgs_batch_id + '_0*.png')
+        # cmd = [gifski_location, '-o', final_gif_path, input_img_pattern_for_gifski, '--fps', str(fps), '--quality', str(95)]
+    # else: # should never this else as we check before, but just in case
+        # raise Exception(f"No support for OS type: {current_user_os}")
+        
+    # check_and_download_gifski(models_folder, current_user_os)
+    start_time = time.time()
+    # cmd = ['realesrgan-ncnn-vulkan', '-i', 'D:/D-SD/realsrfan/f' ,'-o', 'D:/D-SD/realsrfan/output_xrplus', '-s', '2']
+    cmd = ['realesrgan-ncnn-vulkan', '-i', 'D:/D-SD/realsrfan/f' ,'-o', 'D:/D-SD/realsrfan/output_xrplus', '-s', '2']
+    # print(cmd)
+    try:
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = process.communicate()
+        if process.returncode != 0:
+            print(stderr)
+            raise RuntimeError(stderr)
+        print(f"GIF stitching done in {time.time() - start_time:.2f} seconds!")
+    except Exception as e:
+        print(f"GIF stitching *failed* with error:\n{e}")

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -355,7 +355,8 @@ def make_upscale_v2(upscale_factor, upscale_model, keep_imgs, imgs_raw_path, img
     # get clean number from 'x2, x3' etc
     clean_num_r_up_factor = extract_number(upscale_factor)
     # set paths
-    realesrgan_ncnn_location = os.path.join(deforum_models_path, 'realesrgan_ncnn', 'realesrgan-ncnn-vulkan' + ('.exe' if current_user_os == 'Windows' else ''))
+    realesrgan_ncnn_path = os.path.join(deforum_models_path, 'realesrgan_ncnn')
+    realesrgan_ncnn_exec_location = os.path.join(realesrgan_ncnn_path, 'realesrgan-ncnn-vulkan' + ('.exe' if current_user_os == 'Windows' else ''))
     upscaled_folder_path = os.path.join(imgs_raw_path, f"{imgs_batch_id}_upscaled")
     temp_folder_to_keep_raw_ims = os.path.join(upscaled_folder_path, 'temp_raw_imgs_to_upscale')
     out_upscaled_mp4_path = os.path.join(imgs_raw_path, f"{imgs_batch_id}_Upscaled_{upscale_factor}.mp4")
@@ -364,14 +365,14 @@ def make_upscale_v2(upscale_factor, upscale_model, keep_imgs, imgs_raw_path, img
     # make a folder with only the imgs we need to duplicate so we can call the ncnn with the folder syntax (quicker!)
     duplicate_pngs_from_folder(from_folder=imgs_raw_path, to_folder=temp_folder_to_keep_raw_ims, img_batch_id=imgs_batch_id, orig_vid_name='Dummy')
     # set dynamic cmd command
-    cmd = [realesrgan_ncnn_location, '-i', temp_folder_to_keep_raw_ims, '-o', upscaled_folder_path, '-s', str(clean_num_r_up_factor), '-n', upscale_model]
+    cmd = [realesrgan_ncnn_exec_location, '-i', temp_folder_to_keep_raw_ims, '-o', upscaled_folder_path, '-s', str(clean_num_r_up_factor), '-n', upscale_model]
     # msg to print - need it to hide that text later on (!)
     msg_to_print = f"Upscaling raw output PNGs using {upscale_model} at {upscale_factor}..."
     # blink the msg in the cli until action is done
     console.print(msg_to_print, style="blink yellow", end="") 
     start_time = time.time()
     # make call to ncnn upscaling executble
-    process = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    process = subprocess.run(cmd, capture_output=True, check=True, text=True, cwd=realesrgan_ncnn_path)
     print("\r" + " " * len(msg_to_print), end="", flush=True)
     print(f"\r{msg_to_print}", flush=True)
     print(f"\rUpscaling \033[0;32mdone\033[0m in {time.time() - start_time:.2f} seconds!", flush=True)

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -297,7 +297,7 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
         executble_name = 'realesrgan-ncnn-vulkan'
         zip_checksum_value = 'df44c4e9a1ff66331079795f018a67fbad8ce37c4472929a56b5a38440cf96982d6e164a086b438c3d26d269025290dd6498bd50846bda8691521ecf8f0fafdf'
         download_url = 'https://github.com/hithereai/Real-ESRGAN/releases/download/real-esrgan-ncnn-linux/realesrgan-ncnn-linux.zip'
-    elif current_user_os == 'Apple':
+    elif current_user_os == 'Mac':
         zip_file_name = 'realesrgan-ncnn-mac.zip'
         executble_name = 'realesrgan-ncnn-vulkan'
         zip_checksum_value = '65f09472025b55b18cf6ba64149ede8cded90c20e18d35a9edb1ab60715b383a6ffbf1be90d973fc2075cf99d4cc1411fbdc459411af5c904f544b8656111469'

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -291,7 +291,7 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
 
         os.remove(realesrgan_zip_path)
 
-def make_upscale_v2(upscale_factor, upscale_model, imgs_raw_path, imgs_batch_id, fps, deforum_models_path, current_user_os):
+def make_upscale_v2(upscale_factor, upscale_model, keep_imgs, imgs_raw_path, imgs_batch_id, fps, deforum_models_path, current_user_os):
 
     print(f"\033[0;33mUpscaling raw output images using realesrgan\033[0m")
 
@@ -318,5 +318,10 @@ def make_upscale_v2(upscale_factor, upscale_model, imgs_raw_path, imgs_batch_id,
         print(f"Video upscaling done in {time.time() - start_time:.2f} seconds!")
     except Exception as e:
         print(f"Video upscaling *failed* with error:\n{e}")
-     
+    
+    
     shutil.rmtree(temp_folder_to_keep_raw_ims)
+    
+    # shutil.move(,)
+    if not keep_imgs:
+        shutil.rmtree(upscaled_folder_path)

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -304,10 +304,9 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
         with zipfile.ZipFile(realesrgan_zip_path, 'r') as zip_ref:
             zip_ref.extractall(os.path.dirname(realesrgan_zip_path))
             
+        os.remove(realesrgan_zip_path)
         if current_user_os == 'Linux':
             os.chmod(realesrgan_exec_path, 0o755)
-
-        os.remove(realesrgan_zip_path)
        
 def make_upscale_v2(upscale_factor, upscale_model, keep_imgs, imgs_raw_path, imgs_batch_id, deforum_models_path, current_user_os, ffmpeg_location, ffmpeg_crf, ffmpeg_preset, fps, stitch_from_frame, stitch_to_frame, audio_path, add_soundtrack):
     

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -342,8 +342,11 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
         # delete the zip file
         os.remove(realesrgan_zip_path)
         # chmod 755 the exec if we're in a linux machine, otherwise we'd get permission errors
-        if current_user_os in ['Linux', 'Mac']:
+        if current_user_os in ('Linux', 'Mac'):
             os.chmod(realesrgan_exec_path, 0o755)
+            if current_user_os == 'Mac':
+                subprocess.run(['xattr', '-d', 'com.apple.quarantine', f'./{realesrgan_exec_path}'])
+
     except Exception as e:
         raise Exception(f"Error while downloading {realesrgan_zip_path}. Please download from: {download_url}, and extract its contents into: {models_folder}/realesrgan_ncnn")
 

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -325,7 +325,7 @@ def make_upscale_v2(upscale_factor, upscale_model, keep_imgs, imgs_raw_path, img
     duplicate_pngs_from_folder(from_folder=imgs_raw_path, to_folder=temp_folder_to_keep_raw_ims, img_batch_id=imgs_batch_id, orig_vid_name='Dummy')
     cmd = [realesrgan_ncnn_location, '-i', temp_folder_to_keep_raw_ims, '-o', upscaled_folder_path, '-s', str(clean_num_r_up_factor), '-n', upscale_model]
     msg_to_print = "Upscaling raw output PNGs using realesrgan"
-    console.print(msg_to_print, style="blink yellow", end="")
+    console.print(msg_to_print, style="blink", end="")
     start_time = time.time()
     # make call to ncnn upscaling executble
     process = subprocess.run(cmd, capture_output=True, check=True, text=True)

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -350,13 +350,14 @@ def make_upscale_v2(upscale_factor, upscale_model, keep_imgs, imgs_raw_path, img
     # set dynamic cmd command
     cmd = [realesrgan_ncnn_location, '-i', temp_folder_to_keep_raw_ims, '-o', upscaled_folder_path, '-s', str(clean_num_r_up_factor), '-n', upscale_model]
     # msg to print - need it to hide that text later on (!)
-    msg_to_print = f"Upscaling raw output PNGs using {upscale_model} at {upscale_factor}"
+    msg_to_print = f"Upscaling raw output PNGs using {upscale_model} at {upscale_factor}..."
     # blink the msg in the cli until action is done
     console.print(msg_to_print, style="blink yellow", end="") 
     start_time = time.time()
     # make call to ncnn upscaling executble
     process = subprocess.run(cmd, capture_output=True, check=True, text=True)
     print("\r" + " " * len(msg_to_print), end="", flush=True)
+    print(f"\r{msg_to_print}", flush=True)
     print(f"\rUpscaling \033[0;32mdone\033[0m in {time.time() - start_time:.2f} seconds!", flush=True)
     # set custom path for ffmpeg func below
     upscaled_imgs_path_for_ffmpeg = os.path.join(upscaled_folder_path, f"{imgs_batch_id}_%05d.png")

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -318,3 +318,5 @@ def make_upscale_v2(upscale_factor, upscale_model, imgs_raw_path, imgs_batch_id,
         print(f"Video upscaling done in {time.time() - start_time:.2f} seconds!")
     except Exception as e:
         print(f"Video upscaling *failed* with error:\n{e}")
+     
+    shutil.rmtree(temp_folder_to_keep_raw_ims)

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -8,6 +8,8 @@ import time
 from pkg_resources import resource_filename
 from modules.shared import state
 from .general_utils import checksum, duplicate_pngs_from_folder
+# move these from here?
+from .rich import console
 
 # e.g gets 'x2' returns just 2 as int
 def extract_number(string):
@@ -322,13 +324,13 @@ def make_upscale_v2(upscale_factor, upscale_model, keep_imgs, imgs_raw_path, img
     # make a folder with only the imgs we need to duplicate so we can call the ncnn with the folder syntax (quicker!)
     duplicate_pngs_from_folder(from_folder=imgs_raw_path, to_folder=temp_folder_to_keep_raw_ims, img_batch_id=imgs_batch_id, orig_vid_name='Dummy')
     cmd = [realesrgan_ncnn_location, '-i', temp_folder_to_keep_raw_ims, '-o', upscaled_folder_path, '-s', str(clean_num_r_up_factor), '-n', upscale_model]
-    print("\033[0;33mUpscaling raw output PNGs using realesrgan\033[0m")
+    msg_to_print = "Upscaling raw output PNGs using realesrgan"
+    console.print(msg_to_print, style="blink yellow", end="")
     start_time = time.time()
     # make call to ncnn upscaling executble
     process = subprocess.run(cmd, capture_output=True, check=True, text=True)
-    
-    print(f"Upscaling done in {time.time() - start_time:.2f} seconds!")
-
+    print("\r" + " " * len(msg_to_print), end="", flush=True)
+    print(f"\rUpscaling \033[0;32mdone\033[0m in {time.time() - start_time:.2f} seconds!", flush=True)
     # set custom path for ffmpeg func below
     upscaled_imgs_path_for_ffmpeg = os.path.join(upscaled_folder_path, f"{imgs_batch_id}_%05d.png")
     # stitch video from upscaled pngs 

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -9,6 +9,10 @@ from pkg_resources import resource_filename
 from modules.shared import state
 from .general_utils import checksum, duplicate_pngs_from_folder
 
+# e.g gets 'x2' returns just 2 as int
+def extract_number(string):
+    return int(string[1:]) if len(string) > 1 and string[1:].isdigit() else -1
+    
 def vid2frames(video_path, video_in_frame_path, n=1, overwrite=True, extract_from_frame=0, extract_to_frame=-1, out_img_format='jpg', numeric_files_output = False): 
     if (extract_to_frame <= extract_from_frame) and extract_to_frame != -1:
         raise RuntimeError('Error: extract_to_frame can not be higher than extract_from_frame')
@@ -292,16 +296,18 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
         os.remove(realesrgan_zip_path)
        
 def make_upscale_v2(upscale_factor, upscale_model, keep_imgs, imgs_raw_path, imgs_batch_id, deforum_models_path, current_user_os, ffmpeg_location, ffmpeg_crf, ffmpeg_preset, fps, stitch_from_frame, stitch_to_frame, audio_path, add_soundtrack):
+
+    clean_num_r_up_factor = extract_number(upscale_factor)
     # set paths
     realesrgan_ncnn_location = os.path.join(deforum_models_path, 'realesrgan_ncnn', 'realesrgan-ncnn-vulkan.exe')
     upscaled_folder_path = os.path.join(imgs_raw_path, f"{imgs_batch_id}_upscaled")
     temp_folder_to_keep_raw_ims = os.path.join(upscaled_folder_path, 'temp_raw_imgs_to_upscale')
-    out_upscaled_mp4_path = os.path.join(imgs_raw_path, f"{imgs_batch_id}_Upscaled_x{upscale_factor}.mp4")
+    out_upscaled_mp4_path = os.path.join(imgs_raw_path, f"{imgs_batch_id}_Upscaled_{upscale_factor}.mp4")
     # download upscaling model if needed
     check_and_download_realesrgan_ncnn(deforum_models_path, current_user_os)
     # make a folder with only the imgs we need to duplicate so we can call the ncnn with the folder syntax (quicker!)
     duplicate_pngs_from_folder(from_folder=imgs_raw_path, to_folder=temp_folder_to_keep_raw_ims, img_batch_id=imgs_batch_id, orig_vid_name='Dummy')
-    cmd = [realesrgan_ncnn_location, '-i', temp_folder_to_keep_raw_ims, '-o', upscaled_folder_path, '-s', str(upscale_factor), '-n', upscale_model]
+    cmd = [realesrgan_ncnn_location, '-i', temp_folder_to_keep_raw_ims, '-o', upscaled_folder_path, '-s', str(clean_num_r_up_factor), '-n', upscale_model]
     print("\033[0;33mUpscaling raw output PNGs using realesrgan\033[0m")
     start_time = time.time()
     # make call to ncnn upscaling executble

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -7,7 +7,7 @@ import subprocess
 import time
 from pkg_resources import resource_filename
 from modules.shared import state
-from .general_utils import checksum
+from .general_utils import checksum, duplicate_pngs_from_folder
 
 def vid2frames(video_path, video_in_frame_path, n=1, overwrite=True, extract_from_frame=0, extract_to_frame=-1, out_img_format='jpg', numeric_files_output = False): 
     if (extract_to_frame <= extract_from_frame) and extract_to_frame != -1:
@@ -296,9 +296,14 @@ def make_upscale_v2(imgs_raw_path, imgs_batch_id, fps, deforum_models_path, curr
     print(f"\033[0;33mUpscaling raw output images using realesrgan\033[0m")
 
     realesrgan_ncnn_location = os.path.join(deforum_models_path, 'realesrgan_ncnn', 'realesrgan-ncnn-vulkan.exe')
-    upscaled_folder_path = os.path.join(imgs_raw_path, imgs_batch_id + '.gif')
+    
+    upscaled_folder_path = os.path.join(imgs_raw_path, imgs_batch_id + 'upscaled')
+    temp_folder_to_keep_raw_ims = os.path.join(upscaled_folder_path, 'temp_raw_imgs_to_upscale')
         
     check_and_download_realesrgan_ncnn(deforum_models_path, current_user_os)
+    
+    duplicate_pngs_from_folder(from_folder=imgs_raw_path, to_folder=temp_folder_to_keep_raw_ims, img_batch_id=imgs_batch_id, orig_vid_name='Dummy') # keep dummy?
+    
     cmd = [realesrgan_ncnn_location, '-i', 'D:/D-SD/realesrgan/f' ,'-o', 'D:/D-SD/realesrgan/output_xrplus', '-s', '2']
    
     print(cmd)

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -344,6 +344,7 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
         # chmod 755 the exec if we're in a linux machine, otherwise we'd get permission errors
         if current_user_os in ('Linux', 'Mac'):
             os.chmod(realesrgan_exec_path, 0o755)
+            # enable running the exec for mac users
             if current_user_os == 'Mac':
                 subprocess.run(['xattr', '-d', 'com.apple.quarantine', f'./{realesrgan_exec_path}'])
 

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -146,8 +146,12 @@ def ffmpeg_stitch_video(ffmpeg_location=None, fps=None, outmp4_path=None, stitch
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = process.communicate()
     except FileNotFoundError:
+        print("\r" + " " * len(msg_to_print), end="", flush=True)
+        print(f"\r{msg_to_print}", flush=True)
         raise FileNotFoundError("FFmpeg not found. Please make sure you have a working ffmpeg path under 'ffmpeg_location' parameter.")
     except Exception as e:
+        print("\r" + " " * len(msg_to_print), end="", flush=True)
+        print(f"\r{msg_to_print}", flush=True)
         raise Exception(f'Error stitching frames to video. Actual runtime error:{e}')
     
     if add_soundtrack != 'None':
@@ -258,9 +262,10 @@ def check_and_download_gifski(models_folder, current_user_os):
 # create a gif using gifski - limited to up to 30 fps (from the ui; if users wanna try to hack it, results are not good, but possible up to 100 fps theoretically)   
 def make_gifski_gif(imgs_raw_path, imgs_batch_id, fps, models_folder, current_user_os):
     import glob
-    print(f"\033[0;33mStitching *gif* from frames using Gifski:\033[0m")
+    msg_to_print = f"Stitching *gif* from frames using Gifski..."
+    # blink the msg in the cli until action is done
+    console.print(msg_to_print, style="blink yellow", end="") 
     start_time = time.time()
-    
     gifski_location = os.path.join(models_folder, 'gifski' + ('.exe' if current_user_os == 'Windows' else ''))
     final_gif_path = os.path.join(imgs_raw_path, imgs_batch_id + '.gif')
     if current_user_os == "Linux":
@@ -276,12 +281,14 @@ def make_gifski_gif(imgs_raw_path, imgs_batch_id, fps, models_folder, current_us
     check_and_download_gifski(models_folder, current_user_os)
 
     try:
-        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE) 
         stdout, stderr = process.communicate()
         if process.returncode != 0:
             print(stderr)
             raise RuntimeError(stderr)
-        print(f"GIF stitching done in {time.time() - start_time:.2f} seconds!")
+        print("\r" + " " * len(msg_to_print), end="", flush=True)
+        print(f"\r{msg_to_print}", flush=True)
+        print(f"GIF stitching \033[0;32mdone\033[0m in {time.time() - start_time:.2f} seconds!")
     except Exception as e:
         print(f"GIF stitching *failed* with error:\n{e}")
         

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -350,7 +350,6 @@ def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
 def make_upscale_v2(upscale_factor, upscale_model, keep_imgs, imgs_raw_path, imgs_batch_id, deforum_models_path, current_user_os, ffmpeg_location, ffmpeg_crf, ffmpeg_preset, fps, stitch_from_frame, stitch_to_frame, audio_path, add_soundtrack):
     # get clean number from 'x2, x3' etc
     clean_num_r_up_factor = extract_number(upscale_factor)
-
     # set paths
     realesrgan_ncnn_location = os.path.join(deforum_models_path, 'realesrgan_ncnn', 'realesrgan-ncnn-vulkan' + ('.exe' if current_user_os == 'Windows' else ''))
     upscaled_folder_path = os.path.join(imgs_raw_path, f"{imgs_batch_id}_upscaled")

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -333,7 +333,7 @@ def make_upscale_v2(upscale_factor, upscale_model, keep_imgs, imgs_raw_path, img
     # make a folder with only the imgs we need to duplicate so we can call the ncnn with the folder syntax (quicker!)
     duplicate_pngs_from_folder(from_folder=imgs_raw_path, to_folder=temp_folder_to_keep_raw_ims, img_batch_id=imgs_batch_id, orig_vid_name='Dummy')
     cmd = [realesrgan_ncnn_location, '-i', temp_folder_to_keep_raw_ims, '-o', upscaled_folder_path, '-s', str(clean_num_r_up_factor), '-n', upscale_model]
-    msg_to_print = "Upscaling raw output PNGs using realesrgan"
+    msg_to_print = f"Upscaling raw output PNGs using {upscale_model} at {upscale_factor}"
     console.print(msg_to_print, style="blink", end="")
     start_time = time.time()
     # make call to ncnn upscaling executble

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -274,10 +274,23 @@ def make_gifski_gif(imgs_raw_path, imgs_batch_id, fps, models_folder, current_us
     except Exception as e:
         print(f"GIF stitching *failed* with error:\n{e}")
         
-def check_and_download_realesrgan_ncnn():
-    pass
-    
-# def make_upscale_v2(imgs_raw_path, imgs_batch_id, fps, models_folder, current_user_os):
+def check_and_download_realesrgan_ncnn(models_folder, current_user_os):
+    import zipfile
+    from basicsr.utils.download_util import load_file_from_url
+
+    realesrgan_ncnn_folder = os.path.join(models_folder, 'realesrgan_ncnn')
+    realesrgan_exe_path = os.path.join(realesrgan_ncnn_folder, 'realesrgan-ncnn-vulkan.exe')
+    realesrgan_zip_path = os.path.join(realesrgan_ncnn_folder, 'realesrgan_ncnn_windows.zip')
+    download_url = 'https://github.com/hithereai/Real-ESRGAN/releases/download/real-esrgan-ncnn-windows/realesrgan_ncnn_windows.zip'
+    if not os.path.exists(realesrgan_exe_path): # todo: change logic to check folder content
+        os.makedirs(realesrgan_ncnn_folder)
+        load_file_from_url(download_url, realesrgan_ncnn_folder)
+
+        with zipfile.ZipFile(realesrgan_zip_path, 'r') as zip_ref:
+            zip_ref.extractall(os.path.dirname(realesrgan_zip_path))
+
+        os.remove(realesrgan_zip_path)
+
 def make_upscale_v2(imgs_raw_path, imgs_batch_id, fps, deforum_models_path, current_user_os):
 
     print(f"\033[0;33mUpscaling raw output images using realesrgan\033[0m")
@@ -285,7 +298,7 @@ def make_upscale_v2(imgs_raw_path, imgs_batch_id, fps, deforum_models_path, curr
     realesrgan_ncnn_location = os.path.join(deforum_models_path, 'realesrgan_ncnn', 'realesrgan-ncnn-vulkan.exe')
     upscaled_folder_path = os.path.join(imgs_raw_path, imgs_batch_id + '.gif')
         
-    # check_and_download_realesrgan_ncnn(models_folder, current_user_os)
+    check_and_download_realesrgan_ncnn(deforum_models_path, current_user_os)
     cmd = [realesrgan_ncnn_location, '-i', 'D:/D-SD/realesrgan/f' ,'-o', 'D:/D-SD/realesrgan/output_xrplus', '-s', '2']
    
     print(cmd)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/121192995/218888978-f464ee44-fc63-4b99-9cd7-fe6e15896f3d.png)

It's so fast I think we should enable x2 by default. For the default 120 frames, it takes about 30 seconds to do 2x on *free* colab, and 3.5 seconds on a 4090. 

3 models included in this PR:
- realesr-animevideov3: default, does 2, 3 and 4x
- realesrgan-x4plus: does only 4x, slower (still 10-30x faster than any other webui upscaling method), but looks MUCH better with more detailes. Probably best for non anime-themed vids.
- realesrgan-x4plus-anime: didn't test it too much, does only 4x too.



Extra models + video upload option to be added soon, this is an initial pr so people can enjoy the speed rn. 

Tested thoroughly and will show *only* on windows and linux machines. Apple users won't even see the option.