### PR TITLE
Fixed issue where depth only worked properly at 1:1 aspect ratio

### DIFF
--- a/scripts/deforum_helpers/animation.py
+++ b/scripts/deforum_helpers/animation.py
@@ -216,7 +216,7 @@ def transform_image_3d(device, prev_img_cv2, depth_tensor, rot_mat, translate, a
     # adapted and optimized version of transform_image_3d from Disco Diffusion https://github.com/alembics/disco-diffusion 
     w, h = prev_img_cv2.shape[1], prev_img_cv2.shape[0]
 
-    aspect_ratio = float(w)/float(h)
+    aspect_ratio = 1
     near = keys.near_series[frame_idx]
     far = keys.far_series[frame_idx]
     fov_deg = keys.fov_series[frame_idx]


### PR DESCRIPTION
Fixed issue where depth only worked properly at 1:1 aspect ratio
This has been an issue with Deforum as far back as I can remember... If the proportion was too wide, things would stretch unnaturally vertically, and if proportion was too thin, things would stretch horizontally.

I found that changing the aspect ratio in this function to 1, things are always correct, no matter the proportion of the image!

This is a major change to Deforum, but in all of my tests the results are much more consistent and reliable. I've tested extremes, like 3:1, 1:3, 4:1, 1:4, and everything seems even now. Tested different depth setings and FOV, and it all seems right to me now.