### PR TITLE
Use only one mask preset in mask composition, fix video masks not moving

### DIFF
--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -17,7 +17,7 @@ def Root():
     device = sh.device
     models_path = ph.models_path + '/Deforum'
     half_precision = not cmd_opts.no_half
-    mask_preset_names = ['everywhere','init_mask','video_mask']
+    mask_preset_names = ['everywhere','video_mask']
     p = None
     frames_cache = []
     initial_seed = None
@@ -71,8 +71,8 @@ def DeforumAnimArgs():
     sampler_schedule = '0: ("Euler a")'
     # Composable mask scheduling
     use_noise_mask = False
-    mask_schedule = '0: ("!({everywhere}^({init_mask}|{video_mask}) ) ")'
-    noise_mask_schedule = '0: ("!({everywhere}^({init_mask}|{video_mask}) ) ")'
+    mask_schedule = '0: ("{video_mask}")'
+    noise_mask_schedule = '0: ("{video_mask}")'
     # Checkpoint Scheduling
     enable_checkpoint_scheduling = False
     checkpoint_schedule = '0: ("model1.ckpt"), 100: ("model2.ckpt")'
@@ -574,7 +574,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         <ul style="list-style-type:circle; margin-left:0.75em; margin-bottom:0.2em">
                         <li>To enable, check use_mask in the Init tab</li>
                         <li>Supports boolean operations: (! - negation, & - and, | - or, ^ - xor, \ - difference, () - nested operations)</li>
-                        <li>default variables: in \{\}, like \{init_mask\}, \{video_mask\}, \{everywhere\}</li>
+                        <li>default variables: in \{\}, like \{video_mask\}, \{everywhere\}</li>
                         <li>masks from files: in [], like [mask1.png]</li>
                         <li>description-based: <i>word masks</i> in &lt;&gt;, like &lt;apple&gt;, &lt;hair&gt</li>
                         </ul>

--- a/scripts/deforum_helpers/composable_masks.py
+++ b/scripts/deforum_helpers/composable_masks.py
@@ -1,6 +1,5 @@
 # At the moment there are three types of masks: mask from variable, file mask and word mask
-# Variable masks include init_mask for the predefined whole-video mask, frame_mask from video-masking system
-# and human_mask for a model which better segments people in the background video
+# Variable masks include video_mask (which can be set to auto-generated human masks) and everywhere
 # They are put in {}-brackets
 # Word masks are framed with <>-bracets, like: <cat>, <anime girl>
 # File masks are put in []-brackes

--- a/scripts/deforum_helpers/generate.py
+++ b/scripts/deforum_helpers/generate.py
@@ -188,13 +188,19 @@ def generate(args, keys, anim_args, loop_args, controlnet_args, root, frame = 0,
     if processed is None:
         # Mask functions
         if args.use_mask:
-            mask = args.mask_image
-            #assign masking options to pipeline
-            if mask is not None:
-                p.inpainting_mask_invert = args.invert_mask
-                p.inpainting_fill = args.fill 
-                p.inpaint_full_res= args.full_res_mask 
-                p.inpaint_full_res_padding = args.full_res_mask_padding
+            mask = prepare_mask(args.mask_file if mask_image is None else mask_image, 
+                                (args.W, args.H),
+                                args.mask_contrast_adjust, 
+                                args.mask_brightness_adjust)
+            p.inpainting_mask_invert = args.invert_mask
+            p.inpainting_fill = args.fill 
+            p.inpaint_full_res= args.full_res_mask 
+            p.inpaint_full_res_padding = args.full_res_mask_padding
+            #prevent loaded mask from throwing errors in Image operations if completely black and crop and resize in webui pipeline
+            #doing this after contrast and brightness adjustments to ensure that mask is not passed as black or blank
+            mask = check_mask_for_errors(mask, args.invert_mask)
+            args.noise_mask = mask
+            
         else:
             mask = None
 

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -148,6 +148,10 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
     # Video mask overrides the init image mask, also, won't be searching for init_mask if use_mask_video is set
     # Made to solve https://github.com/deforum-art/deforum-for-automatic1111-webui/issues/386
     if anim_args.use_mask_video:
+
+        args.mask_file = get_mask_from_file(get_next_frame(args.outdir, anim_args.video_mask_path, frame_idx, True), args)
+        args.noise_mask = get_mask_from_file(get_next_frame(args.outdir, anim_args.video_mask_path, frame_idx, True), args)
+
         mask_vals['video_mask'] = get_mask_from_file(get_next_frame(args.outdir, anim_args.video_mask_path, frame_idx, True), args)
         noise_mask_vals['video_mask'] = get_mask_from_file(get_next_frame(args.outdir, anim_args.video_mask_path, frame_idx, True), args)
     elif mask_image is None and args.use_mask:
@@ -401,6 +405,9 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
             print(f"Using video init frame {init_frame}")
             args.init_image = init_frame
         if anim_args.use_mask_video:
+            args.mask_file = get_mask_from_file(get_next_frame(args.outdir, anim_args.video_mask_path, frame_idx, True), args)
+            args.noise_mask = get_mask_from_file(get_next_frame(args.outdir, anim_args.video_mask_path, frame_idx, True), args)
+
             mask_vals['video_mask'] = get_mask_from_file(get_next_frame(args.outdir, anim_args.video_mask_path, frame_idx, True), args)
 
         if args.use_mask:

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -161,7 +161,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
     #Webui
     state.job_count = anim_args.max_frames
     
-    while frame_idx < anim_args.max_frames:
+    while frame_idx < (anim_args.max_frames if not anim_args.use_mask_video else anim_args.max_frames - 1):
         #Webui
         state.job = f"frame {frame_idx + 1}/{anim_args.max_frames}"
         state.job_no = frame_idx + 1

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -147,20 +147,18 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
         _, mask_image = load_img(args.init_image, 
                                         shape=(args.W, args.H),  
                                         use_alpha_as_mask=args.use_alpha_as_mask)
-        mask_vals['init_mask'] = mask_image
-        noise_mask_vals['init_mask'] = mask_image
+        mask_vals['video_mask'] = mask_image
+        noise_mask_vals['video_mask'] = mask_image
     
-    # Grab the first frame masks since they wont be provided until next frame
-    if mask_image is None and args.use_mask:
-        mask_vals['init_mask'] = get_mask(args)
-        noise_mask_vals['init_mask'] = get_mask(args) # TODO?: add a different default noise mask
-
+    # Grab the first frame masks since they wont be provided until next frame    
+    # Video mask overrides the init image mask, also, won't be searching for init_mask if use_mask_video is set
+    # Made to solve https://github.com/deforum-art/deforum-for-automatic1111-webui/issues/386
     if anim_args.use_mask_video:
         mask_vals['video_mask'] = get_mask_from_file(get_next_frame(args.outdir, anim_args.video_mask_path, frame_idx, True), args)
         noise_mask_vals['video_mask'] = get_mask_from_file(get_next_frame(args.outdir, anim_args.video_mask_path, frame_idx, True), args)
-    else:
-        mask_vals['video_mask'] = None
-        noise_mask_vals['video_mask'] = None
+    elif mask_image is None and args.use_mask:
+        mask_vals['video_mask'] = get_mask(args)
+        noise_mask_vals['video_mask'] = get_mask(args) # TODO?: add a different default noisc mask
 
     #Webui
     state.job_count = anim_args.max_frames


### PR DESCRIPTION
Makes video_mask override init_mask

fixes "There is a bug where it is checking the mask_file path for no good reason, when it should only be using video masks" in #386