### PR TITLE
Align img filenames to be of length %09d.extension

### DIFF
--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -111,7 +111,7 @@ def run_deforum(*args, **kwargs):
 
         path_name_modifier = video_args.path_name_modifier
         if video_args.render_steps: # render steps from a single image
-            fname = f"{path_name_modifier}_%05d.png"
+            fname = f"{path_name_modifier}_%09d.png"
             all_step_dirs = [os.path.join(args.outdir, d) for d in os.listdir(args.outdir) if os.path.isdir(os.path.join(args.outdir,d))]
             newest_dir = max(all_step_dirs, key=os.path.getmtime)
             image_path = os.path.join(newest_dir, fname)
@@ -119,7 +119,7 @@ def run_deforum(*args, **kwargs):
             mp4_path = os.path.join(newest_dir, f"{args.timestring}_{path_name_modifier}.mp4")
             max_video_frames = args.steps
         else: # render images for a video
-            image_path = os.path.join(args.outdir, f"{args.timestring}_%05d.png")
+            image_path = os.path.join(args.outdir, f"{args.timestring}_%09d.png")
             mp4_path = os.path.join(args.outdir, f"{args.timestring}.mp4")
             max_video_frames = anim_args.max_frames
 

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -255,7 +255,7 @@ def DeforumOutputArgs():
     skip_video_for_run_all = False
     fps = 15 
     make_gif = False
-    image_path = "C:/SD/20230124234916_%05d.png" 
+    image_path = "C:/SD/20230124234916_%09d.png" 
     mp4_path = "testvidmanualsettings.mp4" 
     ffmpeg_location = find_ffmpeg_binary()
     ffmpeg_crf = '17'
@@ -416,9 +416,11 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
             # EXTA SCHEDULES TABS
             with gr.Tabs(elem_id='extra_schedules'):
                 with gr.TabItem('Strength'):
-                    strength_schedule = gr.Textbox(label="Strength schedule", lines=1, value = da.strength_schedule, interactive=True)
+                    with gr.Row(variant='compact'):
+                        strength_schedule = gr.Textbox(label="Strength schedule", lines=1, value = da.strength_schedule, interactive=True)
                 with gr.TabItem('CFG'):
-                    cfg_scale_schedule = gr.Textbox(label="CFG scale schedule", lines=1, value = da.cfg_scale_schedule, interactive=True)
+                    with gr.Row(variant='compact'):
+                        cfg_scale_schedule = gr.Textbox(label="CFG scale schedule", lines=1, value = da.cfg_scale_schedule, interactive=True)
                 with gr.TabItem('Seed') as a3:
                     with gr.Row(variant='compact'):
                         seed_behavior = gr.Radio(['iter', 'fixed', 'random', 'ladder', 'alternate', 'schedule'], label="Seed behavior", value=d.seed_behavior, elem_id="seed_behavior")
@@ -427,9 +429,10 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                     with gr.Row(visible=False) as seed_schedule_row:
                         seed_schedule = gr.Textbox(label="Seed schedule", lines=1, value = da.seed_schedule, interactive=True)
                 with gr.TabItem('SubSeed', open=False) as subseed_sch_tab:
-                    enable_subseed_scheduling = gr.Checkbox(label="Enable Subseed scheduling", value=da.enable_subseed_scheduling, interactive=True)
-                    subseed_schedule = gr.Textbox(label="Subseed schedule", lines=1, value = da.subseed_schedule, interactive=True)
-                    subseed_strength_schedule = gr.Textbox(label="Subseed strength schedule", lines=1, value = da.subseed_strength_schedule, interactive=True)
+                    with gr.Row(variant='compact'):
+                        enable_subseed_scheduling = gr.Checkbox(label="Enable Subseed scheduling", value=da.enable_subseed_scheduling, interactive=True)
+                        subseed_schedule = gr.Textbox(label="Subseed schedule", lines=1, value = da.subseed_schedule, interactive=True)
+                        subseed_strength_schedule = gr.Textbox(label="Subseed strength schedule", lines=1, value = da.subseed_strength_schedule, interactive=True)
                     with gr.Row(variant='compact'):
                         seed_resize_from_w = gr.Slider(minimum=0, maximum=2048, step=64, label="Resize seed from width", value=0)
                         seed_resize_from_h = gr.Slider(minimum=0, maximum=2048, step=64, label="Resize seed from height", value=0)
@@ -911,7 +914,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                  <p style="margin-top:0em">
                     Important Notes:
                     <ul style="list-style-type:circle; margin-left:1em; margin-bottom:0.25em">
-                        <li>Enter relative to webui folder or Full-Absolute path, and make sure it ends with something like this: '20230124234916_%05d.png', just replace 20230124234916 with your batch ID. The %05d is important, don't forget it!</li>
+                        <li>Enter relative to webui folder or Full-Absolute path, and make sure it ends with something like this: '20230124234916_%09d.png', just replace 20230124234916 with your batch ID. The %05d is important, don't forget it!</li>
                     </ul>
                     """)
                 with gr.Row(variant='compact'):

--- a/scripts/deforum_helpers/deforum_controlnet.py
+++ b/scripts/deforum_helpers/deforum_controlnet.py
@@ -191,8 +191,8 @@ def process_txt2img_with_controlnet(p, args, anim_args, loop_args, controlnet_ar
     # TODO: use init image and mask here
     p.control_net_enabled = False # we don't want to cause concurrence
     p.init_images = []
-    controlnet_frame_path = os.path.join(args.outdir, 'controlnet_inputframes', f"{frame_idx:05}.jpg")
-    controlnet_mask_frame_path = os.path.join(args.outdir, 'controlnet_maskframes', f"{frame_idx:05}.jpg")
+    controlnet_frame_path = os.path.join(args.outdir, 'controlnet_inputframes', f"{frame_idx:09}.jpg")
+    controlnet_mask_frame_path = os.path.join(args.outdir, 'controlnet_maskframes', f"{frame_idx:09}.jpg")
     cn_mask_np = None
     cn_image_np = None
 
@@ -271,8 +271,8 @@ def process_txt2img_with_controlnet(p, args, anim_args, loop_args, controlnet_ar
 
 def process_img2img_with_controlnet(p, args, anim_args, loop_args, controlnet_args, root, frame_idx = 0):
     p.control_net_enabled = False # we don't want to cause concurrence
-    controlnet_frame_path = os.path.join(args.outdir, 'controlnet_inputframes', f"{frame_idx:05}.jpg")
-    controlnet_mask_frame_path = os.path.join(args.outdir, 'controlnet_maskframes', f"{frame_idx:05}.jpg")
+    controlnet_frame_path = os.path.join(args.outdir, 'controlnet_inputframes', f"{frame_idx:09}.jpg")
+    controlnet_mask_frame_path = os.path.join(args.outdir, 'controlnet_maskframes', f"{frame_idx:09}.jpg")
 
     print(f'Reading ControlNet base frame {frame_idx} at {controlnet_frame_path}')
     print(f'Reading ControlNet mask frame {frame_idx} at {controlnet_mask_frame_path}')

--- a/scripts/deforum_helpers/frame_interpolation.py
+++ b/scripts/deforum_helpers/frame_interpolation.py
@@ -120,7 +120,7 @@ def prepare_film_inference(deforum_models_path, x_am, sl_enabled, sl_am, keep_im
         custom_interp_path = "{}_{}".format(output_interp_imgs_folder, img_batch_id)
 
     # interp_vid_path = os.path.join(raw_output_imgs_path, str(img_batch_id) + '_FILM_x' + str(x_am))
-    img_path_for_ffmpeg = os.path.join(custom_interp_path, "frame_%05d.png")
+    img_path_for_ffmpeg = os.path.join(custom_interp_path, "frame_%09d.png")
 
     if sl_enabled:
         interp_vid_path = interp_vid_path + '_slomo_x' + str(sl_am)
@@ -150,7 +150,7 @@ def prepare_film_inference(deforum_models_path, x_am, sl_enabled, sl_am, keep_im
     print (f"*Passing interpolated frames to ffmpeg...*")
     exception_raised = False
     try:
-        ffmpeg_stitch_video(ffmpeg_location=f_location, fps=fps, outmp4_path=interp_vid_path, stitch_from_frame=0, stitch_to_frame=999999, imgs_path=img_path_for_ffmpeg, add_soundtrack=add_soundtrack, audio_path=audio_track, crf=f_crf, preset=f_preset)
+        ffmpeg_stitch_video(ffmpeg_location=f_location, fps=fps, outmp4_path=interp_vid_path, stitch_from_frame=0, stitch_to_frame=999999999, imgs_path=img_path_for_ffmpeg, add_soundtrack=add_soundtrack, audio_path=audio_track, crf=f_crf, preset=f_preset)
     except Exception as e:
         exception_raised = True
         print(f"An error occurred while stitching the video: {e}")

--- a/scripts/deforum_helpers/general_utils.py
+++ b/scripts/deforum_helpers/general_utils.py
@@ -43,6 +43,6 @@ def convert_images_from_list(paths, output_dir, format):
         # Open the image
         with Image.open(path) as img:
             # Generate the output filename
-            filename = f"{i+1:07d}.{format}"
+            filename = f"{i+1:09d}.{format}"
             # Save the image to the output directory
             img.save(os.path.join(output_dir, filename))

--- a/scripts/deforum_helpers/hybrid_video.py
+++ b/scripts/deforum_helpers/hybrid_video.py
@@ -70,12 +70,12 @@ def hybrid_generation(args, anim_args, root):
     return args, anim_args, inputfiles
 
 def hybrid_composite(args, anim_args, frame_idx, prev_img, depth_model, hybrid_comp_schedules, root):
-    video_frame = os.path.join(args.outdir, 'inputframes', get_frame_name(anim_args.video_init_path) + f"{frame_idx:05}.jpg")
-    video_depth_frame = os.path.join(args.outdir, 'hybridframes', get_frame_name(anim_args.video_init_path) + f"_vid_depth{frame_idx:05}.jpg")
-    depth_frame = os.path.join(args.outdir, f"{args.timestring}_depth_{frame_idx-1:05}.png")
-    mask_frame = os.path.join(args.outdir, 'hybridframes', get_frame_name(anim_args.video_init_path) + f"_mask{frame_idx:05}.jpg")
-    comp_frame = os.path.join(args.outdir, 'hybridframes', get_frame_name(anim_args.video_init_path) + f"_comp{frame_idx:05}.jpg")
-    prev_frame = os.path.join(args.outdir, 'hybridframes', get_frame_name(anim_args.video_init_path) + f"_prev{frame_idx:05}.jpg")
+    video_frame = os.path.join(args.outdir, 'inputframes', get_frame_name(anim_args.video_init_path) + f"{frame_idx:09}.jpg")
+    video_depth_frame = os.path.join(args.outdir, 'hybridframes', get_frame_name(anim_args.video_init_path) + f"_vid_depth{frame_idx:09}.jpg")
+    depth_frame = os.path.join(args.outdir, f"{args.timestring}_depth_{frame_idx-1:09}.png")
+    mask_frame = os.path.join(args.outdir, 'hybridframes', get_frame_name(anim_args.video_init_path) + f"_mask{frame_idx:09}.jpg")
+    comp_frame = os.path.join(args.outdir, 'hybridframes', get_frame_name(anim_args.video_init_path) + f"_comp{frame_idx:09}.jpg")
+    prev_frame = os.path.join(args.outdir, 'hybridframes', get_frame_name(anim_args.video_init_path) + f"_prev{frame_idx:09}.jpg")
     prev_img = cv2.cvtColor(prev_img, cv2.COLOR_BGR2RGB)
     prev_img_hybrid = Image.fromarray(prev_img)
     video_image = Image.open(video_frame)
@@ -298,7 +298,7 @@ def get_flow_from_images_Farneback(i1, i2, preset="normal", last_flow=None, pyr_
     return flow
 
 def save_flow_visualization(frame_idx, dimensions, flow, inputfiles, hybrid_frame_path):
-    flow_img_file = os.path.join(hybrid_frame_path, f"flow{frame_idx:05}.jpg")
+    flow_img_file = os.path.join(hybrid_frame_path, f"flow{frame_idx:09}.jpg")
     flow_img = cv2.imread(str(inputfiles[frame_idx]))
     flow_img = cv2.resize(flow_img, (dimensions[0], dimensions[1]), cv2.INTER_AREA)
     flow_img = cv2.cvtColor(flow_img, cv2.COLOR_RGB2GRAY)

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -122,7 +122,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
         last_frame = start_frame-1
         if turbo_steps > 1:
             last_frame -= last_frame%turbo_steps
-        path = os.path.join(args.outdir,f"{args.timestring}_{last_frame:05}.png")
+        path = os.path.join(args.outdir,f"{args.timestring}_{last_frame:09}.png")
         img = cv2.imread(path)
         #img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB) # Changed the colors on resume
         prev_img = img
@@ -281,10 +281,10 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
                     img = cv2.cvtColor(img.astype(np.uint8), cv2.COLOR_BGR2GRAY)
                     img = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
 
-                filename = f"{args.timestring}_{tween_frame_idx:05}.png"
+                filename = f"{args.timestring}_{tween_frame_idx:09}.png"
                 cv2.imwrite(os.path.join(args.outdir, filename), img)
                 if anim_args.save_depth_maps:
-                    depth_model.save(os.path.join(args.outdir, f"{args.timestring}_depth_{tween_frame_idx:05}.png"), depth)
+                    depth_model.save(os.path.join(args.outdir, f"{args.timestring}_depth_{tween_frame_idx:09}.png"), depth)
             if turbo_next_image is not None:
                 prev_img = turbo_next_image
 
@@ -318,7 +318,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
                 if anim_args.color_coherence == 'Video Input' and hybrid_available:
                     video_color_coherence_frame = int(frame_idx) % int(anim_args.color_coherence_video_every_N_frames) == 0
                     if video_color_coherence_frame:
-                        prev_vid_img = Image.open(os.path.join(args.outdir, 'inputframes', get_frame_name(anim_args.video_init_path) + f"{frame_idx:05}.jpg"))
+                        prev_vid_img = Image.open(os.path.join(args.outdir, 'inputframes', get_frame_name(anim_args.video_init_path) + f"{frame_idx:09}.jpg"))
                         prev_vid_img = prev_vid_img.resize((args.W, args.H), Image.Resampling.LANCZOS)
                         color_match_sample = np.asarray(prev_vid_img)
                         color_match_sample = cv2.cvtColor(color_match_sample, cv2.COLOR_RGB2BGR)
@@ -453,7 +453,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
             turbo_next_image, turbo_next_frame_idx = opencv_image, frame_idx
             frame_idx += turbo_steps
         else:    
-            filename = f"{args.timestring}_{frame_idx:05}.png"
+            filename = f"{args.timestring}_{frame_idx:09}.png"
             save_image(image, 'PIL', filename, args, video_args, root)
 
             if anim_args.save_depth_maps:
@@ -463,7 +463,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
                     devices.torch_gc()
                     depth_model.to(root.device)
                 depth = depth_model.predict(opencv_image, anim_args.midas_weight, root.half_precision)
-                depth_model.save(os.path.join(args.outdir, f"{args.timestring}_depth_{frame_idx:05}.png"), depth)
+                depth_model.save(os.path.join(args.outdir, f"{args.timestring}_depth_{frame_idx:09}.png"), depth)
                 if cmd_opts.lowvram or cmd_opts.medvram:
                     depth_model.to('cpu')
                     devices.torch_gc()

--- a/scripts/deforum_helpers/render_modes.py
+++ b/scripts/deforum_helpers/render_modes.py
@@ -140,7 +140,7 @@ def render_interpolation(args, anim_args, video_args, parseq_args, loop_args, co
         opts.data["CLIP_stop_at_last_layers"] = scheduled_clipskip if scheduled_clipskip is not None else opts.data["CLIP_stop_at_last_layers"]
 
         image = generate(args, keys, anim_args, loop_args, controlnet_args, root, frame_idx, sampler_name=scheduled_sampler_name)
-        filename = f"{args.timestring}_{frame_idx:05}.png"
+        filename = f"{args.timestring}_{frame_idx:09}.png"
 
         save_image(image, 'PIL', filename, args, video_args, root)
 

--- a/scripts/deforum_helpers/src/film_interpolation/film_inference.py
+++ b/scripts/deforum_helpers/src/film_interpolation/film_inference.py
@@ -106,7 +106,7 @@ def run_film_interp_infer(
 
         outer_loop_count = i
         for i, frame in enumerate(frames):
-            frame_path = os.path.join(args.save_folder, f"frame_{next_number:05d}.png") 
+            frame_path = os.path.join(args.save_folder, f"frame_{next_number:09d}.png") 
             # last pair, save all frames including the last one
             if len(image_paths) - 2 == outer_loop_count:
                 cv2.imwrite(frame_path, frame)

--- a/scripts/deforum_helpers/src/rife/inference_video.py
+++ b/scripts/deforum_helpers/src/rife/inference_video.py
@@ -211,7 +211,7 @@ def clear_write_buffer(user_args, write_buffer, custom_interp_path):
         item = write_buffer.get()
         if item is None:
             break
-        filename = '{}/{:0>7d}.png'.format(custom_interp_path, cnt)
+        filename = '{}/{:0>9d}.png'.format(custom_interp_path, cnt)
 
         cv2.imwrite(filename, item[:, :, ::-1])
 
@@ -261,7 +261,7 @@ def stitch_video(img_batch_id, fps, img_folder_path, audio_path, ffmpeg_location
         mp4_path = mp4_path + '_slomo_x' + str(slow_mo_x_amount)
     mp4_path = mp4_path + '.mp4'
 
-    t = os.path.join(img_folder_path, "%07d.png")
+    t = os.path.join(img_folder_path, "%09d.png")
     add_soundtrack = 'None'
     if not audio_path is None:
         add_soundtrack = 'File'

--- a/scripts/deforum_helpers/upscaling.py
+++ b/scripts/deforum_helpers/upscaling.py
@@ -100,7 +100,7 @@ def stitch_video(img_batch_id, fps, img_folder_path, audio_path, ffmpeg_location
     
     mp4_path = mp4_path + '.mp4'
 
-    t = os.path.join(img_folder_path, "%07d.png")
+    t = os.path.join(img_folder_path, "%09d.png")
     add_soundtrack = 'None'
     if not audio_path is None:
         add_soundtrack = 'File'
@@ -162,7 +162,7 @@ def process_ncnn_video_upscaling(vid_path, outdir, in_vid_fps, in_vid_res, out_v
     print(f"\r{msg_to_print}", flush=True)
     print(f"\rUpscaling \033[0;32mdone\033[0m in {time.time() - start_time:.2f} seconds!", flush=True)
     # set custom path for ffmpeg func below
-    upscaled_imgs_path_for_ffmpeg = os.path.join(upscaled_folder_path, "%05d.png")
+    upscaled_imgs_path_for_ffmpeg = os.path.join(upscaled_folder_path, "%09d.png")
     add_soundtrack = 'None'
     # don't pass add_soundtrack to ffmpeg if orig video doesn't contain any audio, so we won't get a message saying audio couldn't be added :)
     if media_file_has_audio(vid_path.name, f_location):
@@ -252,7 +252,7 @@ def make_upscale_v2(upscale_factor, upscale_model, keep_imgs, imgs_raw_path, img
     print(f"\r{msg_to_print}", flush=True)
     print(f"\rUpscaling \033[0;32mdone\033[0m in {time.time() - start_time:.2f} seconds!", flush=True)
     # set custom path for ffmpeg func below
-    upscaled_imgs_path_for_ffmpeg = os.path.join(upscaled_folder_path, f"{imgs_batch_id}_%05d.png")
+    upscaled_imgs_path_for_ffmpeg = os.path.join(upscaled_folder_path, f"{imgs_batch_id}_%09d.png")
     # stitch video from upscaled pngs 
     ffmpeg_stitch_video(ffmpeg_location=ffmpeg_location, fps=fps, outmp4_path=out_upscaled_mp4_path, stitch_from_frame=stitch_from_frame, stitch_to_frame=stitch_to_frame, imgs_path=upscaled_imgs_path_for_ffmpeg, add_soundtrack=add_soundtrack, audio_path=audio_path, crf=ffmpeg_crf, preset=ffmpeg_preset)
 

--- a/scripts/deforum_helpers/vid2depth.py
+++ b/scripts/deforum_helpers/vid2depth.py
@@ -154,7 +154,7 @@ def stitch_video(img_batch_id, fps, img_folder_path, audio_path, ffmpeg_location
     
     mp4_path = mp4_path + '.mp4'
 
-    t = os.path.join(img_folder_path, "%07d.png")
+    t = os.path.join(img_folder_path, "%09d.png")
     add_soundtrack = 'None'
     if not audio_path is None:
         add_soundtrack = 'File'

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -66,9 +66,9 @@ def vid2frames(video_path, video_in_frame_path, n=1, overwrite=True, extract_fro
                     return
                 if (count <= extract_to_frame or extract_to_frame == -1) and count % n == 0:
                     if numeric_files_output == True:
-                        cv2.imwrite(video_in_frame_path + os.path.sep + f"{t:05}.{out_img_format}" , image) # save frame as file
+                        cv2.imwrite(video_in_frame_path + os.path.sep + f"{t:09}.{out_img_format}" , image) # save frame as file
                     else:
-                        cv2.imwrite(video_in_frame_path + os.path.sep + name + f"{t:05}.{out_img_format}" , image) # save frame as file
+                        cv2.imwrite(video_in_frame_path + os.path.sep + name + f"{t:09}.{out_img_format}" , image) # save frame as file
                     t += 1
                 success,image = vidcap.read()
                 count += 1
@@ -122,7 +122,7 @@ def ffmpeg_stitch_video(ffmpeg_location=None, fps=None, outmp4_path=None, stitch
     msg_to_print = f"Stitching *video*..."
     console.print(msg_to_print, style="blink yellow", end="") 
     if stitch_to_frame == -1:
-        stitch_to_frame = 9999999
+        stitch_to_frame = 999999999
     try:
         cmd = [
             ffmpeg_location,
@@ -195,7 +195,7 @@ def get_frame_name(path):
 def get_next_frame(outdir, video_path, frame_idx, mask=False):
     frame_path = 'inputframes'
     if (mask): frame_path = 'maskframes'
-    return os.path.join(outdir, frame_path, get_frame_name(video_path) + f"{frame_idx+1:05}.jpg")
+    return os.path.join(outdir, frame_path, get_frame_name(video_path) + f"{frame_idx+1:09}.jpg")
      
 def find_ffmpeg_binary():
     try:


### PR DESCRIPTION
+ All img filenames now have a 09d ending instead of a 05d one. 
+ tiny fix for non compact-type  gradio sections in UI. 

Closes https://github.com/deforum-art/deforum-for-automatic1111-webui/issues/382 as a semi-temporary fix until, and if, we implement dynamic file name lengths. 
In such case this pr will be handy cuz it points to all places that handle frame naming. 
