### PR TITLE
Fix missing prompts in save_settings_from_animation_run p1

### DIFF
--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -63,7 +63,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
     print(f"Saving animation frames to:\n{args.outdir}")
     
     # save settings.txt file for the current run
-    save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args)
+    save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args, animation_prompts)
 
     # resume from timestring
     if anim_args.resume_from_timestring:

--- a/scripts/deforum_helpers/render_modes.py
+++ b/scripts/deforum_helpers/render_modes.py
@@ -80,7 +80,7 @@ def render_interpolation(args, anim_args, video_args, parseq_args, loop_args, co
     print(f"Saving interpolation animation frames to {args.outdir}")
 
     # save settings.txt file for the current run
-    save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args)
+    save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args, animation_prompts)
         
     # Compute interpolated prompts
     if use_parseq and keys.manages_prompts():

--- a/scripts/deforum_helpers/settings.py
+++ b/scripts/deforum_helpers/settings.py
@@ -47,7 +47,8 @@ def load_args(args_dict,anim_args_dict, parseq_args_dict, loop_args_dict, contro
             print(parseq_args_dict)
             print(loop_args_dict)
 
-def save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args):
+def save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args, animation_prompts):
+    args.__dict__["prompts"] = animation_prompts
     exclude_keys = get_keys_to_exclude()
     settings_filename = os.path.join(args.outdir, f"{args.timestring}_settings.txt")
     with open(settings_filename, "w+", encoding="utf-8") as f:


### PR DESCRIPTION
EDIT: after checking, those negative and positive prompts params were never saved in the setting file that is auto-saved when one is generating an animation. They were only saved when clicking the save setting button, and it still works like this today .
I will fix it, but it's not related to the Merge settings PR, unlike the missing animation_prompts that's fixed in this PR. 

Seems positive prompt and negative prompt "static" params aren't saved, will fix in a diff pr. 