### PR TITLE
Embed ControlNet

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2494,3 +2494,26 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+------------------------
+The following is the License of sd-webui-controlnet
+MIT License
+
+Copyright (c) 2023 Kakigōri Maker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ av
 pims
 imageio_ffmpeg
 rich
+svglib
+reportlab

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -677,12 +677,8 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
         # CONTROLNET TAB
         with gr.Tab('ControlNet'):
                 gr.HTML("""
-                Requires the <a style='color:SteelBlue;' target='_blank' href='https://github.com/Mikubill/sd-webui-controlnet'>ControlNet</a> extension to be installed.</p>
                 <p style="margin-top:0.2em">
-                    *Work In Progress*. All params below are going to be keyframable at some point. If you want to speedup the integration, join Deforum's development. &#128521;
-                </p>
-                <p">
-                    Due to ControlNet base extension's inner works it needs its models to be located at 'extensions/deforum-for-automatic1111-webui/models'. So copy, symlink or move them there until a more elegant solution is found. And, as of now, it requires use_init checked for the first run. The ControlNet extension version used in the dev process is a24089a62e70a7fae44b7bf35b51fd584dd55e25, if even with all the other options above used it still breaks, upgrade/downgrade your CN version to this one.
+                    *Work In Progress*. ControlNet version used is frozen to <a style='color:SteelBlue;' target='_blank' href='https://github.com/Mikubill/sd-webui-controlnet/commit/a24089a62e70a7fae44b7bf35b51fd584dd55e25'>a24089a</a> If you want to bring new features and fix bugs sooner, <b style='color:Violet;' target='_blank' src='https://github.com/deforum-art/deforum-for-automatic1111-webui'>join Deforum's development</b>. &#128521;
                 </p>
                 """)
                 controlnet_dict = setup_controlnet_ui()

--- a/scripts/deforum_helpers/deforum_controlnet.py
+++ b/scripts/deforum_helpers/deforum_controlnet.py
@@ -111,6 +111,7 @@ def setup_controlnet_ui_raw():
         controlnet_lowvram = gr.Checkbox(label='Low VRAM', value=False, visible=False)
 
     def refresh_all_models(*inputs):
+        from .deforum_controlnet_hardcode import update_cn_models
         update_cn_models()
         
         dd = inputs[0]

--- a/scripts/deforum_helpers/deforum_controlnet.py
+++ b/scripts/deforum_helpers/deforum_controlnet.py
@@ -19,7 +19,7 @@ def find_controlnet():
         return has_controlnet
     
     try:
-        from sd_webui_controlnet.scripts import controlnet
+        from sd_webui_controlnet.cn_scripts import controlnet
     except Exception as e:
         print(f'\033[33mFailed to import controlnet! The exact error is {e}. Deforum support for ControlNet will not be activated\033[0m')
         has_controlnet = False
@@ -68,8 +68,8 @@ def ControlnetArgs():
 
 def setup_controlnet_ui_raw():
     # Already under an accordion
-    from sd_webui_controlnet.scripts import controlnet
-    from sd_webui_controlnet.scripts.controlnet import cn_models, cn_models_names
+    from sd_webui_controlnet.cn_scripts import controlnet
+    from sd_webui_controlnet.cn_scripts.controlnet import cn_models, cn_models_names
 
     refresh_symbol = '\U0001f504'  # 🔄
     switch_values_symbol = '\U000021C5' # ⇅
@@ -85,7 +85,7 @@ def setup_controlnet_ui_raw():
         def get_block_name(self):
             return "button"
             
-    from sd_webui_controlnet.scripts.processor import canny, midas, midas_normal, leres, hed, mlsd, openpose, pidinet, simple_scribble, fake_scribble, uniformer
+    from sd_webui_controlnet.cn_scripts.processor import canny, midas, midas_normal, leres, hed, mlsd, openpose, pidinet, simple_scribble, fake_scribble, uniformer
 
     preprocessor = {
         "none": lambda x, *args, **kwargs: x,

--- a/scripts/deforum_helpers/deforum_controlnet.py
+++ b/scripts/deforum_helpers/deforum_controlnet.py
@@ -3,7 +3,6 @@
 
 import os, sys
 import gradio as gr
-import scripts
 import modules.scripts as scrpts
 from PIL import Image
 import numpy as np
@@ -20,7 +19,7 @@ def find_controlnet():
         return has_controlnet
     
     try:
-        from scripts import controlnet
+        from sd_webui_controlnet.scripts import controlnet
     except Exception as e:
         print(f'\033[33mFailed to import controlnet! The exact error is {e}. Deforum support for ControlNet will not be activated\033[0m')
         has_controlnet = False
@@ -69,8 +68,8 @@ def ControlnetArgs():
 
 def setup_controlnet_ui_raw():
     # Already under an accordion
-    from scripts import controlnet
-    from scripts.controlnet import update_cn_models, cn_models, cn_models_names
+    from sd_webui_controlnet.scripts import controlnet
+    from sd_webui_controlnet.scripts.controlnet import cn_models, cn_models_names
 
     refresh_symbol = '\U0001f504'  # 🔄
     switch_values_symbol = '\U000021C5' # ⇅
@@ -86,7 +85,7 @@ def setup_controlnet_ui_raw():
         def get_block_name(self):
             return "button"
             
-    from scripts.processor import canny, midas, midas_normal, leres, hed, mlsd, openpose, pidinet, simple_scribble, fake_scribble, uniformer
+    from sd_webui_controlnet.scripts.processor import canny, midas, midas_normal, leres, hed, mlsd, openpose, pidinet, simple_scribble, fake_scribble, uniformer
 
     preprocessor = {
         "none": lambda x, *args, **kwargs: x,

--- a/scripts/deforum_helpers/deforum_controlnet_hardcode.py
+++ b/scripts/deforum_helpers/deforum_controlnet_hardcode.py
@@ -1,20 +1,19 @@
-# TODO HACK FIXME HARDCODE — as using the scripts doesn't seem to work for some reason
 deforum_latest_network = None
 deforum_latest_params = (None, 'placeholder to trigger the model loading')
 deforum_input_image = None
-from scripts.processor import unload_hed, unload_mlsd, unload_midas, unload_leres, unload_pidinet, unload_openpose, unload_uniformer, HWC3
+from sd_webui_controlnet.scripts.processor import unload_hed, unload_mlsd, unload_midas, unload_leres, unload_pidinet, unload_openpose, unload_uniformer, HWC3
 import modules.shared as shared
 import modules.devices as devices
 import modules.processing as processing
 from modules.processing import StableDiffusionProcessingImg2Img, StableDiffusionProcessingTxt2Img
 import numpy as np
-from scripts.controlnet import update_cn_models, cn_models, cn_models_names
+from sd_webui_controlnet.scripts.controlnet import cn_models, cn_models_names
 import os
 import modules.scripts as scrpts
 import torch
-from scripts.cldm import PlugableControlModel
-from scripts.adapter import PlugableAdapter
-from scripts.utils import load_state_dict
+from sd_webui_controlnet.scripts.cldm import PlugableControlModel
+from sd_webui_controlnet.scripts.adapter import PlugableAdapter
+from sd_webui_controlnet.scripts.utils import load_state_dict
 from torchvision.transforms import Resize, InterpolationMode, CenterCrop, Compose
 from einops import rearrange
 cn_models_dir = os.path.join(scrpts.basedir(), "models")
@@ -123,7 +122,7 @@ def process(p, *args):
         detected_map[np.min(deforum_input_image, axis=2) < 127] = 255
         deforum_input_image = detected_map
     
-    from scripts.processor import canny, midas, midas_normal, leres, hed, mlsd, openpose, pidinet, simple_scribble, fake_scribble, uniformer
+    from sd_webui_controlnet.scripts.processor import canny, midas, midas_normal, leres, hed, mlsd, openpose, pidinet, simple_scribble, fake_scribble, uniformer
     
     preprocessor = {
         "none": lambda x, *args, **kwargs: x,


### PR DESCRIPTION
Embeds the ControlNet version of `a24089a62e70a7fae44b7bf35b51fd584dd55e25` into the extension, so it will be less affected with breaking changes of its side.

Also, now searches for CN's models in `extensions/sd-webui-controlnet` too, so the users won't have to move or copy them anywhere

Closes #378 and closes #366 and closes #372 