### PR TITLE
Revert "Merge pull request #422 from hithereai/sampler_sch_fixes"

### DIFF
--- a/scripts/deforum_helpers/generate.py
+++ b/scripts/deforum_helpers/generate.py
@@ -241,7 +241,7 @@ def print_combined_table(args, anim_args, p, keys, frame_idx):
         rows1.append(f"{p.denoising_strength:.5g}" if p.denoising_strength is not None else "None")
 
     rows1 += [str(p.subseed), f"{p.subseed_strength:.5g}"] * (anim_args.enable_subseed_scheduling)
-    rows1 += [args.sampler] * anim_args.enable_sampler_scheduling
+    rows1 += [p.sampler_name] * anim_args.enable_sampler_scheduling
     rows1 += [str(args.checkpoint)] * anim_args.enable_checkpoint_scheduling
     
     rows2 = []


### PR DESCRIPTION
This reverts commit 09c99d10edc82583afba63f21282fc7d3e9663a1, reversing changes made to 97ab68b13bd0dbf245916748e5e68f6246a303de.

Turns out it shows the real in-work sampler, and that the bug is that the sampler for the 0 frame is always taken from the run tab, and not from sampler schedule even if it's enabled. I'll fix the real bug in a sep PR soon™.