### PR TITLE
use opts.outdir_samples for upscaling and interpolation too

### DIFF
--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -837,50 +837,50 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                 vid_to_upscale_chosen_file = gr.File(label="Video to Upscale", interactive=True, file_count="single", file_types=["video"], elem_id="vid_to_upscale_chosen_file")
                 with gr.Column():
                     # NCNN UPSCALE TAB
-                    with gr.Tab('Upscale V2') as ncnn_upscale_tab:
-                        with gr.Row(variant='compact') as ncnn_upload_vid_stats_row:
-                            # Non interactive textbox showing uploaded input vid total Frame Count
-                            ncnn_upscale_in_vid_frame_count_window = gr.Textbox(label="In Frame Count", lines=1, interactive=False, value='---')
-                            # Non interactive textbox showing uploaded input vid FPS
-                            ncnn_upscale_in_vid_fps_ui_window = gr.Textbox(label="In FPS", lines=1, interactive=False, value='---')
-                            # Non interactive textbox showing uploaded input resolution
-                            ncnn_upscale_in_vid_res = gr.Textbox(label="In Res", lines=1, interactive=False, value='---')
-                            # Non interactive textbox showing expected output resolution
-                            ncnn_upscale_out_vid_res = gr.Textbox(label="Out Res", value='---')
-                        with gr.Column():
-                            with gr.Row(variant='compact', visible=True) as ncnn_actual_upscale_row:
-                                ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = "realesr-animevideov3", type="value")
-                                ncnn_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value="x2", type="value")
-                                ncnn_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=True, interactive=True) # fix value
-                        ncnn_upscale_btn = gr.Button(value="*Upscale uploaded video*")
-                        ncnn_upscale_btn.click(ncnn_upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, ncnn_upscale_in_vid_fps_ui_window, ncnn_upscale_in_vid_res, ncnn_upscale_out_vid_res, ncnn_upscale_model, ncnn_upscale_factor, ncnn_upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
-                    with gr.Tab('Upscale V1'):
-                        with gr.Column():
-                            selected_tab = gr.State(value=0)
-                            with gr.Tabs(elem_id="extras_resize_mode"):
-                                with gr.TabItem('Scale by', elem_id="extras_scale_by_tab") as tab_scale_by:
-                                    upscaling_resize = gr.Slider(minimum=1.0, maximum=8.0, step=0.05, label="Resize", value=2, elem_id="extras_upscaling_resize")
-                                with gr.TabItem('Scale to', elem_id="extras_scale_to_tab") as tab_scale_to:
-                                    with FormRow():
-                                        upscaling_resize_w = gr.Slider(label="Width", minimum=1, maximum=7680, step=1, value=512, elem_id="extras_upscaling_resize_w")
-                                        upscaling_resize_h = gr.Slider(label="Height", minimum=1, maximum=7680, step=1, value=512, elem_id="extras_upscaling_resize_h")
-                                        upscaling_crop = gr.Checkbox(label='Crop to fit', value=True, elem_id="extras_upscaling_crop")
-                            with FormRow():
-                                extras_upscaler_1 = gr.Dropdown(label='Upscaler 1', elem_id="extras_upscaler_1", choices=[x.name for x in sh.sd_upscalers], value=sh.sd_upscalers[3].name)
-                                extras_upscaler_2 = gr.Dropdown(label='Upscaler 2', elem_id="extras_upscaler_2", choices=[x.name for x in sh.sd_upscalers], value=sh.sd_upscalers[0].name)
-                            with FormRow():
-                                with gr.Column(scale=3):
-                                    extras_upscaler_2_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Upscaler 2 visibility", value=0.0, elem_id="extras_upscaler_2_visibility")
-                                with gr.Column(scale=1, min_width=80):
-                                    upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", elem_id="upscale_keep_imgs", value=True, interactive=True)
-                            tab_scale_by.select(fn=lambda: 0, inputs=[], outputs=[selected_tab])
-                            tab_scale_to.select(fn=lambda: 1, inputs=[], outputs=[selected_tab])
-                            # This is the actual button that's pressed to initiate the Upscaling:
-                            upscale_btn = gr.Button(value="*Upscale uploaded video*")
-                            # Show a text about CLI outputs:
-                            gr.HTML("* check your CLI for outputs")
-                            # make the function call when the UPSCALE button is clicked
-                            upscale_btn.click(upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, selected_tab, upscaling_resize, upscaling_resize_w, upscaling_resize_h, upscaling_crop, extras_upscaler_1, extras_upscaler_2, extras_upscaler_2_visibility, upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
+                    # with gr.Tab('Upscale V2') as ncnn_upscale_tab:
+                    with gr.Row(variant='compact') as ncnn_upload_vid_stats_row:
+                        # Non interactive textbox showing uploaded input vid total Frame Count
+                        ncnn_upscale_in_vid_frame_count_window = gr.Textbox(label="In Frame Count", lines=1, interactive=False, value='---')
+                        # Non interactive textbox showing uploaded input vid FPS
+                        ncnn_upscale_in_vid_fps_ui_window = gr.Textbox(label="In FPS", lines=1, interactive=False, value='---')
+                        # Non interactive textbox showing uploaded input resolution
+                        ncnn_upscale_in_vid_res = gr.Textbox(label="In Res", lines=1, interactive=False, value='---')
+                        # Non interactive textbox showing expected output resolution
+                        ncnn_upscale_out_vid_res = gr.Textbox(label="Out Res", value='---')
+                    with gr.Column():
+                        with gr.Row(variant='compact', visible=True) as ncnn_actual_upscale_row:
+                            ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = "realesr-animevideov3", type="value")
+                            ncnn_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value="x2", type="value")
+                            ncnn_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=True, interactive=True) # fix value
+                    ncnn_upscale_btn = gr.Button(value="*Upscale uploaded video*")
+                    ncnn_upscale_btn.click(ncnn_upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, ncnn_upscale_in_vid_fps_ui_window, ncnn_upscale_in_vid_res, ncnn_upscale_out_vid_res, ncnn_upscale_model, ncnn_upscale_factor, ncnn_upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
+                    # with gr.Tab('Upscale V1'):
+                    with gr.Column(visible=False): # Disabled 06-03-23
+                        selected_tab = gr.State(value=0)
+                        with gr.Tabs(elem_id="extras_resize_mode"):
+                            with gr.TabItem('Scale by', elem_id="extras_scale_by_tab") as tab_scale_by:
+                                upscaling_resize = gr.Slider(minimum=1.0, maximum=8.0, step=0.05, label="Resize", value=2, elem_id="extras_upscaling_resize")
+                            with gr.TabItem('Scale to', elem_id="extras_scale_to_tab") as tab_scale_to:
+                                with FormRow():
+                                    upscaling_resize_w = gr.Slider(label="Width", minimum=1, maximum=7680, step=1, value=512, elem_id="extras_upscaling_resize_w")
+                                    upscaling_resize_h = gr.Slider(label="Height", minimum=1, maximum=7680, step=1, value=512, elem_id="extras_upscaling_resize_h")
+                                    upscaling_crop = gr.Checkbox(label='Crop to fit', value=True, elem_id="extras_upscaling_crop")
+                        with FormRow():
+                            extras_upscaler_1 = gr.Dropdown(label='Upscaler 1', elem_id="extras_upscaler_1", choices=[x.name for x in sh.sd_upscalers], value=sh.sd_upscalers[3].name)
+                            extras_upscaler_2 = gr.Dropdown(label='Upscaler 2', elem_id="extras_upscaler_2", choices=[x.name for x in sh.sd_upscalers], value=sh.sd_upscalers[0].name)
+                        with FormRow():
+                            with gr.Column(scale=3):
+                                extras_upscaler_2_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Upscaler 2 visibility", value=0.0, elem_id="extras_upscaler_2_visibility")
+                            with gr.Column(scale=1, min_width=80):
+                                upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", elem_id="upscale_keep_imgs", value=True, interactive=True)
+                        tab_scale_by.select(fn=lambda: 0, inputs=[], outputs=[selected_tab])
+                        tab_scale_to.select(fn=lambda: 1, inputs=[], outputs=[selected_tab])
+                        # This is the actual button that's pressed to initiate the Upscaling:
+                        upscale_btn = gr.Button(value="*Upscale uploaded video*")
+                        # Show a text about CLI outputs:
+                        gr.HTML("* check your CLI for outputs")
+                        # make the function call when the UPSCALE button is clicked
+                        upscale_btn.click(upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, selected_tab, upscaling_resize, upscaling_resize_w, upscaling_resize_h, upscaling_crop, extras_upscaler_1, extras_upscaler_2, extras_upscaler_2_visibility, upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
                     # Vid2Depth TAB
             with gr.Tab('Vid2depth'):
                 vid_to_depth_chosen_file = gr.File(label="Video to get Depth from", interactive=True, file_count="single", file_types=["video"], elem_id="vid_to_depth_chosen_file")

--- a/scripts/deforum_helpers/frame_interpolation.py
+++ b/scripts/deforum_helpers/frame_interpolation.py
@@ -4,6 +4,7 @@ from rife.inference_video import run_rife_new_video_infer
 from .video_audio_utilities import get_quick_vid_info, vid2frames, media_file_has_audio, extract_number, ffmpeg_stitch_video
 from film_interpolation.film_inference import run_film_interp_infer
 from .general_utils import duplicate_pngs_from_folder, checksum, convert_images_from_list
+from modules.shared import opts
 
 # gets 'RIFE v4.3', returns: 'RIFE43'   
 def extract_rife_name(string):
@@ -23,8 +24,6 @@ def set_interp_out_fps(interp_x, slow_x_enabled, slom_x, in_vid_fps):
     if interp_x == 'Disabled' or in_vid_fps in ('---', None, '', 'None'):
         return '---'
 
-    # clean_interp_x = extract_number(interp_x)
-    # clean_slom_x = extract_number(slom_x)
     fps = float(in_vid_fps) * int(interp_x)
     # if slom_x != -1:
     if slow_x_enabled:
@@ -46,10 +45,11 @@ def process_interp_vid_upload_logic(file, engine, x_am, sl_enabled, sl_am, keep_
 
     _, _, resolution = get_quick_vid_info(file.name)
     folder_name = clean_folder_name(Path(vid_file_name).stem)
-    outdir_no_tmp = os.path.join(os.getcwd(), 'outputs', 'frame-interpolation', folder_name)
+    outdir = opts.outdir_samples or os.path.join(os.getcwd(), 'outputs')
+    outdir_no_tmp = outdir + f'/frame-interpolation/{folder_name}'
     i = 1
     while os.path.exists(outdir_no_tmp):
-        outdir_no_tmp = os.path.join(os.getcwd(), 'outputs', 'frame-interpolation', folder_name + '_' + str(i))
+        outdir_no_tmp = f"{outdir}/frame-interpolation/{folder_name}_{i}"
         i += 1
 
     outdir = os.path.join(outdir_no_tmp, 'tmp_input_frames')

--- a/scripts/deforum_helpers/upscaling.py
+++ b/scripts/deforum_helpers/upscaling.py
@@ -17,16 +17,18 @@ from basicsr.utils.download_util import load_file_from_url
 from .rich import console
 import time
 import subprocess
+from modules.shared import opts
 
 def process_upscale_vid_upload_logic(file, selected_tab, upscaling_resize, upscaling_resize_w, upscaling_resize_h, upscaling_crop, extras_upscaler_1, extras_upscaler_2, extras_upscaler_2_visibility, vid_file_name, keep_imgs, f_location, f_crf, f_preset):
     print("Got a request to *upscale* an existing video.")
-
+    
     in_vid_fps, _, _ = get_quick_vid_info(file.name)
     folder_name = clean_folder_name(Path(vid_file_name).stem)
-    outdir_no_tmp = os.path.join(os.getcwd(), 'outputs', 'frame-upscaling', folder_name)
+    outdir = opts.outdir_samples or os.path.join(os.getcwd(), 'outputs')
+    outdir_no_tmp = outdir + f'/frame-upscaling/{folder_name}'
     i = 1
     while os.path.exists(outdir_no_tmp):
-        outdir_no_tmp = os.path.join(os.getcwd(), 'outputs', 'frame-upscaling', folder_name + '_' + str(i))
+        outdir_no_tmp = f"{outdir}/frame-upscaling/{folder_name}_{i}"
         i += 1
 
     outdir = os.path.join(outdir_no_tmp, 'tmp_input_frames')
@@ -125,10 +127,11 @@ def process_ncnn_upscale_vid_upload_logic(vid_path, in_vid_fps, in_vid_res, out_
     print(f"Got a request to *upscale* a video using {upscale_model} at {upscale_factor}")
 
     folder_name = clean_folder_name(Path(vid_path.orig_name).stem)
-    outdir_no_tmp = os.path.join(os.getcwd(), 'outputs', 'frame-upscaling', folder_name)
+    outdir = opts.outdir_samples or os.path.join(os.getcwd(), 'outputs')
+    outdir_no_tmp = outdir + f'/frame-upscaling/{folder_name}'
     i = 1
     while os.path.exists(outdir_no_tmp):
-        outdir_no_tmp = os.path.join(os.getcwd(), 'outputs', 'frame-upscaling', folder_name + '_' + str(i))
+        outdir_no_tmp = f"{outdir}/frame-upscaling/{folder_name}_{i}"
         i += 1
 
     outdir = os.path.join(outdir_no_tmp, 'tmp_input_frames')


### PR DESCRIPTION
Already in use for reg animation outputs. Fixed a bug for rundiffusion.com and generally is an improvement. 

+ Hide upscale v1 tab, as turns out it's not working currently. Don't think it should come back, but we'll see about that. Only hidden for now. Not deleted from code.