### PR TITLE
fix rich pip install for colab users

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,5 +1,6 @@
 import launch
 import os
+import sys
 
 req_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requirements.txt")
 
@@ -7,4 +8,7 @@ with open(req_file) as file:
     for lib in file:
         lib = lib.strip()
         if not launch.is_installed(lib):
-            launch.run_pip(f"install {lib}", f"Deforum requirement: {lib}")
+            if lib == 'rich':
+                launch.run(f'"{sys.executable}" -m pip install {lib}', desc=f"Installing Deforum requirement: {lib}", errdesc=f"Couldn't install {lib}")
+            else:
+                launch.run_pip(f"install {lib}", f"Deforum requirement: {lib}")


### PR DESCRIPTION
Explanation copied from issue 362:
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/launch.py#L137

We use auto's pip install function, and turns out it always runs with --prefer-binary, which yields an error on colab when combined with the rich package. I will make a workaround in our code shortly so that it won't adds that flag when installing rich.

Closes https://github.com/deforum-art/deforum-for-automatic1111-webui/issues/362