### PR TITLE
Add option to auto delete imgs after successful video/gif/upscale/interp creations + rename skip video for run all --> skip video creation

### DIFF
--- a/javascript/deforum-hints.js
+++ b/javascript/deforum-hints.js
@@ -116,7 +116,7 @@ deforum_titles = {
     "Resume timestring": "the required timestamp to reference when resuming. Currently only available in 2D & 3D mode, the timestamp is saved as the settings .txt file name as well as images produced during your previous run. The format follows: yyyymmddhhmmss - a timestamp of when the run was started to diffuse.",
 	
     //Video Output
-    "Skip video for run all": "when checked, do not output a video",
+    "Skip video creation": "when checked, do not output a video",
 	"Make GIF": "create a gif in addition to .mp4 file. supports up to 30 fps, will self-disable at higher fps values",
 	"Upscale":"upscale the images of the next run once it's finished + make a video out of them",
 	"Upscale model":"model of the upscaler to use. 'realesr-animevideov3' is much faster but yields smoother, less detailed results. the other models only do x4",

--- a/javascript/deforum-hints.js
+++ b/javascript/deforum-hints.js
@@ -136,6 +136,7 @@ deforum_titles = {
     //"path_name_modifier": "",
     "Image path": "the location of images to create the video from, when use_manual_settings is checked",
     "MP4 path": "the output location of the mp4 file, when use_manual_settings is checked",
+	"Delete Imgs": "if enabled, raw imgs will be deleted after a successful video/ videos (upsacling, interpolation, gif) creation",
 	"Engine": "choose the frame interpolation engine and version",
 	"Interp X":"how many times to interpolate the source video. e.g source video fps of 12 and a value of x2 will yield a 24fps interpolated video",
 	"Slow-Mo X":"how many times to slow-down the video. *Naturally affects output fps as well",

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -104,10 +104,10 @@ def run_deforum(*args, **kwargs):
 
     # Decide whether or not we need to try and frame interpolate laters
     need_to_frame_interpolate = False
-    if video_args.frame_interpolation_engine != "None" and not video_args.skip_video_for_run_all and not video_args.store_frames_in_ram:
+    if video_args.frame_interpolation_engine != "None" and not video_args.skip_video_creation and not video_args.store_frames_in_ram:
         need_to_frame_interpolate = True
         
-    if video_args.skip_video_for_run_all:
+    if video_args.skip_video_creation:
         print("\nSkipping video creation, uncheck 'Skip video for run all' in 'Output' tab if you want to get a video too :)")
     else:
         import subprocess
@@ -151,11 +151,11 @@ def run_deforum(*args, **kwargs):
         print(f"Got a request to *frame interpolate* using {video_args.frame_interpolation_engine}")
         process_video_interpolation(frame_interpolation_engine=video_args.frame_interpolation_engine, frame_interpolation_x_amount=video_args.frame_interpolation_x_amount,frame_interpolation_slow_mo_enabled=video_args.frame_interpolation_slow_mo_enabled, frame_interpolation_slow_mo_amount=video_args.frame_interpolation_slow_mo_amount, orig_vid_fps=video_args.fps, deforum_models_path=root.models_path, real_audio_track=real_audio_track, raw_output_imgs_path=args.outdir, img_batch_id=args.timestring, ffmpeg_location=video_args.ffmpeg_location, ffmpeg_crf=video_args.ffmpeg_crf, ffmpeg_preset=video_args.ffmpeg_preset, keep_interp_imgs=video_args.frame_interpolation_keep_imgs, orig_vid_name=None, resolution=None)
     
-    if video_args.make_gif and not video_args.skip_video_for_run_all and not video_args.store_frames_in_ram:
+    if video_args.make_gif and not video_args.skip_video_creation and not video_args.store_frames_in_ram:
         make_gifski_gif(imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, models_folder = root.models_path, current_user_os = root.current_user_os)
     
     # Upscale video once generation is done:
-    if video_args.r_upscale_video and not video_args.skip_video_for_run_all and not video_args.store_frames_in_ram:
+    if video_args.r_upscale_video and not video_args.skip_video_creation and not video_args.store_frames_in_ram:
         
         # out mp4 path is defined in make_upscale func
         make_upscale_v2(upscale_factor = video_args.r_upscale_factor, upscale_model = video_args.r_upscale_model, keep_imgs = video_args.r_upscale_keep_imgs, imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, deforum_models_path = root.models_path, current_user_os = root.current_user_os, ffmpeg_location=video_args.ffmpeg_location, stitch_from_frame=0, stitch_to_frame=max_video_frames, ffmpeg_crf=video_args.ffmpeg_crf, ffmpeg_preset=video_args.ffmpeg_preset, add_soundtrack = video_args.add_soundtrack ,audio_path=real_audio_track)

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -163,7 +163,7 @@ def run_deforum(*args, **kwargs):
         make_upscale_v2(upscale_factor = video_args.r_upscale_factor, upscale_model = video_args.r_upscale_model, keep_imgs = video_args.r_upscale_keep_imgs, imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, deforum_models_path = root.models_path, current_user_os = root.current_user_os, ffmpeg_location=video_args.ffmpeg_location, stitch_from_frame=0, stitch_to_frame=max_video_frames, ffmpeg_crf=video_args.ffmpeg_crf, ffmpeg_preset=video_args.ffmpeg_preset, add_soundtrack = video_args.add_soundtrack ,audio_path=real_audio_track)
         
     if video_args.delete_imgs and not video_args.skip_video_creation:
-        handle_imgs_deletion(vid_path=mp4_path, imgs_folder_path=args.outdir, run_id=args.timestring)
+        handle_imgs_deletion(vid_path=mp4_path, imgs_folder_path=args.outdir, batch_id=args.timestring)
         
     root.initial_info += "\n The animation is stored in " + args.outdir
     root.initial_info += "\n Timestring = " + args.timestring + '\n'

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -26,7 +26,7 @@ import json
 
 from modules.processing import Processed, StableDiffusionProcessingImg2Img, process_images
 from PIL import Image
-from deforum_helpers.video_audio_utilities import ffmpeg_stitch_video, make_gifski_gif
+from deforum_helpers.video_audio_utilities import ffmpeg_stitch_video, make_gifski_gif, handle_imgs_deletion
 from deforum_helpers.upscaling import make_upscale_v2
 import gc
 import torch
@@ -159,6 +159,9 @@ def run_deforum(*args, **kwargs):
         
         # out mp4 path is defined in make_upscale func
         make_upscale_v2(upscale_factor = video_args.r_upscale_factor, upscale_model = video_args.r_upscale_model, keep_imgs = video_args.r_upscale_keep_imgs, imgs_raw_path = args.outdir, imgs_batch_id = args.timestring, fps = video_args.fps, deforum_models_path = root.models_path, current_user_os = root.current_user_os, ffmpeg_location=video_args.ffmpeg_location, stitch_from_frame=0, stitch_to_frame=max_video_frames, ffmpeg_crf=video_args.ffmpeg_crf, ffmpeg_preset=video_args.ffmpeg_preset, add_soundtrack = video_args.add_soundtrack ,audio_path=real_audio_track)
+        
+    if video_args.delete_imgs and not video_args.skip_video_creation:
+        handle_imgs_deletion(vid_path=mp4_path, imgs_folder_path=args.outdir, run_id=args.timestring)
         
     root.initial_info += "\n The animation is stored in " + args.outdir
     root.initial_info += "\n Timestring = " + args.timestring + '\n'

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -252,7 +252,7 @@ def ParseqArgs():
     return locals()
     
 def DeforumOutputArgs():
-    skip_video_for_run_all = False
+    skip_video_creation = False
     fps = 15 
     make_gif = False
     delete_imgs = False # True will delete all imgs after a successful mp4 creation
@@ -758,7 +758,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         add_soundtrack = gr.Radio(['None', 'File', 'Init Video'], label="Add soundtrack", value=dv.add_soundtrack)
                         soundtrack_path = gr.Textbox(label="Soundtrack path", lines=1, interactive=True, value = dv.soundtrack_path)
                     with gr.Row(variant='compact'):
-                        skip_video_for_run_all = gr.Checkbox(label="Skip video creation", value=dv.skip_video_for_run_all, interactive=True)
+                        skip_video_creation = gr.Checkbox(label="Skip video creation", value=dv.skip_video_creation, interactive=True)
                         store_frames_in_ram = gr.Checkbox(label="Store frames in ram", value=dv.store_frames_in_ram, interactive=True)
                         save_depth_maps = gr.Checkbox(label="Save depth maps", value=da.save_depth_maps, interactive=True)
                         # the following param only shows for windows and linux users!
@@ -975,9 +975,9 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
     seed_behavior.change(fn=change_seed_schedule_visibility, inputs=seed_behavior, outputs=seed_schedule_row)
     color_coherence.change(fn=change_color_coherence_video_every_N_frames_visibility, inputs=color_coherence, outputs=color_coherence_video_every_N_frames_row)
     noise_type.change(fn=change_perlin_visibility, inputs=noise_type, outputs=perlin_row)
-    skip_video_for_run_all_outputs = [fps_out_format_row, soundtrack_row, ffmpeg_quality_accordion, store_frames_in_ram, make_gif, r_upscale_row]
-    for output in skip_video_for_run_all_outputs:
-        skip_video_for_run_all.change(fn=change_visibility_from_skip_video, inputs=skip_video_for_run_all, outputs=output)  
+    skip_video_creation_outputs = [fps_out_format_row, soundtrack_row, ffmpeg_quality_accordion, store_frames_in_ram, make_gif, r_upscale_row]
+    for output in skip_video_creation_outputs:
+        skip_video_creation.change(fn=change_visibility_from_skip_video, inputs=skip_video_creation, outputs=output)  
     frame_interpolation_slow_mo_enabled.change(fn=hide_slow_mo,inputs=frame_interpolation_slow_mo_enabled,outputs=frame_interp_slow_mo_amount_column)
     frame_interpolation_engine.change(fn=change_interp_x_max_limit,inputs=[frame_interpolation_engine,frame_interpolation_x_amount],outputs=frame_interpolation_x_amount)
     [change_fn.change(set_interp_out_fps, inputs=[frame_interpolation_x_amount, frame_interpolation_slow_mo_enabled, frame_interpolation_slow_mo_amount, in_vid_fps_ui_window], outputs=out_interp_vid_estimated_fps) for change_fn in [frame_interpolation_x_amount, frame_interpolation_slow_mo_amount, frame_interpolation_slow_mo_enabled]]
@@ -1048,7 +1048,7 @@ args_names =    str(r'''W, H, tiling, restore_faces,
                         fill, full_res_mask, full_res_mask_padding,
                         reroll_blank_frames'''
                     ).replace("\n", "").replace("\r", "").replace(" ", "").split(',')
-video_args_names =  str(r'''skip_video_for_run_all,
+video_args_names =  str(r'''skip_video_creation,
                             fps, make_gif, delete_imgs, output_format, ffmpeg_location, ffmpeg_crf, ffmpeg_preset,
                             add_soundtrack, soundtrack_path,
                             r_upscale_video, r_upscale_model, r_upscale_factor, r_upscale_keep_imgs,

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -255,6 +255,7 @@ def DeforumOutputArgs():
     skip_video_for_run_all = False
     fps = 15 
     make_gif = False
+    delete_imgs = False # True will delete all imgs after a successful mp4 creation
     image_path = "C:/SD/20230124234916_%09d.png" 
     mp4_path = "testvidmanualsettings.mp4" 
     ffmpeg_location = find_ffmpeg_binary()
@@ -762,6 +763,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         save_depth_maps = gr.Checkbox(label="Save depth maps", value=da.save_depth_maps, interactive=True)
                         # the following param only shows for windows and linux users!
                         make_gif = gr.Checkbox(label="Make GIF", value=dv.make_gif, interactive=True)
+                        delete_imgs = gr.Checkbox(label="Del Imgs", value=dv.delete_imgs, interactive=True)
                 with gr.Row(equal_height=True, variant='compact', visible=True) as r_upscale_row:
                     r_upscale_video = gr.Checkbox(label="Upscale", value=dv.r_upscale_video, interactive=True)
                     r_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
@@ -1047,7 +1049,7 @@ args_names =    str(r'''W, H, tiling, restore_faces,
                         reroll_blank_frames'''
                     ).replace("\n", "").replace("\r", "").replace(" ", "").split(',')
 video_args_names =  str(r'''skip_video_for_run_all,
-                            fps, make_gif, output_format, ffmpeg_location, ffmpeg_crf, ffmpeg_preset,
+                            fps, make_gif, delete_imgs, output_format, ffmpeg_location, ffmpeg_crf, ffmpeg_preset,
                             add_soundtrack, soundtrack_path,
                             r_upscale_video, r_upscale_model, r_upscale_factor, r_upscale_keep_imgs,
                             render_steps,

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -759,11 +759,11 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         soundtrack_path = gr.Textbox(label="Soundtrack path", lines=1, interactive=True, value = dv.soundtrack_path)
                     with gr.Row(variant='compact'):
                         skip_video_creation = gr.Checkbox(label="Skip video creation", value=dv.skip_video_creation, interactive=True)
+                        delete_imgs = gr.Checkbox(label="Delete Imgs", value=dv.delete_imgs, interactive=True)
                         store_frames_in_ram = gr.Checkbox(label="Store frames in ram", value=dv.store_frames_in_ram, interactive=True)
                         save_depth_maps = gr.Checkbox(label="Save depth maps", value=da.save_depth_maps, interactive=True)
                         # the following param only shows for windows and linux users!
                         make_gif = gr.Checkbox(label="Make GIF", value=dv.make_gif, interactive=True)
-                        delete_imgs = gr.Checkbox(label="Del Imgs", value=dv.delete_imgs, interactive=True)
                 with gr.Row(equal_height=True, variant='compact', visible=True) as r_upscale_row:
                     r_upscale_video = gr.Checkbox(label="Upscale", value=dv.r_upscale_video, interactive=True)
                     r_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
@@ -975,7 +975,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
     seed_behavior.change(fn=change_seed_schedule_visibility, inputs=seed_behavior, outputs=seed_schedule_row)
     color_coherence.change(fn=change_color_coherence_video_every_N_frames_visibility, inputs=color_coherence, outputs=color_coherence_video_every_N_frames_row)
     noise_type.change(fn=change_perlin_visibility, inputs=noise_type, outputs=perlin_row)
-    skip_video_creation_outputs = [fps_out_format_row, soundtrack_row, ffmpeg_quality_accordion, store_frames_in_ram, make_gif, r_upscale_row]
+    skip_video_creation_outputs = [fps_out_format_row, soundtrack_row, ffmpeg_quality_accordion, store_frames_in_ram, make_gif, r_upscale_row, delete_imgs]
     for output in skip_video_creation_outputs:
         skip_video_creation.change(fn=change_visibility_from_skip_video, inputs=skip_video_creation, outputs=output)  
     frame_interpolation_slow_mo_enabled.change(fn=hide_slow_mo,inputs=frame_interpolation_slow_mo_enabled,outputs=frame_interp_slow_mo_amount_column)

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -758,7 +758,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         add_soundtrack = gr.Radio(['None', 'File', 'Init Video'], label="Add soundtrack", value=dv.add_soundtrack)
                         soundtrack_path = gr.Textbox(label="Soundtrack path", lines=1, interactive=True, value = dv.soundtrack_path)
                     with gr.Row(variant='compact'):
-                        skip_video_for_run_all = gr.Checkbox(label="Skip video for run all", value=dv.skip_video_for_run_all, interactive=True)
+                        skip_video_for_run_all = gr.Checkbox(label="Skip video creation", value=dv.skip_video_for_run_all, interactive=True)
                         store_frames_in_ram = gr.Checkbox(label="Store frames in ram", value=dv.store_frames_in_ram, interactive=True)
                         save_depth_maps = gr.Checkbox(label="Save depth maps", value=da.save_depth_maps, interactive=True)
                         # the following param only shows for windows and linux users!

--- a/scripts/deforum_helpers/deprecation_utils.py
+++ b/scripts/deforum_helpers/deprecation_utils.py
@@ -2,12 +2,10 @@
 # and print a message containing the old and the new names
 # if the latter is removed completely, put a warning
 
-# as of 2023-02-05
-# "histogram_matching" -> None
-
 deprecation_map = {
     "histogram_matching": None,
-    "flip_2d_perspective": "enable_perspective_flip"
+    "flip_2d_perspective": "enable_perspective_flip",
+    "skip_video_for_run_all": "skip_video_creation"    
 }
 
 def handle_deprecated_settings(settings_json):

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -303,3 +303,27 @@ def make_gifski_gif(imgs_raw_path, imgs_batch_id, fps, models_folder, current_us
         print("\r" + " " * len(msg_to_print), end="", flush=True)
         print(f"\r{msg_to_print}", flush=True)
         print(f"GIF stitching *failed* with error:\n{e}")
+        
+def handle_imgs_deletion(vid_path=None, imgs_folder_path=None, run_id=None):
+    try:
+        total_imgs_to_delete = count_matching_frames(imgs_folder_path, run_id)
+        if total_imgs_to_delete is None or total_imgs_to_delete == 0:
+            return
+        print("Deleting raw images, as requested:")
+        _, fcount, _ = get_quick_vid_info(vid_path)
+        if fcount == total_imgs_to_delete:
+            total_imgs_deleted = delete_matching_frames(imgs_folder_path, run_id)
+            print(f"Deleted {total_imgs_deleted} out of {total_imgs_to_delete} imgs!")
+        else:
+            print("Did not delete imgs as there was a mismatch between # of frames in folder, and # of frames in actual video. Please check and delete manually. ")
+    except Exception as e:
+        print(f"Error deleting raw images. Please delete them manually if you want. Actual error:\n{e}")
+    
+def delete_matching_frames(from_folder, img_batch_id):
+    return sum(1 for f in os.listdir(from_folder) if get_matching_frame(f, img_batch_id) and os.remove(os.path.join(from_folder, f)) is None)
+    
+def count_matching_frames(from_folder, img_batch_id):
+    return sum(1 for f in os.listdir(from_folder) if get_matching_frame(f, img_batch_id))
+
+def get_matching_frame(f, img_batch_id=None):
+    return ('png' in f or 'jpg' in f) and '-' not in f and '_depth_' not in f and ((img_batch_id is not None and f.startswith(img_batch_id) or img_batch_id is None))

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -304,15 +304,15 @@ def make_gifski_gif(imgs_raw_path, imgs_batch_id, fps, models_folder, current_us
         print(f"\r{msg_to_print}", flush=True)
         print(f"GIF stitching *failed* with error:\n{e}")
         
-def handle_imgs_deletion(vid_path=None, imgs_folder_path=None, run_id=None):
+def handle_imgs_deletion(vid_path=None, imgs_folder_path=None, batch_id=None):
     try:
-        total_imgs_to_delete = count_matching_frames(imgs_folder_path, run_id)
+        total_imgs_to_delete = count_matching_frames(imgs_folder_path, batch_id)
         if total_imgs_to_delete is None or total_imgs_to_delete == 0:
             return
         print("Deleting raw images, as requested:")
         _, fcount, _ = get_quick_vid_info(vid_path)
         if fcount == total_imgs_to_delete:
-            total_imgs_deleted = delete_matching_frames(imgs_folder_path, run_id)
+            total_imgs_deleted = delete_matching_frames(imgs_folder_path, batch_id)
             print(f"Deleted {total_imgs_deleted} out of {total_imgs_to_delete} imgs!")
         else:
             print("Did not delete imgs as there was a mismatch between # of frames in folder, and # of frames in actual video. Please check and delete manually. ")


### PR DESCRIPTION
New option in output tab: 
![image](https://user-images.githubusercontent.com/121192995/223883227-2be50e46-54e5-44e2-bbd0-f91d4fb6bf76.png)

if enabled (and assuming skip video creation is NOT checked), at the very end of the run, after vid creation, interpolation, gif creation etc, it will delete the raw images of the run:
- Checks # of raw frames, and compares them to the actual # of frames in the output .mp4 video. 
- Only if they match, imgs will get deleted. Otherwise a clear message will be printed. 
*** Depth maps imgs are not deleted, as we don't make a video out of them for now. 

How it looks in CLI:
![image](https://user-images.githubusercontent.com/121192995/223883802-a2774889-8187-483b-b159-0f944f12a422.png)

Additionaly, I renamed `skip_video_for_running_all` to `skip_video_creation`. Added the required change in deprecation_utils.py too. 
