### PR TITLE
Add saving of pos and neg prompts to anim_run sett file

### DIFF
--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -1121,6 +1121,8 @@ def process_args(args_dict_main):
     for key in root.animation_prompts:
         animationPromptCurr = root.animation_prompts[key]
         root.animation_prompts[key] = f"{positive_prompts} {animationPromptCurr} {'' if '--neg' in animationPromptCurr else '--neg'} {negative_prompts}"
+    root.positive_prompts = positive_prompts
+    root.negative_prompts = negative_prompts
     from deforum_helpers.settings import load_args
     
     if override_settings_with_file:

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -63,7 +63,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
     print(f"Saving animation frames to:\n{args.outdir}")
     
     # save settings.txt file for the current run
-    save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args, animation_prompts)
+    save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args, root)
 
     # resume from timestring
     if anim_args.resume_from_timestring:

--- a/scripts/deforum_helpers/render_modes.py
+++ b/scripts/deforum_helpers/render_modes.py
@@ -80,7 +80,7 @@ def render_interpolation(args, anim_args, video_args, parseq_args, loop_args, co
     print(f"Saving interpolation animation frames to {args.outdir}")
 
     # save settings.txt file for the current run
-    save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args, animation_prompts)
+    save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args, root)
         
     # Compute interpolated prompts
     if use_parseq and keys.manages_prompts():

--- a/scripts/deforum_helpers/settings.py
+++ b/scripts/deforum_helpers/settings.py
@@ -47,8 +47,10 @@ def load_args(args_dict,anim_args_dict, parseq_args_dict, loop_args_dict, contro
             print(parseq_args_dict)
             print(loop_args_dict)
 
-def save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args, animation_prompts):
-    args.__dict__["prompts"] = animation_prompts
+def save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args, root):
+    args.__dict__["prompts"] = root.animation_prompts
+    args.__dict__["positive_prompts"] = root.positive_prompts
+    args.__dict__["negative_prompts"] = root.negative_prompts
     exclude_keys = get_keys_to_exclude()
     settings_filename = os.path.join(args.outdir, f"{args.timestring}_settings.txt")
     with open(settings_filename, "w+", encoding="utf-8") as f:


### PR DESCRIPTION
They were missing since day 1 when they were added. Only existed in the setting file upon manually clicking the save settings button. 

Now they also appear in the auto-saved sett file with each animation run.