### PR TITLE
More vertical-compact Keyframes tab

### DIFF
--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -463,96 +463,97 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                     with gr.Row(variant='compact'):
                         clipskip_schedule = gr.Textbox(label="CLIP skip schedule", lines=1, value = da.clipskip_schedule, interactive=True)
             # MOTION INNER TAB
-            with gr.Tab('Motion') as motion_tab:
-                with gr.Column(visible=True) as only_2d_motion_column:
-                    with gr.Row(variant='compact'):
-                        zoom = gr.Textbox(label="Zoom", lines=1, value = da.zoom, interactive=True)
-                    with gr.Row(variant='compact'):
-                        angle = gr.Textbox(label="Angle", lines=1, value = da.angle, interactive=True)
-                    with gr.Row(variant='compact'):
-                        transform_center_x = gr.Textbox(label="Transform Center X", lines=1, value = da.transform_center_x, interactive=True)
-                    with gr.Row(variant='compact'):
-                        transform_center_y = gr.Textbox(label="Transform Center Y", lines=1, value = da.transform_center_y, interactive=True)
-                with gr.Column(visible=True) as both_anim_mode_motion_params_column:
-                    with gr.Row(variant='compact'):
-                        translation_x = gr.Textbox(label="Translation X", lines=1, value = da.translation_x, interactive=True)
-                    with gr.Row(variant='compact'):
-                        translation_y = gr.Textbox(label="Translation Y", lines=1, value = da.translation_y, interactive=True)
-                with gr.Column(visible=False) as only_3d_motion_column:
-                    with gr.Row(variant='compact'):
-                        translation_z = gr.Textbox(label="Translation Z", lines=1, value = da.translation_z, interactive=True)
-                    with gr.Row(variant='compact'):
-                        rotation_3d_x = gr.Textbox(label="Rotation 3D X", lines=1, value = da.rotation_3d_x, interactive=True)
-                    with gr.Row(variant='compact'):
-                        rotation_3d_y = gr.Textbox(label="Rotation 3D Y", lines=1, value = da.rotation_3d_y, interactive=True)
-                    with gr.Row(variant='compact'):
-                        rotation_3d_z = gr.Textbox(label="Rotation 3D Z", lines=1, value = da.rotation_3d_z, interactive=True)
-                # 3D DEPTH & FOV ACCORD
-                with gr.Accordion('Depth Warping & FOV', visible=False, open=False) as depth_3d_warping_accord:
-                    with gr.Tab('Depth Warping'): 
+            with gr.Tabs(elem_id='motion_noise_etc'):
+                with gr.TabItem('Motion') as motion_tab:
+                    with gr.Column(visible=True) as only_2d_motion_column:
                         with gr.Row(variant='compact'):
-                            use_depth_warping = gr.Checkbox(label="Use depth warping", value=da.use_depth_warping, interactive=True)
-                            midas_weight = gr.Number(label="MiDaS weight", value=da.midas_weight, interactive=True)
+                            zoom = gr.Textbox(label="Zoom", lines=1, value = da.zoom, interactive=True)
                         with gr.Row(variant='compact'):
-                            padding_mode = gr.Radio(['border', 'reflection', 'zeros'], label="Padding mode", value=da.padding_mode, elem_id="padding_mode")
-                            sampling_mode = gr.Radio(['bicubic', 'bilinear', 'nearest'], label="Sampling mode", value=da.sampling_mode, elem_id="sampling_mode")
-                    with gr.Tab('Field Of View', visible=False, open=False) as fov_accord:
+                            angle = gr.Textbox(label="Angle", lines=1, value = da.angle, interactive=True)
                         with gr.Row(variant='compact'):
-                            fov_schedule = gr.Textbox(label="FOV schedule", lines=1, value = da.fov_schedule, interactive=True)
+                            transform_center_x = gr.Textbox(label="Transform Center X", lines=1, value = da.transform_center_x, interactive=True)
                         with gr.Row(variant='compact'):
-                            aspect_ratio_schedule = gr.Textbox(label="Aspect Ratio schedule", lines=1, value = da.aspect_ratio_schedule, interactive=True)
+                            transform_center_y = gr.Textbox(label="Transform Center Y", lines=1, value = da.transform_center_y, interactive=True)
+                    with gr.Column(visible=True) as both_anim_mode_motion_params_column:
                         with gr.Row(variant='compact'):
-                            near_schedule = gr.Textbox(label="Near schedule", lines=1, value = da.near_schedule, interactive=True)
+                            translation_x = gr.Textbox(label="Translation X", lines=1, value = da.translation_x, interactive=True)
                         with gr.Row(variant='compact'):
-                            far_schedule = gr.Textbox(label="Far schedule", lines=1, value = da.far_schedule, interactive=True)
-                # PERSPECTIVE FLIP ACCORD
-                with gr.Accordion('Perspective Flip', open=False) as perspective_flip_accord:
+                            translation_y = gr.Textbox(label="Translation Y", lines=1, value = da.translation_y, interactive=True)
+                    with gr.Column(visible=False) as only_3d_motion_column:
+                        with gr.Row(variant='compact'):
+                            translation_z = gr.Textbox(label="Translation Z", lines=1, value = da.translation_z, interactive=True)
+                        with gr.Row(variant='compact'):
+                            rotation_3d_x = gr.Textbox(label="Rotation 3D X", lines=1, value = da.rotation_3d_x, interactive=True)
+                        with gr.Row(variant='compact'):
+                            rotation_3d_y = gr.Textbox(label="Rotation 3D Y", lines=1, value = da.rotation_3d_y, interactive=True)
+                        with gr.Row(variant='compact'):
+                            rotation_3d_z = gr.Textbox(label="Rotation 3D Z", lines=1, value = da.rotation_3d_z, interactive=True)
+                    # 3D DEPTH & FOV ACCORD
+                    with gr.Accordion('Depth Warping & FOV', visible=False, open=False) as depth_3d_warping_accord:
+                        with gr.TabItem('Depth Warping'): 
+                            with gr.Row(variant='compact'):
+                                use_depth_warping = gr.Checkbox(label="Use depth warping", value=da.use_depth_warping, interactive=True)
+                                midas_weight = gr.Number(label="MiDaS weight", value=da.midas_weight, interactive=True)
+                            with gr.Row(variant='compact'):
+                                padding_mode = gr.Radio(['border', 'reflection', 'zeros'], label="Padding mode", value=da.padding_mode, elem_id="padding_mode")
+                                sampling_mode = gr.Radio(['bicubic', 'bilinear', 'nearest'], label="Sampling mode", value=da.sampling_mode, elem_id="sampling_mode")
+                        with gr.TabItem('Field Of View', visible=False, open=False) as fov_accord:
+                            with gr.Row(variant='compact'):
+                                fov_schedule = gr.Textbox(label="FOV schedule", lines=1, value = da.fov_schedule, interactive=True)
+                            with gr.Row(variant='compact'):
+                                aspect_ratio_schedule = gr.Textbox(label="Aspect Ratio schedule", lines=1, value = da.aspect_ratio_schedule, interactive=True)
+                            with gr.Row(variant='compact'):
+                                near_schedule = gr.Textbox(label="Near schedule", lines=1, value = da.near_schedule, interactive=True)
+                            with gr.Row(variant='compact'):
+                                far_schedule = gr.Textbox(label="Far schedule", lines=1, value = da.far_schedule, interactive=True)
+                    # PERSPECTIVE FLIP ACCORD
+                    with gr.Accordion('Perspective Flip', open=False) as perspective_flip_accord:
+                        with gr.Row(variant='compact'):
+                            enable_perspective_flip = gr.Checkbox(label="Enable perspective flip", value=da.enable_perspective_flip, interactive=True)
+                        with gr.Row(variant='compact'):
+                            perspective_flip_theta = gr.Textbox(label="Perspective flip theta", lines=1, value = da.perspective_flip_theta, interactive=True)
+                        with gr.Row(variant='compact'):
+                            perspective_flip_phi = gr.Textbox(label="Perspective flip phi", lines=1, value = da.perspective_flip_phi, interactive=True)
+                        with gr.Row(variant='compact'):
+                            perspective_flip_gamma = gr.Textbox(label="Perspective flip gamma", lines=1, value = da.perspective_flip_gamma, interactive=True)
+                        with gr.Row(variant='compact'):
+                            perspective_flip_fv = gr.Textbox(label="Perspective flip fv", lines=1, value = da.perspective_flip_fv, interactive=True)
+                # NOISE INNER TAB
+                with gr.TabItem('Noise') as a8:
                     with gr.Row(variant='compact'):
-                        enable_perspective_flip = gr.Checkbox(label="Enable perspective flip", value=da.enable_perspective_flip, interactive=True)
+                        noise_type = gr.Radio(['uniform', 'perlin'], label="Noise type", value=da.noise_type, elem_id="noise_type")
                     with gr.Row(variant='compact'):
-                        perspective_flip_theta = gr.Textbox(label="Perspective flip theta", lines=1, value = da.perspective_flip_theta, interactive=True)
+                        noise_schedule = gr.Textbox(label="Noise schedule", lines=1, value = da.noise_schedule, interactive=True)
+                    with gr.Row(variant='compact') as perlin_row:
+                        with gr.Column(min_width=220):
+                            perlin_octaves = gr.Slider(label="Perlin octaves", minimum=1, maximum=7, value=da.perlin_octaves, step=1, interactive=True)
+                        with gr.Column(min_width=220):
+                            perlin_persistence = gr.Slider(label="Perlin persistence", minimum=0, maximum=1, value=da.perlin_persistence, step=0.02, interactive=True)
+                # COHERENCE INNER TAB
+                with gr.TabItem('Coherence', open=False) as coherence_accord:
                     with gr.Row(variant='compact'):
-                        perspective_flip_phi = gr.Textbox(label="Perspective flip phi", lines=1, value = da.perspective_flip_phi, interactive=True)
+                        # Future TODO: remove 'match frame 0' prefix (after we manage the deprecated-names settings import), then convert from Dropdown to Radio!
+                        color_coherence = gr.Dropdown(label="Color coherence", choices=['None', 'Match Frame 0 HSV', 'Match Frame 0 LAB', 'Match Frame 0 RGB', 'Video Input'], value=da.color_coherence, type="value", elem_id="color_coherence", interactive=True)
+                        # with gr.Column(variant='compact') as force_grayscale_column:
+                        color_force_grayscale = gr.Checkbox(label="Color force Grayscale", value=da.color_force_grayscale, interactive=True)
+                    with gr.Row(visible=False) as color_coherence_video_every_N_frames_row:
+                        color_coherence_video_every_N_frames = gr.Number(label="Color coherence video every N frames", value=1, interactive=True)
                     with gr.Row(variant='compact'):
-                        perspective_flip_gamma = gr.Textbox(label="Perspective flip gamma", lines=1, value = da.perspective_flip_gamma, interactive=True)
+                        contrast_schedule = gr.Textbox(label="Contrast schedule", lines=1, value = da.contrast_schedule, interactive=True)
+                        optical_flow_cadence = gr.Checkbox(label="Optical flow cadence", value=False, interactive=True, elem_id='optical_flow_cadence')
                     with gr.Row(variant='compact'):
-                        perspective_flip_fv = gr.Textbox(label="Perspective flip fv", lines=1, value = da.perspective_flip_fv, interactive=True)
-            # NOISE INNER TAB
-            with gr.Tab('Noise', open=True) as a8:
-                with gr.Row(variant='compact'):
-                    noise_type = gr.Radio(['uniform', 'perlin'], label="Noise type", value=da.noise_type, elem_id="noise_type")
-                with gr.Row(variant='compact'):
-                    noise_schedule = gr.Textbox(label="Noise schedule", lines=1, value = da.noise_schedule, interactive=True)
-                with gr.Row(variant='compact') as perlin_row:
-                    with gr.Column(min_width=220):
-                        perlin_octaves = gr.Slider(label="Perlin octaves", minimum=1, maximum=7, value=da.perlin_octaves, step=1, interactive=True)
-                    with gr.Column(min_width=220):
-                        perlin_persistence = gr.Slider(label="Perlin persistence", minimum=0, maximum=1, value=da.perlin_persistence, step=0.02, interactive=True)
-            # COHERENCE INNER TAB
-            with gr.Tab('Coherence', open=False) as coherence_accord:
-                with gr.Row(variant='compact'):
-                    # Future TODO: remove 'match frame 0' prefix (after we manage the deprecated-names settings import), then convert from Dropdown to Radio!
-                    color_coherence = gr.Dropdown(label="Color coherence", choices=['None', 'Match Frame 0 HSV', 'Match Frame 0 LAB', 'Match Frame 0 RGB', 'Video Input'], value=da.color_coherence, type="value", elem_id="color_coherence", interactive=True)
-                    # with gr.Column(variant='compact') as force_grayscale_column:
-                    color_force_grayscale = gr.Checkbox(label="Color force Grayscale", value=da.color_force_grayscale, interactive=True)
-                with gr.Row(visible=False) as color_coherence_video_every_N_frames_row:
-                    color_coherence_video_every_N_frames = gr.Number(label="Color coherence video every N frames", value=1, interactive=True)
-                with gr.Row(variant='compact'):
-                    contrast_schedule = gr.Textbox(label="Contrast schedule", lines=1, value = da.contrast_schedule, interactive=True)
-                    optical_flow_cadence = gr.Checkbox(label="Optical flow cadence", value=False, interactive=True, elem_id='optical_flow_cadence')
-                with gr.Row(variant='compact'):
-                    # what to do with blank frames (they may result from glitches or the NSFW filter being turned on): reroll with +1 seed, interrupt the animation generation, or do nothing
-                    reroll_blank_frames = gr.Radio(['reroll', 'interrupt', 'ignore'], label="Reroll blank frames", value=d.reroll_blank_frames, elem_id="reroll_blank_frames")
-            # ANTI BLUR INNER TAB  
-            with gr.Tab('Anti Blur', open=False, elem_id='anti_blur_accord') as anti_blur_tab:
-                with gr.Row(variant='compact'):
-                    kernel_schedule = gr.Textbox(label="Kernel schedule", lines=1, value = da.kernel_schedule, interactive=True)
-                with gr.Row(variant='compact'):
-                    sigma_schedule = gr.Textbox(label="Sigma schedule", lines=1, value = da.sigma_schedule, interactive=True)
-                with gr.Row(variant='compact'):
-                    amount_schedule = gr.Textbox(label="Amount schedule", lines=1, value = da.amount_schedule, interactive=True)
-                with gr.Row(variant='compact'):
-                    threshold_schedule = gr.Textbox(label="Threshold schedule", lines=1, value = da.threshold_schedule, interactive=True)
+                        # what to do with blank frames (they may result from glitches or the NSFW filter being turned on): reroll with +1 seed, interrupt the animation generation, or do nothing
+                        reroll_blank_frames = gr.Radio(['reroll', 'interrupt', 'ignore'], label="Reroll blank frames", value=d.reroll_blank_frames, elem_id="reroll_blank_frames")
+                # ANTI BLUR INNER TAB  
+                with gr.TabItem('Anti Blur', open=False, elem_id='anti_blur_accord') as anti_blur_tab:
+                    with gr.Row(variant='compact'):
+                        kernel_schedule = gr.Textbox(label="Kernel schedule", lines=1, value = da.kernel_schedule, interactive=True)
+                    with gr.Row(variant='compact'):
+                        sigma_schedule = gr.Textbox(label="Sigma schedule", lines=1, value = da.sigma_schedule, interactive=True)
+                    with gr.Row(variant='compact'):
+                        amount_schedule = gr.Textbox(label="Amount schedule", lines=1, value = da.amount_schedule, interactive=True)
+                    with gr.Row(variant='compact'):
+                        threshold_schedule = gr.Textbox(label="Threshold schedule", lines=1, value = da.threshold_schedule, interactive=True)
         # PROMPTS TAB    
         with gr.Tab('Prompts'):
             # PROMPTS INFO ACCORD  

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -334,614 +334,615 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
             )
             
     with gr.Blocks():
-        # RUN TAB
-        with gr.Tab('Run'):
-            from modules.sd_samplers import samplers_for_img2img
-            with gr.Row(variant='compact'):
-                sampler = gr.Dropdown(label="Sampler", choices=[x.name for x in samplers_for_img2img], value=samplers_for_img2img[0].name, type="value", elem_id="sampler", interactive=True)
-                steps = gr.Slider(label="Steps", minimum=0, maximum=200, step=1, value=d.steps, interactive=True)
-            with gr.Row(variant='compact'):
-                W = gr.Slider(label="Width", minimum=64, maximum=2048, step=64, value=d.W, interactive=True)
-                H = gr.Slider(label="Height", minimum=64, maximum=2048, step=64, value=d.H, interactive=True) 
-            with gr.Row(variant='compact'):
-                seed = gr.Number(label="Seed", value=d.seed, interactive=True, precision=0)
-                batch_name = gr.Textbox(label="Batch name", lines=1, interactive=True, value = d.batch_name)
-            with gr.Accordion('Restore Faces, Tiling & more', open=False) as run_more_settings_accord:
+        with gr.Tabs():
+            # RUN TAB
+            with gr.TabItem('Run'):
+                from modules.sd_samplers import samplers_for_img2img
                 with gr.Row(variant='compact'):
-                    restore_faces = gr.Checkbox(label='Restore Faces', value=d.restore_faces)
-                    tiling = gr.Checkbox(label='Tiling', value=False)
-                    ddim_eta = gr.Number(label="DDIM Eta", value=d.ddim_eta, interactive=True)
-                with gr.Row(variant='compact') as pix2pix_img_cfg_scale_row:
-                    pix2pix_img_cfg_scale_schedule = gr.Textbox(label="Pix2Pix img CFG schedule", value=da.pix2pix_img_cfg_scale_schedule, interactive=True)    
-            # RUN FROM SETTING FILE ACCORD
-            with gr.Accordion('Resume & Run from file', open=False):
-                with gr.Tab('Run from Settings file'):
-                    with gr.Row(variant='compact'):
-                        override_settings_with_file = gr.Checkbox(label="Override settings", value=False, interactive=True, elem_id='override_settings')
-                        custom_settings_file = gr.Textbox(label="Custom settings file", lines=1, interactive=True, elem_id='custom_settings_file')
-                # RESUME ANIMATION ACCORD
-                with gr.Tab('Resume Animation'):
-                    with gr.Row(variant='compact'):
-                        resume_from_timestring = gr.Checkbox(label="Resume from timestring", value=da.resume_from_timestring, interactive=True)
-                        resume_timestring = gr.Textbox(label="Resume timestring", lines=1, value = da.resume_timestring, interactive=True)
-        # KEYFRAMES TAB
-        with gr.Tab('Keyframes'): #TODO make a some sort of the original dictionary parsing
-            with gr.Row(variant='compact'):
-                with gr.Column(scale=2):
-                    animation_mode = gr.Radio(['2D', '3D', 'Interpolation', 'Video Input'], label="Animation mode", value=da.animation_mode, elem_id="animation_mode")
-                with gr.Column(scale=1, min_width=180):
-                    border = gr.Radio(['replicate', 'wrap'], label="Border", value=da.border, elem_id="border")
-            with gr.Row(variant='compact'):
-                diffusion_cadence = gr.Slider(label="Cadence", minimum=1, maximum=50, step=1, value=da.diffusion_cadence, interactive=True)
-                # optical_flow_cadence = gr.Checkbox(label="Optical flow cadence", value=False, interactive=True, elem_id='optical_flow_cadence')
-                max_frames = gr.Number(label="Max frames", lines=1, value = da.max_frames, interactive=True, precision=0)
-            # GUIDED IMAGES ACCORD
-            with gr.Accordion('Guided Images', open=False, elem_id='guided_images_accord') as guided_images_accord:
-                # GUIDED IMAGES INFO ACCORD
-                with gr.Accordion('*READ ME before you use this mode!*', open=False):
-                    gr.HTML("""You can use this as a guided image tool or as a looper depending on your settings in the keyframe images field. 
-                               Set the keyframes and the images that you want to show up. 
-                               Note: the number of frames between each keyframe should be greater than the tweening frames.""")
-                    #    In later versions this should be also in the strength schedule, but for now you need to set it.
-                    gr.HTML("""Prerequisites and Important Info: 
-                               <ul style="list-style-type:circle; margin-left:2em; margin-bottom:0em">
-                                   <li>This mode works ONLY with 2D/3D animation modes. Interpolation and Video Input modes aren't supported.</ li>
-                                   <li>Set Init tab's strength slider greater than 0. Recommended value (.65 - .80).</ li>
-                                   <li>Set 'seed_behavior' to 'schedule' under the Seed Scheduling section below.</li>
-                                </ul>
-                            """)
-                    gr.HTML("""Looping recommendations: 
-                                <ul style="list-style-type:circle; margin-left:2em; margin-bottom:0em">
-                                    <li>seed_schedule should start and end on the same seed. <br />
-                                        Example: seed_schedule could use 0:(5), 1:(-1), 219:(-1), 220:(5)</li>
-                                    <li>The 1st and last keyframe images should match.</li>
-                                    <li>Set your total number of keyframes to be 21 more than the last inserted keyframe image. <br />
-                                        Example: Default args should use 221 as total keyframes.</li>
-                                    <li>Prompts are stored in JSON format. If you've got an error, check it in validator, <a style="color:SteelBlue" href="https://odu.github.io/slingjsonlint/">like here</a></li>
-                                </ul>
-                            """)
+                    sampler = gr.Dropdown(label="Sampler", choices=[x.name for x in samplers_for_img2img], value=samplers_for_img2img[0].name, type="value", elem_id="sampler", interactive=True)
+                    steps = gr.Slider(label="Steps", minimum=0, maximum=200, step=1, value=d.steps, interactive=True)
                 with gr.Row(variant='compact'):
-                    use_looper = gr.Checkbox(label="Enable guided images mode", value=dloopArgs.use_looper, interactive=True)
+                    W = gr.Slider(label="Width", minimum=64, maximum=2048, step=64, value=d.W, interactive=True)
+                    H = gr.Slider(label="Height", minimum=64, maximum=2048, step=64, value=d.H, interactive=True) 
                 with gr.Row(variant='compact'):
-                    init_images = gr.Textbox(label="Images to use for keyframe guidance", lines=9, value = keyframeExamples(), interactive=True)
-                # GUIDED IMAGES SCHEDULES ACCORD
-                with gr.Accordion('Guided images schedules', open=False):
+                    seed = gr.Number(label="Seed", value=d.seed, interactive=True, precision=0)
+                    batch_name = gr.Textbox(label="Batch name", lines=1, interactive=True, value = d.batch_name)
+                with gr.Accordion('Restore Faces, Tiling & more', open=False) as run_more_settings_accord:
                     with gr.Row(variant='compact'):
-                        image_strength_schedule = gr.Textbox(label="Image strength schedule", lines=1, value = dloopArgs.image_strength_schedule, interactive=True)
-                    with gr.Row(variant='compact'):
-                        blendFactorMax = gr.Textbox(label="Blend factor max", lines=1, value = dloopArgs.blendFactorMax, interactive=True)
-                    with gr.Row(variant='compact'):
-                        blendFactorSlope = gr.Textbox(label="Blend factor slope", lines=1, value = dloopArgs.blendFactorSlope, interactive=True)
-                    with gr.Row(variant='compact'):
-                        tweening_frames_schedule = gr.Textbox(label="Tweening frames schedule", lines=1, value = dloopArgs.tweening_frames_schedule, interactive=True)
-                    with gr.Row(variant='compact'):
-                        color_correction_factor = gr.Textbox(label="Color correction factor", lines=1, value = dloopArgs.color_correction_factor, interactive=True)
-            # EXTA SCHEDULES TABS
-            with gr.Tabs(elem_id='extra_schedules'):
-                with gr.TabItem('Strength'):
-                    with gr.Row(variant='compact'):
-                        strength_schedule = gr.Textbox(label="Strength schedule", lines=1, value = da.strength_schedule, interactive=True)
-                with gr.TabItem('CFG'):
-                    with gr.Row(variant='compact'):
-                        cfg_scale_schedule = gr.Textbox(label="CFG scale schedule", lines=1, value = da.cfg_scale_schedule, interactive=True)
-                with gr.TabItem('Seed') as a3:
-                    with gr.Row(variant='compact'):
-                        seed_behavior = gr.Radio(['iter', 'fixed', 'random', 'ladder', 'alternate', 'schedule'], label="Seed behavior", value=d.seed_behavior, elem_id="seed_behavior")
-                    with gr.Row(variant='compact') as seed_iter_N_row:
-                        seed_iter_N = gr.Number(label="Seed iter N", value=d.seed_iter_N, interactive=True, precision=0)
-                    with gr.Row(visible=False) as seed_schedule_row:
-                        seed_schedule = gr.Textbox(label="Seed schedule", lines=1, value = da.seed_schedule, interactive=True)
-                with gr.TabItem('SubSeed', open=False) as subseed_sch_tab:
-                    with gr.Row(variant='compact'):
-                        enable_subseed_scheduling = gr.Checkbox(label="Enable Subseed scheduling", value=da.enable_subseed_scheduling, interactive=True)
-                        subseed_schedule = gr.Textbox(label="Subseed schedule", lines=1, value = da.subseed_schedule, interactive=True)
-                        subseed_strength_schedule = gr.Textbox(label="Subseed strength schedule", lines=1, value = da.subseed_strength_schedule, interactive=True)
-                    with gr.Row(variant='compact'):
-                        seed_resize_from_w = gr.Slider(minimum=0, maximum=2048, step=64, label="Resize seed from width", value=0)
-                        seed_resize_from_h = gr.Slider(minimum=0, maximum=2048, step=64, label="Resize seed from height", value=0)
-                # Steps Scheduling
-                with gr.TabItem('Step') as a13:
-                    with gr.Row(variant='compact'):
-                        enable_steps_scheduling = gr.Checkbox(label="Enable steps scheduling", value=da.enable_steps_scheduling, interactive=True)
-                    with gr.Row(variant='compact'):
-                        steps_schedule = gr.Textbox(label="Steps schedule", lines=1, value = da.steps_schedule, interactive=True)
-                # Sampler Scheduling
-                with gr.TabItem('Sampler') as a14:
-                    with gr.Row(variant='compact'):
-                        enable_sampler_scheduling = gr.Checkbox(label="Enable sampler scheduling", value=da.enable_sampler_scheduling, interactive=True)
-                    with gr.Row(variant='compact'):
-                        sampler_schedule = gr.Textbox(label="Sampler schedule", lines=1, value = da.sampler_schedule, interactive=True)
-                # Checkpoint Scheduling
-                with gr.TabItem('Checkpoint') as a15:
-                    with gr.Row(variant='compact'):
-                        enable_checkpoint_scheduling = gr.Checkbox(label="Enable checkpoint scheduling", value=da.enable_checkpoint_scheduling, interactive=True)
-                    with gr.Row(variant='compact'):
-                        checkpoint_schedule = gr.Textbox(label="Checkpoint schedule", lines=1, value = da.checkpoint_schedule, interactive=True)
-                with gr.TabItem('CLIP Skip', open=False) as a16:
-                    with gr.Row(variant='compact'):
-                        enable_clipskip_scheduling = gr.Checkbox(label="Enable CLIP skip scheduling", value=da.enable_clipskip_scheduling, interactive=True)
-                    with gr.Row(variant='compact'):
-                        clipskip_schedule = gr.Textbox(label="CLIP skip schedule", lines=1, value = da.clipskip_schedule, interactive=True)
-            # MOTION INNER TAB
-            with gr.Tabs(elem_id='motion_noise_etc'):
-                with gr.TabItem('Motion') as motion_tab:
-                    with gr.Column(visible=True) as only_2d_motion_column:
+                        restore_faces = gr.Checkbox(label='Restore Faces', value=d.restore_faces)
+                        tiling = gr.Checkbox(label='Tiling', value=False)
+                        ddim_eta = gr.Number(label="DDIM Eta", value=d.ddim_eta, interactive=True)
+                    with gr.Row(variant='compact') as pix2pix_img_cfg_scale_row:
+                        pix2pix_img_cfg_scale_schedule = gr.Textbox(label="Pix2Pix img CFG schedule", value=da.pix2pix_img_cfg_scale_schedule, interactive=True)    
+                # RUN FROM SETTING FILE ACCORD
+                with gr.Accordion('Resume & Run from file', open=False):
+                    with gr.Tab('Run from Settings file'):
                         with gr.Row(variant='compact'):
-                            zoom = gr.Textbox(label="Zoom", lines=1, value = da.zoom, interactive=True)
+                            override_settings_with_file = gr.Checkbox(label="Override settings", value=False, interactive=True, elem_id='override_settings')
+                            custom_settings_file = gr.Textbox(label="Custom settings file", lines=1, interactive=True, elem_id='custom_settings_file')
+                    # RESUME ANIMATION ACCORD
+                    with gr.Tab('Resume Animation'):
                         with gr.Row(variant='compact'):
-                            angle = gr.Textbox(label="Angle", lines=1, value = da.angle, interactive=True)
+                            resume_from_timestring = gr.Checkbox(label="Resume from timestring", value=da.resume_from_timestring, interactive=True)
+                            resume_timestring = gr.Textbox(label="Resume timestring", lines=1, value = da.resume_timestring, interactive=True)
+            # KEYFRAMES TAB
+            with gr.TabItem('Keyframes'): #TODO make a some sort of the original dictionary parsing
+                with gr.Row(variant='compact'):
+                    with gr.Column(scale=2):
+                        animation_mode = gr.Radio(['2D', '3D', 'Interpolation', 'Video Input'], label="Animation mode", value=da.animation_mode, elem_id="animation_mode")
+                    with gr.Column(scale=1, min_width=180):
+                        border = gr.Radio(['replicate', 'wrap'], label="Border", value=da.border, elem_id="border")
+                with gr.Row(variant='compact'):
+                    diffusion_cadence = gr.Slider(label="Cadence", minimum=1, maximum=50, step=1, value=da.diffusion_cadence, interactive=True)
+                    # optical_flow_cadence = gr.Checkbox(label="Optical flow cadence", value=False, interactive=True, elem_id='optical_flow_cadence')
+                    max_frames = gr.Number(label="Max frames", lines=1, value = da.max_frames, interactive=True, precision=0)
+                # GUIDED IMAGES ACCORD
+                with gr.Accordion('Guided Images', open=False, elem_id='guided_images_accord') as guided_images_accord:
+                    # GUIDED IMAGES INFO ACCORD
+                    with gr.Accordion('*READ ME before you use this mode!*', open=False):
+                        gr.HTML("""You can use this as a guided image tool or as a looper depending on your settings in the keyframe images field. 
+                                   Set the keyframes and the images that you want to show up. 
+                                   Note: the number of frames between each keyframe should be greater than the tweening frames.""")
+                        #    In later versions this should be also in the strength schedule, but for now you need to set it.
+                        gr.HTML("""Prerequisites and Important Info: 
+                                   <ul style="list-style-type:circle; margin-left:2em; margin-bottom:0em">
+                                       <li>This mode works ONLY with 2D/3D animation modes. Interpolation and Video Input modes aren't supported.</ li>
+                                       <li>Set Init tab's strength slider greater than 0. Recommended value (.65 - .80).</ li>
+                                       <li>Set 'seed_behavior' to 'schedule' under the Seed Scheduling section below.</li>
+                                    </ul>
+                                """)
+                        gr.HTML("""Looping recommendations: 
+                                    <ul style="list-style-type:circle; margin-left:2em; margin-bottom:0em">
+                                        <li>seed_schedule should start and end on the same seed. <br />
+                                            Example: seed_schedule could use 0:(5), 1:(-1), 219:(-1), 220:(5)</li>
+                                        <li>The 1st and last keyframe images should match.</li>
+                                        <li>Set your total number of keyframes to be 21 more than the last inserted keyframe image. <br />
+                                            Example: Default args should use 221 as total keyframes.</li>
+                                        <li>Prompts are stored in JSON format. If you've got an error, check it in validator, <a style="color:SteelBlue" href="https://odu.github.io/slingjsonlint/">like here</a></li>
+                                    </ul>
+                                """)
+                    with gr.Row(variant='compact'):
+                        use_looper = gr.Checkbox(label="Enable guided images mode", value=dloopArgs.use_looper, interactive=True)
+                    with gr.Row(variant='compact'):
+                        init_images = gr.Textbox(label="Images to use for keyframe guidance", lines=9, value = keyframeExamples(), interactive=True)
+                    # GUIDED IMAGES SCHEDULES ACCORD
+                    with gr.Accordion('Guided images schedules', open=False):
                         with gr.Row(variant='compact'):
-                            transform_center_x = gr.Textbox(label="Transform Center X", lines=1, value = da.transform_center_x, interactive=True)
+                            image_strength_schedule = gr.Textbox(label="Image strength schedule", lines=1, value = dloopArgs.image_strength_schedule, interactive=True)
                         with gr.Row(variant='compact'):
-                            transform_center_y = gr.Textbox(label="Transform Center Y", lines=1, value = da.transform_center_y, interactive=True)
-                    with gr.Column(visible=True) as both_anim_mode_motion_params_column:
+                            blendFactorMax = gr.Textbox(label="Blend factor max", lines=1, value = dloopArgs.blendFactorMax, interactive=True)
                         with gr.Row(variant='compact'):
-                            translation_x = gr.Textbox(label="Translation X", lines=1, value = da.translation_x, interactive=True)
+                            blendFactorSlope = gr.Textbox(label="Blend factor slope", lines=1, value = dloopArgs.blendFactorSlope, interactive=True)
                         with gr.Row(variant='compact'):
-                            translation_y = gr.Textbox(label="Translation Y", lines=1, value = da.translation_y, interactive=True)
-                    with gr.Column(visible=False) as only_3d_motion_column:
+                            tweening_frames_schedule = gr.Textbox(label="Tweening frames schedule", lines=1, value = dloopArgs.tweening_frames_schedule, interactive=True)
                         with gr.Row(variant='compact'):
-                            translation_z = gr.Textbox(label="Translation Z", lines=1, value = da.translation_z, interactive=True)
+                            color_correction_factor = gr.Textbox(label="Color correction factor", lines=1, value = dloopArgs.color_correction_factor, interactive=True)
+                # EXTA SCHEDULES TABS
+                with gr.Tabs(elem_id='extra_schedules'):
+                    with gr.TabItem('Strength'):
                         with gr.Row(variant='compact'):
-                            rotation_3d_x = gr.Textbox(label="Rotation 3D X", lines=1, value = da.rotation_3d_x, interactive=True)
+                            strength_schedule = gr.Textbox(label="Strength schedule", lines=1, value = da.strength_schedule, interactive=True)
+                    with gr.TabItem('CFG'):
                         with gr.Row(variant='compact'):
-                            rotation_3d_y = gr.Textbox(label="Rotation 3D Y", lines=1, value = da.rotation_3d_y, interactive=True)
+                            cfg_scale_schedule = gr.Textbox(label="CFG scale schedule", lines=1, value = da.cfg_scale_schedule, interactive=True)
+                    with gr.TabItem('Seed') as a3:
                         with gr.Row(variant='compact'):
-                            rotation_3d_z = gr.Textbox(label="Rotation 3D Z", lines=1, value = da.rotation_3d_z, interactive=True)
-                    # 3D DEPTH & FOV ACCORD
-                    with gr.Accordion('Depth Warping & FOV', visible=False, open=False) as depth_3d_warping_accord:
-                        with gr.TabItem('Depth Warping'): 
+                            seed_behavior = gr.Radio(['iter', 'fixed', 'random', 'ladder', 'alternate', 'schedule'], label="Seed behavior", value=d.seed_behavior, elem_id="seed_behavior")
+                        with gr.Row(variant='compact') as seed_iter_N_row:
+                            seed_iter_N = gr.Number(label="Seed iter N", value=d.seed_iter_N, interactive=True, precision=0)
+                        with gr.Row(visible=False) as seed_schedule_row:
+                            seed_schedule = gr.Textbox(label="Seed schedule", lines=1, value = da.seed_schedule, interactive=True)
+                    with gr.TabItem('SubSeed', open=False) as subseed_sch_tab:
+                        with gr.Row(variant='compact'):
+                            enable_subseed_scheduling = gr.Checkbox(label="Enable Subseed scheduling", value=da.enable_subseed_scheduling, interactive=True)
+                            subseed_schedule = gr.Textbox(label="Subseed schedule", lines=1, value = da.subseed_schedule, interactive=True)
+                            subseed_strength_schedule = gr.Textbox(label="Subseed strength schedule", lines=1, value = da.subseed_strength_schedule, interactive=True)
+                        with gr.Row(variant='compact'):
+                            seed_resize_from_w = gr.Slider(minimum=0, maximum=2048, step=64, label="Resize seed from width", value=0)
+                            seed_resize_from_h = gr.Slider(minimum=0, maximum=2048, step=64, label="Resize seed from height", value=0)
+                    # Steps Scheduling
+                    with gr.TabItem('Step') as a13:
+                        with gr.Row(variant='compact'):
+                            enable_steps_scheduling = gr.Checkbox(label="Enable steps scheduling", value=da.enable_steps_scheduling, interactive=True)
+                        with gr.Row(variant='compact'):
+                            steps_schedule = gr.Textbox(label="Steps schedule", lines=1, value = da.steps_schedule, interactive=True)
+                    # Sampler Scheduling
+                    with gr.TabItem('Sampler') as a14:
+                        with gr.Row(variant='compact'):
+                            enable_sampler_scheduling = gr.Checkbox(label="Enable sampler scheduling", value=da.enable_sampler_scheduling, interactive=True)
+                        with gr.Row(variant='compact'):
+                            sampler_schedule = gr.Textbox(label="Sampler schedule", lines=1, value = da.sampler_schedule, interactive=True)
+                    # Checkpoint Scheduling
+                    with gr.TabItem('Checkpoint') as a15:
+                        with gr.Row(variant='compact'):
+                            enable_checkpoint_scheduling = gr.Checkbox(label="Enable checkpoint scheduling", value=da.enable_checkpoint_scheduling, interactive=True)
+                        with gr.Row(variant='compact'):
+                            checkpoint_schedule = gr.Textbox(label="Checkpoint schedule", lines=1, value = da.checkpoint_schedule, interactive=True)
+                    with gr.TabItem('CLIP Skip', open=False) as a16:
+                        with gr.Row(variant='compact'):
+                            enable_clipskip_scheduling = gr.Checkbox(label="Enable CLIP skip scheduling", value=da.enable_clipskip_scheduling, interactive=True)
+                        with gr.Row(variant='compact'):
+                            clipskip_schedule = gr.Textbox(label="CLIP skip schedule", lines=1, value = da.clipskip_schedule, interactive=True)
+                # MOTION INNER TAB
+                with gr.Tabs(elem_id='motion_noise_etc'):
+                    with gr.TabItem('Motion') as motion_tab:
+                        with gr.Column(visible=True) as only_2d_motion_column:
                             with gr.Row(variant='compact'):
-                                use_depth_warping = gr.Checkbox(label="Use depth warping", value=da.use_depth_warping, interactive=True)
-                                midas_weight = gr.Number(label="MiDaS weight", value=da.midas_weight, interactive=True)
+                                zoom = gr.Textbox(label="Zoom", lines=1, value = da.zoom, interactive=True)
                             with gr.Row(variant='compact'):
-                                padding_mode = gr.Radio(['border', 'reflection', 'zeros'], label="Padding mode", value=da.padding_mode, elem_id="padding_mode")
-                                sampling_mode = gr.Radio(['bicubic', 'bilinear', 'nearest'], label="Sampling mode", value=da.sampling_mode, elem_id="sampling_mode")
-                        with gr.TabItem('Field Of View', visible=False, open=False) as fov_accord:
+                                angle = gr.Textbox(label="Angle", lines=1, value = da.angle, interactive=True)
                             with gr.Row(variant='compact'):
-                                fov_schedule = gr.Textbox(label="FOV schedule", lines=1, value = da.fov_schedule, interactive=True)
+                                transform_center_x = gr.Textbox(label="Transform Center X", lines=1, value = da.transform_center_x, interactive=True)
                             with gr.Row(variant='compact'):
-                                aspect_ratio_schedule = gr.Textbox(label="Aspect Ratio schedule", lines=1, value = da.aspect_ratio_schedule, interactive=True)
+                                transform_center_y = gr.Textbox(label="Transform Center Y", lines=1, value = da.transform_center_y, interactive=True)
+                        with gr.Column(visible=True) as both_anim_mode_motion_params_column:
                             with gr.Row(variant='compact'):
-                                near_schedule = gr.Textbox(label="Near schedule", lines=1, value = da.near_schedule, interactive=True)
+                                translation_x = gr.Textbox(label="Translation X", lines=1, value = da.translation_x, interactive=True)
                             with gr.Row(variant='compact'):
-                                far_schedule = gr.Textbox(label="Far schedule", lines=1, value = da.far_schedule, interactive=True)
-                    # PERSPECTIVE FLIP ACCORD
-                    with gr.Accordion('Perspective Flip', open=False) as perspective_flip_accord:
+                                translation_y = gr.Textbox(label="Translation Y", lines=1, value = da.translation_y, interactive=True)
+                        with gr.Column(visible=False) as only_3d_motion_column:
+                            with gr.Row(variant='compact'):
+                                translation_z = gr.Textbox(label="Translation Z", lines=1, value = da.translation_z, interactive=True)
+                            with gr.Row(variant='compact'):
+                                rotation_3d_x = gr.Textbox(label="Rotation 3D X", lines=1, value = da.rotation_3d_x, interactive=True)
+                            with gr.Row(variant='compact'):
+                                rotation_3d_y = gr.Textbox(label="Rotation 3D Y", lines=1, value = da.rotation_3d_y, interactive=True)
+                            with gr.Row(variant='compact'):
+                                rotation_3d_z = gr.Textbox(label="Rotation 3D Z", lines=1, value = da.rotation_3d_z, interactive=True)
+                        # 3D DEPTH & FOV ACCORD
+                        with gr.Accordion('Depth Warping & FOV', visible=False, open=False) as depth_3d_warping_accord:
+                            with gr.TabItem('Depth Warping'): 
+                                with gr.Row(variant='compact'):
+                                    use_depth_warping = gr.Checkbox(label="Use depth warping", value=da.use_depth_warping, interactive=True)
+                                    midas_weight = gr.Number(label="MiDaS weight", value=da.midas_weight, interactive=True)
+                                with gr.Row(variant='compact'):
+                                    padding_mode = gr.Radio(['border', 'reflection', 'zeros'], label="Padding mode", value=da.padding_mode, elem_id="padding_mode")
+                                    sampling_mode = gr.Radio(['bicubic', 'bilinear', 'nearest'], label="Sampling mode", value=da.sampling_mode, elem_id="sampling_mode")
+                            with gr.TabItem('Field Of View', visible=False, open=False) as fov_accord:
+                                with gr.Row(variant='compact'):
+                                    fov_schedule = gr.Textbox(label="FOV schedule", lines=1, value = da.fov_schedule, interactive=True)
+                                with gr.Row(variant='compact'):
+                                    aspect_ratio_schedule = gr.Textbox(label="Aspect Ratio schedule", lines=1, value = da.aspect_ratio_schedule, interactive=True)
+                                with gr.Row(variant='compact'):
+                                    near_schedule = gr.Textbox(label="Near schedule", lines=1, value = da.near_schedule, interactive=True)
+                                with gr.Row(variant='compact'):
+                                    far_schedule = gr.Textbox(label="Far schedule", lines=1, value = da.far_schedule, interactive=True)
+                        # PERSPECTIVE FLIP ACCORD
+                        with gr.Accordion('Perspective Flip', open=False) as perspective_flip_accord:
+                            with gr.Row(variant='compact'):
+                                enable_perspective_flip = gr.Checkbox(label="Enable perspective flip", value=da.enable_perspective_flip, interactive=True)
+                            with gr.Row(variant='compact'):
+                                perspective_flip_theta = gr.Textbox(label="Perspective flip theta", lines=1, value = da.perspective_flip_theta, interactive=True)
+                            with gr.Row(variant='compact'):
+                                perspective_flip_phi = gr.Textbox(label="Perspective flip phi", lines=1, value = da.perspective_flip_phi, interactive=True)
+                            with gr.Row(variant='compact'):
+                                perspective_flip_gamma = gr.Textbox(label="Perspective flip gamma", lines=1, value = da.perspective_flip_gamma, interactive=True)
+                            with gr.Row(variant='compact'):
+                                perspective_flip_fv = gr.Textbox(label="Perspective flip fv", lines=1, value = da.perspective_flip_fv, interactive=True)
+                    # NOISE INNER TAB
+                    with gr.TabItem('Noise') as a8:
                         with gr.Row(variant='compact'):
-                            enable_perspective_flip = gr.Checkbox(label="Enable perspective flip", value=da.enable_perspective_flip, interactive=True)
+                            noise_type = gr.Radio(['uniform', 'perlin'], label="Noise type", value=da.noise_type, elem_id="noise_type")
                         with gr.Row(variant='compact'):
-                            perspective_flip_theta = gr.Textbox(label="Perspective flip theta", lines=1, value = da.perspective_flip_theta, interactive=True)
+                            noise_schedule = gr.Textbox(label="Noise schedule", lines=1, value = da.noise_schedule, interactive=True)
+                        with gr.Row(variant='compact') as perlin_row:
+                            with gr.Column(min_width=220):
+                                perlin_octaves = gr.Slider(label="Perlin octaves", minimum=1, maximum=7, value=da.perlin_octaves, step=1, interactive=True)
+                            with gr.Column(min_width=220):
+                                perlin_persistence = gr.Slider(label="Perlin persistence", minimum=0, maximum=1, value=da.perlin_persistence, step=0.02, interactive=True)
+                    # COHERENCE INNER TAB
+                    with gr.TabItem('Coherence', open=False) as coherence_accord:
                         with gr.Row(variant='compact'):
-                            perspective_flip_phi = gr.Textbox(label="Perspective flip phi", lines=1, value = da.perspective_flip_phi, interactive=True)
+                            # Future TODO: remove 'match frame 0' prefix (after we manage the deprecated-names settings import), then convert from Dropdown to Radio!
+                            color_coherence = gr.Dropdown(label="Color coherence", choices=['None', 'Match Frame 0 HSV', 'Match Frame 0 LAB', 'Match Frame 0 RGB', 'Video Input'], value=da.color_coherence, type="value", elem_id="color_coherence", interactive=True)
+                            # with gr.Column(variant='compact') as force_grayscale_column:
+                            color_force_grayscale = gr.Checkbox(label="Color force Grayscale", value=da.color_force_grayscale, interactive=True)
+                        with gr.Row(visible=False) as color_coherence_video_every_N_frames_row:
+                            color_coherence_video_every_N_frames = gr.Number(label="Color coherence video every N frames", value=1, interactive=True)
                         with gr.Row(variant='compact'):
-                            perspective_flip_gamma = gr.Textbox(label="Perspective flip gamma", lines=1, value = da.perspective_flip_gamma, interactive=True)
+                            contrast_schedule = gr.Textbox(label="Contrast schedule", lines=1, value = da.contrast_schedule, interactive=True)
+                            optical_flow_cadence = gr.Checkbox(label="Optical flow cadence", value=False, interactive=True, elem_id='optical_flow_cadence')
                         with gr.Row(variant='compact'):
-                            perspective_flip_fv = gr.Textbox(label="Perspective flip fv", lines=1, value = da.perspective_flip_fv, interactive=True)
-                # NOISE INNER TAB
-                with gr.TabItem('Noise') as a8:
-                    with gr.Row(variant='compact'):
-                        noise_type = gr.Radio(['uniform', 'perlin'], label="Noise type", value=da.noise_type, elem_id="noise_type")
-                    with gr.Row(variant='compact'):
-                        noise_schedule = gr.Textbox(label="Noise schedule", lines=1, value = da.noise_schedule, interactive=True)
-                    with gr.Row(variant='compact') as perlin_row:
-                        with gr.Column(min_width=220):
-                            perlin_octaves = gr.Slider(label="Perlin octaves", minimum=1, maximum=7, value=da.perlin_octaves, step=1, interactive=True)
-                        with gr.Column(min_width=220):
-                            perlin_persistence = gr.Slider(label="Perlin persistence", minimum=0, maximum=1, value=da.perlin_persistence, step=0.02, interactive=True)
-                # COHERENCE INNER TAB
-                with gr.TabItem('Coherence', open=False) as coherence_accord:
-                    with gr.Row(variant='compact'):
-                        # Future TODO: remove 'match frame 0' prefix (after we manage the deprecated-names settings import), then convert from Dropdown to Radio!
-                        color_coherence = gr.Dropdown(label="Color coherence", choices=['None', 'Match Frame 0 HSV', 'Match Frame 0 LAB', 'Match Frame 0 RGB', 'Video Input'], value=da.color_coherence, type="value", elem_id="color_coherence", interactive=True)
-                        # with gr.Column(variant='compact') as force_grayscale_column:
-                        color_force_grayscale = gr.Checkbox(label="Color force Grayscale", value=da.color_force_grayscale, interactive=True)
-                    with gr.Row(visible=False) as color_coherence_video_every_N_frames_row:
-                        color_coherence_video_every_N_frames = gr.Number(label="Color coherence video every N frames", value=1, interactive=True)
-                    with gr.Row(variant='compact'):
-                        contrast_schedule = gr.Textbox(label="Contrast schedule", lines=1, value = da.contrast_schedule, interactive=True)
-                        optical_flow_cadence = gr.Checkbox(label="Optical flow cadence", value=False, interactive=True, elem_id='optical_flow_cadence')
-                    with gr.Row(variant='compact'):
-                        # what to do with blank frames (they may result from glitches or the NSFW filter being turned on): reroll with +1 seed, interrupt the animation generation, or do nothing
-                        reroll_blank_frames = gr.Radio(['reroll', 'interrupt', 'ignore'], label="Reroll blank frames", value=d.reroll_blank_frames, elem_id="reroll_blank_frames")
-                # ANTI BLUR INNER TAB  
-                with gr.TabItem('Anti Blur', open=False, elem_id='anti_blur_accord') as anti_blur_tab:
-                    with gr.Row(variant='compact'):
-                        kernel_schedule = gr.Textbox(label="Kernel schedule", lines=1, value = da.kernel_schedule, interactive=True)
-                    with gr.Row(variant='compact'):
-                        sigma_schedule = gr.Textbox(label="Sigma schedule", lines=1, value = da.sigma_schedule, interactive=True)
-                    with gr.Row(variant='compact'):
-                        amount_schedule = gr.Textbox(label="Amount schedule", lines=1, value = da.amount_schedule, interactive=True)
-                    with gr.Row(variant='compact'):
-                        threshold_schedule = gr.Textbox(label="Threshold schedule", lines=1, value = da.threshold_schedule, interactive=True)
-        # PROMPTS TAB    
-        with gr.Tab('Prompts'):
-            # PROMPTS INFO ACCORD  
-            with gr.Accordion(label='*Important* notes on Prompts', elem_id='prompts_info_accord', open=False, visible=True) as prompts_info_accord:
-                gr.HTML("""
-                    <ul style="list-style-type:circle; margin-left:0.75em; margin-bottom:0.2em">
-                    <li>Please always keep values in math functions above 0.</li>
-                    <li>There is *no* Batch mode like in vanilla deforum. Please Use the txt2img tab for that.</li>
-                    <li>For negative prompts, please write your positive prompt, then --neg ugly, text, assymetric, or any other negative tokens of your choice. OR:</li>
-                    <li>Use the negative_prompts field to automatically append all words as a negative prompt. *Don't* add --neg in the negative_prompts field!</li>
-                    <li>Prompts are stored in JSON format. If you've got an error, check it in a <a style="color:SteelBlue" href="https://odu.github.io/slingjsonlint/">JSON Validator</a></li>
-                    </ul>
-                    """)
-            with gr.Row(variant='compact'):
-                animation_prompts = gr.Textbox(label="Prompts", lines=8, interactive=True, value = DeforumAnimPrompts())
-            with gr.Row(variant='compact'):
-                animation_prompts_positive = gr.Textbox(label="Prompts positive", lines=1, interactive=True, value = "")
-            with gr.Row(variant='compact'):
-                animation_prompts_negative = gr.Textbox(label="Prompts negative", lines=1, interactive=True, value = "")
-            # COMPOSABLE MASK SCHEDULING ACCORD
-            with gr.Accordion('Composable Mask scheduling', open=False):
-                gr.HTML("""
+                            # what to do with blank frames (they may result from glitches or the NSFW filter being turned on): reroll with +1 seed, interrupt the animation generation, or do nothing
+                            reroll_blank_frames = gr.Radio(['reroll', 'interrupt', 'ignore'], label="Reroll blank frames", value=d.reroll_blank_frames, elem_id="reroll_blank_frames")
+                    # ANTI BLUR INNER TAB  
+                    with gr.TabItem('Anti Blur', open=False, elem_id='anti_blur_accord') as anti_blur_tab:
+                        with gr.Row(variant='compact'):
+                            kernel_schedule = gr.Textbox(label="Kernel schedule", lines=1, value = da.kernel_schedule, interactive=True)
+                        with gr.Row(variant='compact'):
+                            sigma_schedule = gr.Textbox(label="Sigma schedule", lines=1, value = da.sigma_schedule, interactive=True)
+                        with gr.Row(variant='compact'):
+                            amount_schedule = gr.Textbox(label="Amount schedule", lines=1, value = da.amount_schedule, interactive=True)
+                        with gr.Row(variant='compact'):
+                            threshold_schedule = gr.Textbox(label="Threshold schedule", lines=1, value = da.threshold_schedule, interactive=True)
+            # PROMPTS TAB    
+            with gr.TabItem('Prompts'):
+                # PROMPTS INFO ACCORD  
+                with gr.Accordion(label='*Important* notes on Prompts', elem_id='prompts_info_accord', open=False, visible=True) as prompts_info_accord:
+                    gr.HTML("""
                         <ul style="list-style-type:circle; margin-left:0.75em; margin-bottom:0.2em">
-                        <li>To enable, check use_mask in the Init tab</li>
-                        <li>Supports boolean operations: (! - negation, & - and, | - or, ^ - xor, \ - difference, () - nested operations)</li>
-                        <li>default variables: in \{\}, like \{init_mask\}, \{video_mask\}, \{everywhere\}</li>
-                        <li>masks from files: in [], like [mask1.png]</li>
-                        <li>description-based: <i>word masks</i> in &lt;&gt;, like &lt;apple&gt;, &lt;hair&gt</li>
+                        <li>Please always keep values in math functions above 0.</li>
+                        <li>There is *no* Batch mode like in vanilla deforum. Please Use the txt2img tab for that.</li>
+                        <li>For negative prompts, please write your positive prompt, then --neg ugly, text, assymetric, or any other negative tokens of your choice. OR:</li>
+                        <li>Use the negative_prompts field to automatically append all words as a negative prompt. *Don't* add --neg in the negative_prompts field!</li>
+                        <li>Prompts are stored in JSON format. If you've got an error, check it in a <a style="color:SteelBlue" href="https://odu.github.io/slingjsonlint/">JSON Validator</a></li>
                         </ul>
                         """)
                 with gr.Row(variant='compact'):
-                    mask_schedule = gr.Textbox(label="Mask schedule", lines=1, value = da.mask_schedule, interactive=True)
+                    animation_prompts = gr.Textbox(label="Prompts", lines=8, interactive=True, value = DeforumAnimPrompts())
                 with gr.Row(variant='compact'):
-                    use_noise_mask = gr.Checkbox(label="Use noise mask", value=da.use_noise_mask, interactive=True)
+                    animation_prompts_positive = gr.Textbox(label="Prompts positive", lines=1, interactive=True, value = "")
                 with gr.Row(variant='compact'):
-                    noise_mask_schedule = gr.Textbox(label="Noise mask schedule", lines=1, value = da.noise_mask_schedule, interactive=True)
-        # INIT MAIN TAB
-        with gr.Tab('Init'):
-            # IMAGE INIT INNER-TAB
-            with gr.Tab('Image Init'):
-                with gr.Row(variant='compact'):
-                    with gr.Column(min_width=150):
-                        use_init = gr.Checkbox(label="Use init", value=d.use_init, interactive=True, visible=True)
-                    with gr.Column(min_width=150):
-                        strength_0_no_init = gr.Checkbox(label="Strength 0 no init", value=True, interactive=True)
-                    with gr.Column(min_width=170):
-                        strength = gr.Slider(label="Strength", minimum=0, maximum=1, step=0.01, value=0, interactive=True)
-                with gr.Row(variant='compact'):
-                    init_image = gr.Textbox(label="Init image", lines=1, interactive=True, value = d.init_image)
-            # VIDEO INIT INNER-TAB
-            with gr.Tab('Video Init'):
-                with gr.Row(variant='compact'):
-                    video_init_path = gr.Textbox(label="Video init path", lines=1, value = da.video_init_path, interactive=True)
-                with gr.Row(variant='compact'):
-                    extract_from_frame = gr.Number(label="Extract from frame", value=da.extract_from_frame, interactive=True, precision=0)
-                    extract_to_frame = gr.Number(label="Extract to frame", value=da.extract_to_frame, interactive=True, precision=0)
-                    extract_nth_frame = gr.Number(label="Extract nth frame", value=da.extract_nth_frame, interactive=True, precision=0)
-                    overwrite_extracted_frames = gr.Checkbox(label="Overwrite extracted frames", value=False, interactive=True)
-                    use_mask_video = gr.Checkbox(label="Use mask video", value=False, interactive=True)
-                with gr.Row(variant='compact'):
-                    video_mask_path = gr.Textbox(label="Video mask path", lines=1, value = da.video_mask_path, interactive=True)
-            # MASK INIT INNER-TAB
-            with gr.Tab('Mask Init'):
-                with gr.Row(variant='compact'):
-                    use_mask = gr.Checkbox(label="Use mask", value=d.use_mask, interactive=True)
-                    use_alpha_as_mask = gr.Checkbox(label="Use alpha as mask", value=d.use_alpha_as_mask, interactive=True)
-                    invert_mask = gr.Checkbox(label="Invert mask", value=d.invert_mask, interactive=True)
-                    overlay_mask = gr.Checkbox(label="Overlay mask", value=d.overlay_mask, interactive=True)
-                with gr.Row(variant='compact'):
-                    mask_file = gr.Textbox(label="Mask file", lines=1, interactive=True, value = d.mask_file)
-                with gr.Row(variant='compact'):
-                    mask_overlay_blur = gr.Slider(label="Mask overlay blur", minimum=0, maximum=64, step=1, value=d.mask_overlay_blur, interactive=True)
-                with gr.Row(variant='compact'):
-                    choice = mask_fill_choices[d.fill]
-                    fill = gr.Radio(label='Mask fill', choices=mask_fill_choices, value=choice, type="index")
-                with gr.Row(variant='compact'):
-                    full_res_mask = gr.Checkbox(label="Full res mask", value=d.full_res_mask, interactive=True)
-                    full_res_mask_padding = gr.Slider(minimum=0, maximum=512, step=1, label="Full res mask padding", value=d.full_res_mask_padding, interactive=True)
-                with gr.Row(variant='compact'):
-                    with gr.Column(min_width=240):
-                        mask_contrast_adjust = gr.Number(label="Mask contrast adjust", value=d.mask_contrast_adjust, interactive=True)
-                    with gr.Column(min_width=250):
-                        mask_brightness_adjust = gr.Number(label="Mask brightness adjust", value=d.mask_brightness_adjust, interactive=True)
-            # PARSEQ ACCORD
-            with gr.Accordion('Parseq', open=False):
-                gr.HTML("""
-                Use an <a style='color:SteelBlue;' target='_blank' href='https://sd-parseq.web.app/deforum'>sd-parseq manifest</a> for your animation (leave blank to ignore).</p>
-                <p style="margin-top:1em">
-                    Note that parseq overrides:
-                    <ul style="list-style-type:circle; margin-left:2em; margin-bottom:1em">
-                        <li>Run: seed, subseed, subseed strength.</li>
-                        <li>Keyframes: generation settings (noise, strength, contrast, scale).</li>
-                        <li>Keyframes: motion parameters for 2D and 3D (angle, zoom, translation, rotation, perspective flip).</li>
-                    </ul>
-                </p>
-                <p">
-                    Parseq does <strong><em>not</em></strong> override:
-                    <ul style="list-style-type:circle; margin-left:2em; margin-bottom:1em">
-                        <li>Run: Sampler, Width, Height, tiling, resize seed.</li>
-                        <li>Keyframes: animation settings (animation mode, max frames, border) </li>
-                        <li>Keyframes: coherence (color coherence & cadence) </li>
-                        <li>Keyframes: depth warping</li>
-                        <li>Output settings: all settings (including fps and max frames)</li>
-                    </ul>
-                </p>
-                """)
-                with gr.Row(variant='compact'):
-                    parseq_manifest = gr.Textbox(label="Parseq Manifest (JSON or URL)", lines=4, value = dp.parseq_manifest, interactive=True)
-                with gr.Row(variant='compact'):
-                    parseq_use_deltas = gr.Checkbox(label="Use delta values for movement parameters", value=dp.parseq_use_deltas, interactive=True)            
-        def show_hybrid_html_msg(choice):
-            if choice not in ['2D','3D']:
-                return gr.update(visible=True) 
-            else:
-                return gr.update(visible=False)
-        def change_hybrid_tab_status(choice):
-            if choice in ['2D','3D']:
-                return gr.update(visible=True) 
-            else:
-                return gr.update(visible=False)
-        # CONTROLNET TAB
-        with gr.Tab('ControlNet'):
-                gr.HTML("""
-                Requires the <a style='color:SteelBlue;' target='_blank' href='https://github.com/Mikubill/sd-webui-controlnet'>ControlNet</a> extension to be installed.</p>
-                <p style="margin-top:0.2em">
-                    *Work In Progress*. All params below are going to be keyframable at some point. If you want to speedup the integration, join Deforum's development. &#128521;
-                </p>
-                <p">
-                    Due to ControlNet base extension's inner works it needs its models to be located at 'extensions/deforum-for-automatic1111-webui/models'. So copy, symlink or move them there until a more elegant solution is found. And, as of now, it requires use_init checked for the first run. The ControlNet extension version used in the dev process is a24089a62e70a7fae44b7bf35b51fd584dd55e25, if even with all the other options above used it still breaks, upgrade/downgrade your CN version to this one.
-                </p>
-                """)
-                controlnet_dict = setup_controlnet_ui()
-        # HYBRID VIDEO TAB
-        with gr.Tab('Hybrid Video'):
-            # this html only shows when not in 2d/3d mode
-            hybrid_msg_html = gr.HTML(value='Please, change animation mode to 2D or 3D to enable Hybrid Mode',visible=False, elem_id='hybrid_msg_html')
-            # HYBRID INFO ACCORD
-            with gr.Accordion("Info & Help", open=False):
-                hybrid_html = "<p style=\"padding-bottom:0\"><b style=\"text-shadow: blue -1px -1px;\">Hybrid Video Compositing in 2D/3D Mode</b><span style=\"color:#DDD;font-size:0.7rem;text-shadow: black -1px -1px;margin-left:10px;\">by <a href=\"https://github.com/reallybigname\">reallybigname</a></span></p>"
-                hybrid_html += "<ul style=\"list-style-type:circle; margin-left:1em; margin-bottom:1em;\"><li>Composite video with previous frame init image in <b>2D or 3D animation_mode</b> <i>(not for Video Input mode)</i></li>"
-                hybrid_html += "<li>Uses your <b>Init</b> settings for <b>video_init_path, extract_nth_frame, overwrite_extracted_frames</b></li>"
-                hybrid_html += "<li>In Keyframes tab, you can also set <b>color_coherence</b> = '<b>Video Input</b>'</li>"
-                hybrid_html += "<li><b>color_coherence_video_every_N_frames</b> lets you only match every N frames</li>"
-                hybrid_html += "<li>Color coherence may be used with hybrid composite off, to just use video color.</li>"
-                hybrid_html += "<li>Hybrid motion may be used with hybrid composite off, to just use video motion.</li></ul>"
-                hybrid_html += "Hybrid Video Schedules"
-                hybrid_html += "<ul style=\"list-style-type:circle; margin-left:1em; margin-bottom:1em;\"><li>The alpha schedule controls overall alpha for video mix, whether using a composite mask or not.</li>"
-                hybrid_html += "<li>The <b>hybrid_comp_mask_blend_alpha_schedule</b> only affects the 'Blend' <b>hybrid_comp_mask_type</b>.</li>"
-                hybrid_html += "<li>Mask contrast schedule is from 0-255. Normal is 1. Affects all masks.</li>"
-                hybrid_html += "<li>Autocontrast low/high cutoff schedules 0-100. Low 0 High 100 is full range. <br>(<i><b>hybrid_comp_mask_auto_contrast</b> must be enabled</i>)</li></ul>"            
-                hybrid_html += "<a style='color:SteelBlue;' target='_blank' href='https://github.com/deforum-art/deforum-for-automatic1111-webui/wiki/Animation-Settings#hybrid-video-mode-for-2d3d-animations'>Click Here</a> for more info/ a Guide."      
-                gr.HTML(hybrid_html)
-            # HYBRID SETTINGS ACCORD
-            with gr.Accordion("Hybrid Settings", open=True) as hybrid_settings_accord:
-                with gr.Row(variant='compact'):
-                    with gr.Column(min_width=340):
-                        with gr.Row(variant='compact'):
-                            hybrid_generate_inputframes = gr.Checkbox(label="Generate inputframes", value=False, interactive=True)
-                            hybrid_composite = gr.Checkbox(label="Hybrid composite", value=False, interactive=True)
-                    with gr.Column(min_width=340) as hybrid_2nd_column:
-                        with gr.Row(variant='compact'):
-                            hybrid_use_first_frame_as_init_image = gr.Checkbox(label="First frame as init image", value=da.hybrid_use_first_frame_as_init_image, interactive=True, visible=False)
-                            hybrid_motion_use_prev_img = gr.Checkbox(label="Motion use prev img", value=False, interactive=True, visible=False)
-                with gr.Row(variant='compact') as hybrid_flow_row:
-                    with gr.Column(variant='compact'):
-                        with gr.Row(variant='compact'):
-                            hybrid_motion = gr.Radio(['None', 'Optical Flow', 'Perspective', 'Affine'], label="Hybrid motion", value=da.hybrid_motion, elem_id="hybrid_motion")
-                    with gr.Column(variant='compact'):
-                        with gr.Row(variant='compact'):
-                            with gr.Column(scale=1):
-                                hybrid_flow_method = gr.Radio(['DIS Medium', 'Farneback'], label="Flow method", value=da.hybrid_flow_method, elem_id="hybrid_flow_method", visible=False)
-                                hybrid_comp_mask_type = gr.Radio(['None', 'Depth', 'Video Depth', 'Blend', 'Difference'], label="Comp mask type", value=da.hybrid_comp_mask_type, elem_id="hybrid_comp_mask_type", visible=False)
-                with gr.Row(visible=False, variant='compact') as hybrid_comp_mask_row:
-                    hybrid_comp_mask_equalize = gr.Radio(['None', 'Before', 'After', 'Both'], label="Comp mask equalize", value=da.hybrid_comp_mask_equalize, elem_id="hybrid_comp_mask_equalize")
-                    with gr.Column(variant='compact'):
-                        hybrid_comp_mask_auto_contrast = gr.Checkbox(label="Comp mask auto contrast", value=False, interactive=True)
-                        hybrid_comp_mask_inverse = gr.Checkbox(label="Comp mask inverse", value=False, interactive=True)
-                with gr.Row(variant='compact'):
-                        hybrid_comp_save_extra_frames = gr.Checkbox(label="Comp save extra frames", value=False, interactive=True)
-            # HYBRID SCHEDULES ACCORD
-            with gr.Accordion("Hybrid Schedules", open=False, visible=False) as hybrid_sch_accord:
-                with gr.Row(variant='compact') as hybrid_comp_alpha_schedule_row:
-                    hybrid_comp_alpha_schedule = gr.Textbox(label="Comp alpha schedule", lines=1, value = da.hybrid_comp_alpha_schedule, interactive=True)
-                with gr.Row(variant='compact', visible=False) as hybrid_comp_mask_blend_alpha_schedule_row:
-                    hybrid_comp_mask_blend_alpha_schedule = gr.Textbox(label="Comp mask blend alpha schedule", lines=1, value = da.hybrid_comp_mask_blend_alpha_schedule, interactive=True, elem_id="hybridelemtest")
-                with gr.Row(variant='compact', visible=False) as hybrid_comp_mask_contrast_schedule_row:
-                    hybrid_comp_mask_contrast_schedule = gr.Textbox(label="Comp mask contrast schedule", lines=1, value = da.hybrid_comp_mask_contrast_schedule, interactive=True)
-                with gr.Row(variant='compact', visible=False) as hybrid_comp_mask_auto_contrast_cutoff_high_schedule_row :
-                    hybrid_comp_mask_auto_contrast_cutoff_high_schedule = gr.Textbox(label="Comp mask auto contrast cutoff high schedule", lines=1, value = da.hybrid_comp_mask_auto_contrast_cutoff_high_schedule, interactive=True)
-                with gr.Row(variant='compact', visible=False) as hybrid_comp_mask_auto_contrast_cutoff_low_schedule_row:
-                    hybrid_comp_mask_auto_contrast_cutoff_low_schedule = gr.Textbox(label="Comp mask auto contrast cutoff low schedule", lines=1, value = da.hybrid_comp_mask_auto_contrast_cutoff_low_schedule, interactive=True)
-            # HUMANS MASKING ACCORD
-            with gr.Accordion("Humans Masking", open=False, visible=False) as humans_masking_accord:
-                with gr.Row(variant='compact'):
-                    hybrid_generate_human_masks = gr.Radio(['None', 'PNGs', 'Video', 'Both'], label="Generate human masks", value=da.hybrid_generate_human_masks, elem_id="hybrid_generate_human_masks")
-        # OUTPUT TAB
-        with gr.Tab('Output'):
-            # VID OUTPUT ACCORD
-            with gr.Accordion('Video Output Settings', open=True):
-                with gr.Row(variant='compact') as fps_out_format_row:
-                    fps = gr.Slider(label="FPS", value=dv.fps, minimum=1, maximum=240, step=1)
-                    # NOT VISIBLE AS OF 11-02-23 moving to ffmpeg-only!
-                    output_format = gr.Dropdown(visible=False, label="Output format", choices=['FFMPEG mp4'], value='FFMPEG mp4', type="value", elem_id="output_format", interactive=True)
-                with gr.Column(variant='compact'):
-                    with gr.Row(variant='compact') as soundtrack_row:
-                        add_soundtrack = gr.Radio(['None', 'File', 'Init Video'], label="Add soundtrack", value=dv.add_soundtrack)
-                        soundtrack_path = gr.Textbox(label="Soundtrack path", lines=1, interactive=True, value = dv.soundtrack_path)
-                    with gr.Row(variant='compact'):
-                        skip_video_creation = gr.Checkbox(label="Skip video creation", value=dv.skip_video_creation, interactive=True)
-                        delete_imgs = gr.Checkbox(label="Delete Imgs", value=dv.delete_imgs, interactive=True)
-                        store_frames_in_ram = gr.Checkbox(label="Store frames in ram", value=dv.store_frames_in_ram, interactive=True)
-                        save_depth_maps = gr.Checkbox(label="Save depth maps", value=da.save_depth_maps, interactive=True)
-                        # the following param only shows for windows and linux users!
-                        make_gif = gr.Checkbox(label="Make GIF", value=dv.make_gif, interactive=True)
-                with gr.Row(equal_height=True, variant='compact', visible=True) as r_upscale_row:
-                    r_upscale_video = gr.Checkbox(label="Upscale", value=dv.r_upscale_video, interactive=True)
-                    r_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
-                    r_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
-                    r_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=dv.r_upscale_keep_imgs, interactive=True)
-                with gr.Accordion('FFmpeg settings', visible=True, open=False) as ffmpeg_quality_accordion:
-                    with gr.Row(equal_height=True, variant='compact', visible=True) as ffmpeg_set_row:
-                        ffmpeg_crf = gr.Slider(minimum=0, maximum=51, step=1, label="CRF", value=dv.ffmpeg_crf, interactive=True)
-                        ffmpeg_preset = gr.Dropdown(label="Preset", choices=['veryslow', 'slower', 'slow', 'medium', 'fast', 'faster', 'veryfast', 'superfast', 'ultrafast'], interactive=True, value = dv.ffmpeg_preset, type="value")
-                    with gr.Row(equal_height=True, variant='compact', visible=True) as ffmpeg_location_row:
-                        ffmpeg_location = gr.Textbox(label="Location", lines=1, interactive=True, value = dv.ffmpeg_location)
-            # FRAME INTERPOLATION TAB
-            with gr.Tab('Frame Interpolation') as frame_interp_tab:
-                with gr.Accordion('Important notes and Help', open=False):
+                    animation_prompts_negative = gr.Textbox(label="Prompts negative", lines=1, interactive=True, value = "")
+                # COMPOSABLE MASK SCHEDULING ACCORD
+                with gr.Accordion('Composable Mask scheduling', open=False):
                     gr.HTML("""
-                    Use <a href="https://github.com/megvii-research/ECCV2022-RIFE">RIFE</a> / <a href="https://film-net.github.io/">FILM</a> Frame Interpolation to smooth out, slow-mo (or both) any video.</p>
-                     <p style="margin-top:1em">
-                        Supported engines:
-                        <ul style="list-style-type:circle; margin-left:1em; margin-bottom:1em">
-                            <li>RIFE v4.6 and FILM.</li>
+                            <ul style="list-style-type:circle; margin-left:0.75em; margin-bottom:0.2em">
+                            <li>To enable, check use_mask in the Init tab</li>
+                            <li>Supports boolean operations: (! - negation, & - and, | - or, ^ - xor, \ - difference, () - nested operations)</li>
+                            <li>default variables: in \{\}, like \{init_mask\}, \{video_mask\}, \{everywhere\}</li>
+                            <li>masks from files: in [], like [mask1.png]</li>
+                            <li>description-based: <i>word masks</i> in &lt;&gt;, like &lt;apple&gt;, &lt;hair&gt</li>
+                            </ul>
+                            """)
+                    with gr.Row(variant='compact'):
+                        mask_schedule = gr.Textbox(label="Mask schedule", lines=1, value = da.mask_schedule, interactive=True)
+                    with gr.Row(variant='compact'):
+                        use_noise_mask = gr.Checkbox(label="Use noise mask", value=da.use_noise_mask, interactive=True)
+                    with gr.Row(variant='compact'):
+                        noise_mask_schedule = gr.Textbox(label="Noise mask schedule", lines=1, value = da.noise_mask_schedule, interactive=True)
+            # INIT MAIN TAB
+            with gr.TabItem('Init'):
+                # IMAGE INIT INNER-TAB
+                with gr.Tab('Image Init'):
+                    with gr.Row(variant='compact'):
+                        with gr.Column(min_width=150):
+                            use_init = gr.Checkbox(label="Use init", value=d.use_init, interactive=True, visible=True)
+                        with gr.Column(min_width=150):
+                            strength_0_no_init = gr.Checkbox(label="Strength 0 no init", value=True, interactive=True)
+                        with gr.Column(min_width=170):
+                            strength = gr.Slider(label="Strength", minimum=0, maximum=1, step=0.01, value=0, interactive=True)
+                    with gr.Row(variant='compact'):
+                        init_image = gr.Textbox(label="Init image", lines=1, interactive=True, value = d.init_image)
+                # VIDEO INIT INNER-TAB
+                with gr.Tab('Video Init'):
+                    with gr.Row(variant='compact'):
+                        video_init_path = gr.Textbox(label="Video init path", lines=1, value = da.video_init_path, interactive=True)
+                    with gr.Row(variant='compact'):
+                        extract_from_frame = gr.Number(label="Extract from frame", value=da.extract_from_frame, interactive=True, precision=0)
+                        extract_to_frame = gr.Number(label="Extract to frame", value=da.extract_to_frame, interactive=True, precision=0)
+                        extract_nth_frame = gr.Number(label="Extract nth frame", value=da.extract_nth_frame, interactive=True, precision=0)
+                        overwrite_extracted_frames = gr.Checkbox(label="Overwrite extracted frames", value=False, interactive=True)
+                        use_mask_video = gr.Checkbox(label="Use mask video", value=False, interactive=True)
+                    with gr.Row(variant='compact'):
+                        video_mask_path = gr.Textbox(label="Video mask path", lines=1, value = da.video_mask_path, interactive=True)
+                # MASK INIT INNER-TAB
+                with gr.Tab('Mask Init'):
+                    with gr.Row(variant='compact'):
+                        use_mask = gr.Checkbox(label="Use mask", value=d.use_mask, interactive=True)
+                        use_alpha_as_mask = gr.Checkbox(label="Use alpha as mask", value=d.use_alpha_as_mask, interactive=True)
+                        invert_mask = gr.Checkbox(label="Invert mask", value=d.invert_mask, interactive=True)
+                        overlay_mask = gr.Checkbox(label="Overlay mask", value=d.overlay_mask, interactive=True)
+                    with gr.Row(variant='compact'):
+                        mask_file = gr.Textbox(label="Mask file", lines=1, interactive=True, value = d.mask_file)
+                    with gr.Row(variant='compact'):
+                        mask_overlay_blur = gr.Slider(label="Mask overlay blur", minimum=0, maximum=64, step=1, value=d.mask_overlay_blur, interactive=True)
+                    with gr.Row(variant='compact'):
+                        choice = mask_fill_choices[d.fill]
+                        fill = gr.Radio(label='Mask fill', choices=mask_fill_choices, value=choice, type="index")
+                    with gr.Row(variant='compact'):
+                        full_res_mask = gr.Checkbox(label="Full res mask", value=d.full_res_mask, interactive=True)
+                        full_res_mask_padding = gr.Slider(minimum=0, maximum=512, step=1, label="Full res mask padding", value=d.full_res_mask_padding, interactive=True)
+                    with gr.Row(variant='compact'):
+                        with gr.Column(min_width=240):
+                            mask_contrast_adjust = gr.Number(label="Mask contrast adjust", value=d.mask_contrast_adjust, interactive=True)
+                        with gr.Column(min_width=250):
+                            mask_brightness_adjust = gr.Number(label="Mask brightness adjust", value=d.mask_brightness_adjust, interactive=True)
+                # PARSEQ ACCORD
+                with gr.Accordion('Parseq', open=False):
+                    gr.HTML("""
+                    Use an <a style='color:SteelBlue;' target='_blank' href='https://sd-parseq.web.app/deforum'>sd-parseq manifest</a> for your animation (leave blank to ignore).</p>
+                    <p style="margin-top:1em">
+                        Note that parseq overrides:
+                        <ul style="list-style-type:circle; margin-left:2em; margin-bottom:1em">
+                            <li>Run: seed, subseed, subseed strength.</li>
+                            <li>Keyframes: generation settings (noise, strength, contrast, scale).</li>
+                            <li>Keyframes: motion parameters for 2D and 3D (angle, zoom, translation, rotation, perspective flip).</li>
                         </ul>
                     </p>
-                     <p style="margin-top:1em">
-                        Important notes:
-                        <ul style="list-style-type:circle; margin-left:1em; margin-bottom:1em">
-                            <li>Frame Interpolation will *not* run if any of the following are enabled: 'Store frames in ram' / 'Skip video for run all'.</li>
-                            <li>Audio (if provided) will *not* be transferred to the interpolated video if Slow-Mo is enabled.</li>
-                            <li>'add_soundtrack' and 'soundtrack_path' aren't being honoured in "Interpolate an existing video" mode. Original vid audio will be used instead with the same slow-mo rules above.</li>
-                            <li>In "Interpolate existing pics" mode, FPS is determined *only* by output FPS slider. Audio will be added if requested even with slow-mo "enabled", as it does *nothing* in this mode.</li>
+                    <p">
+                        Parseq does <strong><em>not</em></strong> override:
+                        <ul style="list-style-type:circle; margin-left:2em; margin-bottom:1em">
+                            <li>Run: Sampler, Width, Height, tiling, resize seed.</li>
+                            <li>Keyframes: animation settings (animation mode, max frames, border) </li>
+                            <li>Keyframes: coherence (color coherence & cadence) </li>
+                            <li>Keyframes: depth warping</li>
+                            <li>Output settings: all settings (including fps and max frames)</li>
                         </ul>
                     </p>
                     """)
-                with gr.Column(variant='compact'):
                     with gr.Row(variant='compact'):
-                        # Interpolation Engine
-                        frame_interpolation_engine = gr.Dropdown(label="Engine", choices=['None','RIFE v4.6','FILM'], value=dv.frame_interpolation_engine, type="value", elem_id="frame_interpolation_engine", interactive=True)
-                        frame_interpolation_slow_mo_enabled = gr.Checkbox(label="Slow Mo", elem_id="frame_interpolation_slow_mo_enabled", value=dv.frame_interpolation_slow_mo_enabled, interactive=True, visible=False)
-                        # If this is set to True, we keep all of the interpolated frames in a folder. Default is False - means we delete them at the end of the run
-                        frame_interpolation_keep_imgs = gr.Checkbox(label="Keep Imgs", elem_id="frame_interpolation_keep_imgs", value=dv.frame_interpolation_keep_imgs, interactive=True, visible=False)
-                    with gr.Row(variant='compact', visible=False) as frame_interp_amounts_row:
-                        with gr.Column(min_width=180) as frame_interp_x_amount_column:
-                            # How many times to interpolate (interp X)
-                            frame_interpolation_x_amount = gr.Slider(minimum=2, maximum=10, step=1, label="Interp X", value=dv.frame_interpolation_x_amount, interactive=True)
-                        with gr.Column(min_width=180, visible=False) as frame_interp_slow_mo_amount_column:
-                            # Interp Slow-Mo (setting final output fps, not really doing anything direclty with RIFE/FILM)
-                            frame_interpolation_slow_mo_amount =  gr.Slider(minimum=2, maximum=10, step=1, label="Slow-Mo X", value=dv.frame_interpolation_x_amount, interactive=True)
-                    with gr.Row(visible=False) as interp_existing_video_row:
-                        # Intrpolate any existing video from the connected PC
-                        with gr.Accordion('Interpolate existing Video/ Images', open=False) as interp_existing_video_accord:
-                            with gr.Row(variant='compact') as interpolate_upload_files_row:
-                                # A drag-n-drop UI box to which the user uploads a *single* (at this stage) video
-                                vid_to_interpolate_chosen_file = gr.File(label="Video to Interpolate", interactive=True, file_count="single", file_types=["video"], elem_id="vid_to_interpolate_chosen_file")
-                                # A drag-n-drop UI box to which the user uploads a pictures to interpolate
-                                pics_to_interpolate_chosen_file = gr.File(label="Pics to Interpolate", interactive=True, file_count="multiple", file_types=["image"], elem_id="pics_to_interpolate_chosen_file")
-                            with gr.Row(variant='compact', visible=False) as interp_live_stats_row:
-                                # Non interactive textbox showing uploaded input vid total Frame Count
-                                in_vid_frame_count_window = gr.Textbox(label="In Frame Count", lines=1, interactive=False, value='---')
-                                # Non interactive textbox showing uploaded input vid FPS
-                                in_vid_fps_ui_window = gr.Textbox(label="In FPS", lines=1, interactive=False, value='---')
-                                # Non interactive textbox showing expected output interpolated video FPS
-                                out_interp_vid_estimated_fps = gr.Textbox(label="Interpolated Vid FPS", value='---')
-                            with gr.Row(variant='compact') as interp_buttons_row:
-                                # This is the actual button that's pressed to initiate the interpolation:
-                                interpolate_button = gr.Button(value="*Interpolate Video*")
-                                interpolate_pics_button = gr.Button(value="*Interpolate Pics*")
-                            # Show a text about CLI outputs:
-                            gr.HTML("* check your CLI for outputs *", elem_id="below_interpolate_butts_msg") # TODO: CSS THIS TO CENTER OF ROW!
-                            # make the functin call when the interpolation button is clicked
-                            interpolate_button.click(upload_vid_to_interpolate,inputs=[vid_to_interpolate_chosen_file, frame_interpolation_engine, frame_interpolation_x_amount, frame_interpolation_slow_mo_enabled, frame_interpolation_slow_mo_amount, frame_interpolation_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset, in_vid_fps_ui_window])
-                            interpolate_pics_button.click(upload_pics_to_interpolate,inputs=[pics_to_interpolate_chosen_file, frame_interpolation_engine, frame_interpolation_x_amount, frame_interpolation_slow_mo_enabled, frame_interpolation_slow_mo_amount, frame_interpolation_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset, fps, add_soundtrack, soundtrack_path])
-            # VIDEO UPSCALE TAB
-            with gr.Tab('Video Upscaling'):
-                vid_to_upscale_chosen_file = gr.File(label="Video to Upscale", interactive=True, file_count="single", file_types=["video"], elem_id="vid_to_upscale_chosen_file")
-                with gr.Column():
-                    # NCNN UPSCALE TAB
-                    # with gr.Tab('Upscale V2') as ncnn_upscale_tab:
-                    with gr.Row(variant='compact') as ncnn_upload_vid_stats_row:
-                        # Non interactive textbox showing uploaded input vid total Frame Count
-                        ncnn_upscale_in_vid_frame_count_window = gr.Textbox(label="In Frame Count", lines=1, interactive=False, value='---')
-                        # Non interactive textbox showing uploaded input vid FPS
-                        ncnn_upscale_in_vid_fps_ui_window = gr.Textbox(label="In FPS", lines=1, interactive=False, value='---')
-                        # Non interactive textbox showing uploaded input resolution
-                        ncnn_upscale_in_vid_res = gr.Textbox(label="In Res", lines=1, interactive=False, value='---')
-                        # Non interactive textbox showing expected output resolution
-                        ncnn_upscale_out_vid_res = gr.Textbox(label="Out Res", value='---')
+                        parseq_manifest = gr.Textbox(label="Parseq Manifest (JSON or URL)", lines=4, value = dp.parseq_manifest, interactive=True)
+                    with gr.Row(variant='compact'):
+                        parseq_use_deltas = gr.Checkbox(label="Use delta values for movement parameters", value=dp.parseq_use_deltas, interactive=True)            
+            def show_hybrid_html_msg(choice):
+                if choice not in ['2D','3D']:
+                    return gr.update(visible=True) 
+                else:
+                    return gr.update(visible=False)
+            def change_hybrid_tab_status(choice):
+                if choice in ['2D','3D']:
+                    return gr.update(visible=True) 
+                else:
+                    return gr.update(visible=False)
+            # CONTROLNET TAB
+            with gr.TabItem('ControlNet'):
+                    gr.HTML("""
+                    Requires the <a style='color:SteelBlue;' target='_blank' href='https://github.com/Mikubill/sd-webui-controlnet'>ControlNet</a> extension to be installed.</p>
+                    <p style="margin-top:0.2em">
+                        *Work In Progress*. All params below are going to be keyframable at some point. If you want to speedup the integration, join Deforum's development. &#128521;
+                    </p>
+                    <p">
+                        Due to ControlNet base extension's inner works it needs its models to be located at 'extensions/deforum-for-automatic1111-webui/models'. So copy, symlink or move them there until a more elegant solution is found. And, as of now, it requires use_init checked for the first run. The ControlNet extension version used in the dev process is a24089a62e70a7fae44b7bf35b51fd584dd55e25, if even with all the other options above used it still breaks, upgrade/downgrade your CN version to this one.
+                    </p>
+                    """)
+                    controlnet_dict = setup_controlnet_ui()
+            # HYBRID VIDEO TAB
+            with gr.TabItem('Hybrid Video'):
+                # this html only shows when not in 2d/3d mode
+                hybrid_msg_html = gr.HTML(value='Please, change animation mode to 2D or 3D to enable Hybrid Mode',visible=False, elem_id='hybrid_msg_html')
+                # HYBRID INFO ACCORD
+                with gr.Accordion("Info & Help", open=False):
+                    hybrid_html = "<p style=\"padding-bottom:0\"><b style=\"text-shadow: blue -1px -1px;\">Hybrid Video Compositing in 2D/3D Mode</b><span style=\"color:#DDD;font-size:0.7rem;text-shadow: black -1px -1px;margin-left:10px;\">by <a href=\"https://github.com/reallybigname\">reallybigname</a></span></p>"
+                    hybrid_html += "<ul style=\"list-style-type:circle; margin-left:1em; margin-bottom:1em;\"><li>Composite video with previous frame init image in <b>2D or 3D animation_mode</b> <i>(not for Video Input mode)</i></li>"
+                    hybrid_html += "<li>Uses your <b>Init</b> settings for <b>video_init_path, extract_nth_frame, overwrite_extracted_frames</b></li>"
+                    hybrid_html += "<li>In Keyframes tab, you can also set <b>color_coherence</b> = '<b>Video Input</b>'</li>"
+                    hybrid_html += "<li><b>color_coherence_video_every_N_frames</b> lets you only match every N frames</li>"
+                    hybrid_html += "<li>Color coherence may be used with hybrid composite off, to just use video color.</li>"
+                    hybrid_html += "<li>Hybrid motion may be used with hybrid composite off, to just use video motion.</li></ul>"
+                    hybrid_html += "Hybrid Video Schedules"
+                    hybrid_html += "<ul style=\"list-style-type:circle; margin-left:1em; margin-bottom:1em;\"><li>The alpha schedule controls overall alpha for video mix, whether using a composite mask or not.</li>"
+                    hybrid_html += "<li>The <b>hybrid_comp_mask_blend_alpha_schedule</b> only affects the 'Blend' <b>hybrid_comp_mask_type</b>.</li>"
+                    hybrid_html += "<li>Mask contrast schedule is from 0-255. Normal is 1. Affects all masks.</li>"
+                    hybrid_html += "<li>Autocontrast low/high cutoff schedules 0-100. Low 0 High 100 is full range. <br>(<i><b>hybrid_comp_mask_auto_contrast</b> must be enabled</i>)</li></ul>"            
+                    hybrid_html += "<a style='color:SteelBlue;' target='_blank' href='https://github.com/deforum-art/deforum-for-automatic1111-webui/wiki/Animation-Settings#hybrid-video-mode-for-2d3d-animations'>Click Here</a> for more info/ a Guide."      
+                    gr.HTML(hybrid_html)
+                # HYBRID SETTINGS ACCORD
+                with gr.Accordion("Hybrid Settings", open=True) as hybrid_settings_accord:
+                    with gr.Row(variant='compact'):
+                        with gr.Column(min_width=340):
+                            with gr.Row(variant='compact'):
+                                hybrid_generate_inputframes = gr.Checkbox(label="Generate inputframes", value=False, interactive=True)
+                                hybrid_composite = gr.Checkbox(label="Hybrid composite", value=False, interactive=True)
+                        with gr.Column(min_width=340) as hybrid_2nd_column:
+                            with gr.Row(variant='compact'):
+                                hybrid_use_first_frame_as_init_image = gr.Checkbox(label="First frame as init image", value=da.hybrid_use_first_frame_as_init_image, interactive=True, visible=False)
+                                hybrid_motion_use_prev_img = gr.Checkbox(label="Motion use prev img", value=False, interactive=True, visible=False)
+                    with gr.Row(variant='compact') as hybrid_flow_row:
+                        with gr.Column(variant='compact'):
+                            with gr.Row(variant='compact'):
+                                hybrid_motion = gr.Radio(['None', 'Optical Flow', 'Perspective', 'Affine'], label="Hybrid motion", value=da.hybrid_motion, elem_id="hybrid_motion")
+                        with gr.Column(variant='compact'):
+                            with gr.Row(variant='compact'):
+                                with gr.Column(scale=1):
+                                    hybrid_flow_method = gr.Radio(['DIS Medium', 'Farneback'], label="Flow method", value=da.hybrid_flow_method, elem_id="hybrid_flow_method", visible=False)
+                                    hybrid_comp_mask_type = gr.Radio(['None', 'Depth', 'Video Depth', 'Blend', 'Difference'], label="Comp mask type", value=da.hybrid_comp_mask_type, elem_id="hybrid_comp_mask_type", visible=False)
+                    with gr.Row(visible=False, variant='compact') as hybrid_comp_mask_row:
+                        hybrid_comp_mask_equalize = gr.Radio(['None', 'Before', 'After', 'Both'], label="Comp mask equalize", value=da.hybrid_comp_mask_equalize, elem_id="hybrid_comp_mask_equalize")
+                        with gr.Column(variant='compact'):
+                            hybrid_comp_mask_auto_contrast = gr.Checkbox(label="Comp mask auto contrast", value=False, interactive=True)
+                            hybrid_comp_mask_inverse = gr.Checkbox(label="Comp mask inverse", value=False, interactive=True)
+                    with gr.Row(variant='compact'):
+                            hybrid_comp_save_extra_frames = gr.Checkbox(label="Comp save extra frames", value=False, interactive=True)
+                # HYBRID SCHEDULES ACCORD
+                with gr.Accordion("Hybrid Schedules", open=False, visible=False) as hybrid_sch_accord:
+                    with gr.Row(variant='compact') as hybrid_comp_alpha_schedule_row:
+                        hybrid_comp_alpha_schedule = gr.Textbox(label="Comp alpha schedule", lines=1, value = da.hybrid_comp_alpha_schedule, interactive=True)
+                    with gr.Row(variant='compact', visible=False) as hybrid_comp_mask_blend_alpha_schedule_row:
+                        hybrid_comp_mask_blend_alpha_schedule = gr.Textbox(label="Comp mask blend alpha schedule", lines=1, value = da.hybrid_comp_mask_blend_alpha_schedule, interactive=True, elem_id="hybridelemtest")
+                    with gr.Row(variant='compact', visible=False) as hybrid_comp_mask_contrast_schedule_row:
+                        hybrid_comp_mask_contrast_schedule = gr.Textbox(label="Comp mask contrast schedule", lines=1, value = da.hybrid_comp_mask_contrast_schedule, interactive=True)
+                    with gr.Row(variant='compact', visible=False) as hybrid_comp_mask_auto_contrast_cutoff_high_schedule_row :
+                        hybrid_comp_mask_auto_contrast_cutoff_high_schedule = gr.Textbox(label="Comp mask auto contrast cutoff high schedule", lines=1, value = da.hybrid_comp_mask_auto_contrast_cutoff_high_schedule, interactive=True)
+                    with gr.Row(variant='compact', visible=False) as hybrid_comp_mask_auto_contrast_cutoff_low_schedule_row:
+                        hybrid_comp_mask_auto_contrast_cutoff_low_schedule = gr.Textbox(label="Comp mask auto contrast cutoff low schedule", lines=1, value = da.hybrid_comp_mask_auto_contrast_cutoff_low_schedule, interactive=True)
+                # HUMANS MASKING ACCORD
+                with gr.Accordion("Humans Masking", open=False, visible=False) as humans_masking_accord:
+                    with gr.Row(variant='compact'):
+                        hybrid_generate_human_masks = gr.Radio(['None', 'PNGs', 'Video', 'Both'], label="Generate human masks", value=da.hybrid_generate_human_masks, elem_id="hybrid_generate_human_masks")
+            # OUTPUT TAB
+            with gr.TabItem('Output', elem_id='output_tab'):
+                # VID OUTPUT ACCORD
+                with gr.Accordion('Video Output Settings', open=True):
+                    with gr.Row(variant='compact') as fps_out_format_row:
+                        fps = gr.Slider(label="FPS", value=dv.fps, minimum=1, maximum=240, step=1)
+                        # NOT VISIBLE AS OF 11-02-23 moving to ffmpeg-only!
+                        output_format = gr.Dropdown(visible=False, label="Output format", choices=['FFMPEG mp4'], value='FFMPEG mp4', type="value", elem_id="output_format", interactive=True)
+                    with gr.Column(variant='compact'):
+                        with gr.Row(variant='compact') as soundtrack_row:
+                            add_soundtrack = gr.Radio(['None', 'File', 'Init Video'], label="Add soundtrack", value=dv.add_soundtrack)
+                            soundtrack_path = gr.Textbox(label="Soundtrack path", lines=1, interactive=True, value = dv.soundtrack_path)
+                        with gr.Row(variant='compact'):
+                            skip_video_creation = gr.Checkbox(label="Skip video creation", value=dv.skip_video_creation, interactive=True)
+                            delete_imgs = gr.Checkbox(label="Delete Imgs", value=dv.delete_imgs, interactive=True)
+                            store_frames_in_ram = gr.Checkbox(label="Store frames in ram", value=dv.store_frames_in_ram, interactive=True)
+                            save_depth_maps = gr.Checkbox(label="Save depth maps", value=da.save_depth_maps, interactive=True)
+                            # the following param only shows for windows and linux users!
+                            make_gif = gr.Checkbox(label="Make GIF", value=dv.make_gif, interactive=True)
+                    with gr.Row(equal_height=True, variant='compact', visible=True) as r_upscale_row:
+                        r_upscale_video = gr.Checkbox(label="Upscale", value=dv.r_upscale_video, interactive=True)
+                        r_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = dv.r_upscale_model, type="value")
+                        r_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value=dv.r_upscale_factor, type="value")
+                        r_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=dv.r_upscale_keep_imgs, interactive=True)
+                    with gr.Accordion('FFmpeg settings', visible=True, open=False) as ffmpeg_quality_accordion:
+                        with gr.Row(equal_height=True, variant='compact', visible=True) as ffmpeg_set_row:
+                            ffmpeg_crf = gr.Slider(minimum=0, maximum=51, step=1, label="CRF", value=dv.ffmpeg_crf, interactive=True)
+                            ffmpeg_preset = gr.Dropdown(label="Preset", choices=['veryslow', 'slower', 'slow', 'medium', 'fast', 'faster', 'veryfast', 'superfast', 'ultrafast'], interactive=True, value = dv.ffmpeg_preset, type="value")
+                        with gr.Row(equal_height=True, variant='compact', visible=True) as ffmpeg_location_row:
+                            ffmpeg_location = gr.Textbox(label="Location", lines=1, interactive=True, value = dv.ffmpeg_location)
+                # FRAME INTERPOLATION TAB
+                with gr.Tab('Frame Interpolation') as frame_interp_tab:
+                    with gr.Accordion('Important notes and Help', open=False):
+                        gr.HTML("""
+                        Use <a href="https://github.com/megvii-research/ECCV2022-RIFE">RIFE</a> / <a href="https://film-net.github.io/">FILM</a> Frame Interpolation to smooth out, slow-mo (or both) any video.</p>
+                         <p style="margin-top:1em">
+                            Supported engines:
+                            <ul style="list-style-type:circle; margin-left:1em; margin-bottom:1em">
+                                <li>RIFE v4.6 and FILM.</li>
+                            </ul>
+                        </p>
+                         <p style="margin-top:1em">
+                            Important notes:
+                            <ul style="list-style-type:circle; margin-left:1em; margin-bottom:1em">
+                                <li>Frame Interpolation will *not* run if any of the following are enabled: 'Store frames in ram' / 'Skip video for run all'.</li>
+                                <li>Audio (if provided) will *not* be transferred to the interpolated video if Slow-Mo is enabled.</li>
+                                <li>'add_soundtrack' and 'soundtrack_path' aren't being honoured in "Interpolate an existing video" mode. Original vid audio will be used instead with the same slow-mo rules above.</li>
+                                <li>In "Interpolate existing pics" mode, FPS is determined *only* by output FPS slider. Audio will be added if requested even with slow-mo "enabled", as it does *nothing* in this mode.</li>
+                            </ul>
+                        </p>
+                        """)
+                    with gr.Column(variant='compact'):
+                        with gr.Row(variant='compact'):
+                            # Interpolation Engine
+                            frame_interpolation_engine = gr.Dropdown(label="Engine", choices=['None','RIFE v4.6','FILM'], value=dv.frame_interpolation_engine, type="value", elem_id="frame_interpolation_engine", interactive=True)
+                            frame_interpolation_slow_mo_enabled = gr.Checkbox(label="Slow Mo", elem_id="frame_interpolation_slow_mo_enabled", value=dv.frame_interpolation_slow_mo_enabled, interactive=True, visible=False)
+                            # If this is set to True, we keep all of the interpolated frames in a folder. Default is False - means we delete them at the end of the run
+                            frame_interpolation_keep_imgs = gr.Checkbox(label="Keep Imgs", elem_id="frame_interpolation_keep_imgs", value=dv.frame_interpolation_keep_imgs, interactive=True, visible=False)
+                        with gr.Row(variant='compact', visible=False) as frame_interp_amounts_row:
+                            with gr.Column(min_width=180) as frame_interp_x_amount_column:
+                                # How many times to interpolate (interp X)
+                                frame_interpolation_x_amount = gr.Slider(minimum=2, maximum=10, step=1, label="Interp X", value=dv.frame_interpolation_x_amount, interactive=True)
+                            with gr.Column(min_width=180, visible=False) as frame_interp_slow_mo_amount_column:
+                                # Interp Slow-Mo (setting final output fps, not really doing anything direclty with RIFE/FILM)
+                                frame_interpolation_slow_mo_amount =  gr.Slider(minimum=2, maximum=10, step=1, label="Slow-Mo X", value=dv.frame_interpolation_x_amount, interactive=True)
+                        with gr.Row(visible=False) as interp_existing_video_row:
+                            # Intrpolate any existing video from the connected PC
+                            with gr.Accordion('Interpolate existing Video/ Images', open=False) as interp_existing_video_accord:
+                                with gr.Row(variant='compact') as interpolate_upload_files_row:
+                                    # A drag-n-drop UI box to which the user uploads a *single* (at this stage) video
+                                    vid_to_interpolate_chosen_file = gr.File(label="Video to Interpolate", interactive=True, file_count="single", file_types=["video"], elem_id="vid_to_interpolate_chosen_file")
+                                    # A drag-n-drop UI box to which the user uploads a pictures to interpolate
+                                    pics_to_interpolate_chosen_file = gr.File(label="Pics to Interpolate", interactive=True, file_count="multiple", file_types=["image"], elem_id="pics_to_interpolate_chosen_file")
+                                with gr.Row(variant='compact', visible=False) as interp_live_stats_row:
+                                    # Non interactive textbox showing uploaded input vid total Frame Count
+                                    in_vid_frame_count_window = gr.Textbox(label="In Frame Count", lines=1, interactive=False, value='---')
+                                    # Non interactive textbox showing uploaded input vid FPS
+                                    in_vid_fps_ui_window = gr.Textbox(label="In FPS", lines=1, interactive=False, value='---')
+                                    # Non interactive textbox showing expected output interpolated video FPS
+                                    out_interp_vid_estimated_fps = gr.Textbox(label="Interpolated Vid FPS", value='---')
+                                with gr.Row(variant='compact') as interp_buttons_row:
+                                    # This is the actual button that's pressed to initiate the interpolation:
+                                    interpolate_button = gr.Button(value="*Interpolate Video*")
+                                    interpolate_pics_button = gr.Button(value="*Interpolate Pics*")
+                                # Show a text about CLI outputs:
+                                gr.HTML("* check your CLI for outputs *", elem_id="below_interpolate_butts_msg") # TODO: CSS THIS TO CENTER OF ROW!
+                                # make the functin call when the interpolation button is clicked
+                                interpolate_button.click(upload_vid_to_interpolate,inputs=[vid_to_interpolate_chosen_file, frame_interpolation_engine, frame_interpolation_x_amount, frame_interpolation_slow_mo_enabled, frame_interpolation_slow_mo_amount, frame_interpolation_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset, in_vid_fps_ui_window])
+                                interpolate_pics_button.click(upload_pics_to_interpolate,inputs=[pics_to_interpolate_chosen_file, frame_interpolation_engine, frame_interpolation_x_amount, frame_interpolation_slow_mo_enabled, frame_interpolation_slow_mo_amount, frame_interpolation_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset, fps, add_soundtrack, soundtrack_path])
+                # VIDEO UPSCALE TAB
+                with gr.TabItem('Video Upscaling'):
+                    vid_to_upscale_chosen_file = gr.File(label="Video to Upscale", interactive=True, file_count="single", file_types=["video"], elem_id="vid_to_upscale_chosen_file")
                     with gr.Column():
-                        with gr.Row(variant='compact', visible=True) as ncnn_actual_upscale_row:
-                            ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = "realesr-animevideov3", type="value")
-                            ncnn_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value="x2", type="value")
-                            ncnn_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=True, interactive=True) # fix value
-                    ncnn_upscale_btn = gr.Button(value="*Upscale uploaded video*")
-                    ncnn_upscale_btn.click(ncnn_upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, ncnn_upscale_in_vid_fps_ui_window, ncnn_upscale_in_vid_res, ncnn_upscale_out_vid_res, ncnn_upscale_model, ncnn_upscale_factor, ncnn_upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
-                    # with gr.Tab('Upscale V1'):
-                    with gr.Column(visible=False): # Disabled 06-03-23
-                        selected_tab = gr.State(value=0)
-                        with gr.Tabs(elem_id="extras_resize_mode"):
-                            with gr.TabItem('Scale by', elem_id="extras_scale_by_tab") as tab_scale_by:
-                                upscaling_resize = gr.Slider(minimum=1.0, maximum=8.0, step=0.05, label="Resize", value=2, elem_id="extras_upscaling_resize")
-                            with gr.TabItem('Scale to', elem_id="extras_scale_to_tab") as tab_scale_to:
-                                with FormRow():
-                                    upscaling_resize_w = gr.Slider(label="Width", minimum=1, maximum=7680, step=1, value=512, elem_id="extras_upscaling_resize_w")
-                                    upscaling_resize_h = gr.Slider(label="Height", minimum=1, maximum=7680, step=1, value=512, elem_id="extras_upscaling_resize_h")
-                                    upscaling_crop = gr.Checkbox(label='Crop to fit', value=True, elem_id="extras_upscaling_crop")
-                        with FormRow():
-                            extras_upscaler_1 = gr.Dropdown(label='Upscaler 1', elem_id="extras_upscaler_1", choices=[x.name for x in sh.sd_upscalers], value=sh.sd_upscalers[3].name)
-                            extras_upscaler_2 = gr.Dropdown(label='Upscaler 2', elem_id="extras_upscaler_2", choices=[x.name for x in sh.sd_upscalers], value=sh.sd_upscalers[0].name)
-                        with FormRow():
-                            with gr.Column(scale=3):
-                                extras_upscaler_2_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Upscaler 2 visibility", value=0.0, elem_id="extras_upscaler_2_visibility")
-                            with gr.Column(scale=1, min_width=80):
-                                upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", elem_id="upscale_keep_imgs", value=True, interactive=True)
-                        tab_scale_by.select(fn=lambda: 0, inputs=[], outputs=[selected_tab])
-                        tab_scale_to.select(fn=lambda: 1, inputs=[], outputs=[selected_tab])
+                        # NCNN UPSCALE TAB
+                        # with gr.Tab('Upscale V2') as ncnn_upscale_tab:
+                        with gr.Row(variant='compact') as ncnn_upload_vid_stats_row:
+                            # Non interactive textbox showing uploaded input vid total Frame Count
+                            ncnn_upscale_in_vid_frame_count_window = gr.Textbox(label="In Frame Count", lines=1, interactive=False, value='---')
+                            # Non interactive textbox showing uploaded input vid FPS
+                            ncnn_upscale_in_vid_fps_ui_window = gr.Textbox(label="In FPS", lines=1, interactive=False, value='---')
+                            # Non interactive textbox showing uploaded input resolution
+                            ncnn_upscale_in_vid_res = gr.Textbox(label="In Res", lines=1, interactive=False, value='---')
+                            # Non interactive textbox showing expected output resolution
+                            ncnn_upscale_out_vid_res = gr.Textbox(label="Out Res", value='---')
+                        with gr.Column():
+                            with gr.Row(variant='compact', visible=True) as ncnn_actual_upscale_row:
+                                ncnn_upscale_model = gr.Dropdown(label="Upscale model", choices=['realesr-animevideov3', 'realesrgan-x4plus', 'realesrgan-x4plus-anime'], interactive=True, value = "realesr-animevideov3", type="value")
+                                ncnn_upscale_factor =  gr.Dropdown(choices=['x2', 'x3', 'x4'], label="Upscale factor", interactive=True, value="x2", type="value")
+                                ncnn_upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", value=True, interactive=True) # fix value
+                        ncnn_upscale_btn = gr.Button(value="*Upscale uploaded video*")
+                        ncnn_upscale_btn.click(ncnn_upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, ncnn_upscale_in_vid_fps_ui_window, ncnn_upscale_in_vid_res, ncnn_upscale_out_vid_res, ncnn_upscale_model, ncnn_upscale_factor, ncnn_upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
+                        # with gr.Tab('Upscale V1'):
+                        with gr.Column(visible=False): # Disabled 06-03-23
+                            selected_tab = gr.State(value=0)
+                            with gr.Tabs(elem_id="extras_resize_mode"):
+                                with gr.TabItem('Scale by', elem_id="extras_scale_by_tab") as tab_scale_by:
+                                    upscaling_resize = gr.Slider(minimum=1.0, maximum=8.0, step=0.05, label="Resize", value=2, elem_id="extras_upscaling_resize")
+                                with gr.TabItem('Scale to', elem_id="extras_scale_to_tab") as tab_scale_to:
+                                    with FormRow():
+                                        upscaling_resize_w = gr.Slider(label="Width", minimum=1, maximum=7680, step=1, value=512, elem_id="extras_upscaling_resize_w")
+                                        upscaling_resize_h = gr.Slider(label="Height", minimum=1, maximum=7680, step=1, value=512, elem_id="extras_upscaling_resize_h")
+                                        upscaling_crop = gr.Checkbox(label='Crop to fit', value=True, elem_id="extras_upscaling_crop")
+                            with FormRow():
+                                extras_upscaler_1 = gr.Dropdown(label='Upscaler 1', elem_id="extras_upscaler_1", choices=[x.name for x in sh.sd_upscalers], value=sh.sd_upscalers[3].name)
+                                extras_upscaler_2 = gr.Dropdown(label='Upscaler 2', elem_id="extras_upscaler_2", choices=[x.name for x in sh.sd_upscalers], value=sh.sd_upscalers[0].name)
+                            with FormRow():
+                                with gr.Column(scale=3):
+                                    extras_upscaler_2_visibility = gr.Slider(minimum=0.0, maximum=1.0, step=0.001, label="Upscaler 2 visibility", value=0.0, elem_id="extras_upscaler_2_visibility")
+                                with gr.Column(scale=1, min_width=80):
+                                    upscale_keep_imgs = gr.Checkbox(label="Keep Imgs", elem_id="upscale_keep_imgs", value=True, interactive=True)
+                            tab_scale_by.select(fn=lambda: 0, inputs=[], outputs=[selected_tab])
+                            tab_scale_to.select(fn=lambda: 1, inputs=[], outputs=[selected_tab])
+                            # This is the actual button that's pressed to initiate the Upscaling:
+                            upscale_btn = gr.Button(value="*Upscale uploaded video*")
+                            # Show a text about CLI outputs:
+                            gr.HTML("* check your CLI for outputs")
+                            # make the function call when the UPSCALE button is clicked
+                            upscale_btn.click(upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, selected_tab, upscaling_resize, upscaling_resize_w, upscaling_resize_h, upscaling_crop, extras_upscaler_1, extras_upscaler_2, extras_upscaler_2_visibility, upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
+                        # Vid2Depth TAB
+                with gr.TabItem('Vid2depth'):
+                    vid_to_depth_chosen_file = gr.File(label="Video to get Depth from", interactive=True, file_count="single", file_types=["video"], elem_id="vid_to_depth_chosen_file")
+                    with gr.Row(variant='compact'):
+                        mode = gr.Dropdown(label='Mode', elem_id="mode", choices=['Depth (Midas/Adabins)', 'Anime Remove Background', 'Mixed', 'None (just grayscale)'], value='Depth (Midas/Adabins)')
+                        threshold_value = gr.Slider(label="Threshold Value Lower", value=127, minimum=0, maximum=255, step=1)
+                        threshold_value_max = gr.Slider(label="Threshold Value Upper", value=255, minimum=0, maximum=255, step=1)
+                    with gr.Row(variant='compact'):
+                        thresholding = gr.Radio(['None', 'Simple', 'Simple (Auto-value)', 'Adaptive (Mean)', 'Adaptive (Gaussian)'], label="Thresholding Mode", value='None')
+                    with gr.Row(variant='compact'):
+                        adapt_block_size = gr.Number(label="Block size", value=11)
+                        adapt_c = gr.Number(label="C", value=2)
+                        invert = gr.Checkbox(label='Closer is brighter', value=True, elem_id="invert")
+                    with gr.Row(variant='compact'):
+                        end_blur = gr.Slider(label="End blur width", value=0, minimum=0, maximum=255, step=1)
+                        midas_weight_vid2depth = gr.Slider(label="MiDaS weight (vid2depth)", value=da.midas_weight, minimum=0, maximum=1, step=0.05, interactive=True)
+                        depth_keep_imgs = gr.Checkbox(label='Keep Imgs', value=True, elem_id="depth_keep_imgs")
+                    with gr.Row(variant='compact'):
                         # This is the actual button that's pressed to initiate the Upscaling:
-                        upscale_btn = gr.Button(value="*Upscale uploaded video*")
+                        depth_btn = gr.Button(value="*Get depth from uploaded video*")
+                    with gr.Row(variant='compact'):
                         # Show a text about CLI outputs:
                         gr.HTML("* check your CLI for outputs")
                         # make the function call when the UPSCALE button is clicked
-                        upscale_btn.click(upload_vid_to_upscale,inputs=[vid_to_upscale_chosen_file, selected_tab, upscaling_resize, upscaling_resize_w, upscaling_resize_h, upscaling_crop, extras_upscaler_1, extras_upscaler_2, extras_upscaler_2_visibility, upscale_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
-                    # Vid2Depth TAB
-            with gr.Tab('Vid2depth'):
-                vid_to_depth_chosen_file = gr.File(label="Video to get Depth from", interactive=True, file_count="single", file_types=["video"], elem_id="vid_to_depth_chosen_file")
-                with gr.Row(variant='compact'):
-                    mode = gr.Dropdown(label='Mode', elem_id="mode", choices=['Depth (Midas/Adabins)', 'Anime Remove Background', 'Mixed', 'None (just grayscale)'], value='Depth (Midas/Adabins)')
-                    threshold_value = gr.Slider(label="Threshold Value Lower", value=127, minimum=0, maximum=255, step=1)
-                    threshold_value_max = gr.Slider(label="Threshold Value Upper", value=255, minimum=0, maximum=255, step=1)
-                with gr.Row(variant='compact'):
-                    thresholding = gr.Radio(['None', 'Simple', 'Simple (Auto-value)', 'Adaptive (Mean)', 'Adaptive (Gaussian)'], label="Thresholding Mode", value='None')
-                with gr.Row(variant='compact'):
-                    adapt_block_size = gr.Number(label="Block size", value=11)
-                    adapt_c = gr.Number(label="C", value=2)
-                    invert = gr.Checkbox(label='Closer is brighter', value=True, elem_id="invert")
-                with gr.Row(variant='compact'):
-                    end_blur = gr.Slider(label="End blur width", value=0, minimum=0, maximum=255, step=1)
-                    midas_weight_vid2depth = gr.Slider(label="MiDaS weight (vid2depth)", value=da.midas_weight, minimum=0, maximum=1, step=0.05, interactive=True)
-                    depth_keep_imgs = gr.Checkbox(label='Keep Imgs', value=True, elem_id="depth_keep_imgs")
-                with gr.Row(variant='compact'):
-                    # This is the actual button that's pressed to initiate the Upscaling:
-                    depth_btn = gr.Button(value="*Get depth from uploaded video*")
-                with gr.Row(variant='compact'):
-                    # Show a text about CLI outputs:
-                    gr.HTML("* check your CLI for outputs")
-                    # make the function call when the UPSCALE button is clicked
-                depth_btn.click(upload_vid_to_depth,inputs=[vid_to_depth_chosen_file, mode, thresholding, threshold_value, threshold_value_max, adapt_block_size, adapt_c, invert, end_blur, midas_weight_vid2depth, depth_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
-            # STITCH FRAMES TO VID TAB
-            with gr.Tab('Frames to Video') as stitch_imgs_to_vid_row:
-                with gr.Row(visible=False):
-                    path_name_modifier = gr.Dropdown(label="Path name modifier", choices=['x0_pred', 'x'], value=dv.path_name_modifier, type="value", elem_id="path_name_modifier", interactive=True, visible=False) 
-                gr.HTML("""
-                 <p style="margin-top:0em">
-                    Important Notes:
-                    <ul style="list-style-type:circle; margin-left:1em; margin-bottom:0.25em">
-                        <li>Enter relative to webui folder or Full-Absolute path, and make sure it ends with something like this: '20230124234916_%09d.png', just replace 20230124234916 with your batch ID. The %05d is important, don't forget it!</li>
-                    </ul>
-                    """)
-                with gr.Row(variant='compact'):
-                      image_path = gr.Textbox(label="Image path", lines=1, interactive=True, value = dv.image_path)
-                ffmpeg_stitch_imgs_but = gr.Button(value="*Stitch frames to video*")
-                ffmpeg_stitch_imgs_but.click(direct_stitch_vid_from_frames,inputs=[image_path, fps, ffmpeg_location, ffmpeg_crf, ffmpeg_preset, add_soundtrack, soundtrack_path])
-            # **OLD + NON ACTIVES AREA**
-            with gr.Accordion(visible=False, label='INVISIBLE') as not_in_use_accordion:
-                    mp4_path = gr.Textbox(label="MP4 path", lines=1, interactive=True, value = dv.mp4_path)
-                    render_steps = gr.Checkbox(label="Render steps", value=dv.render_steps, interactive=True, visible=False)
-                    from_img2img_instead_of_link = gr.Checkbox(label="from_img2img_instead_of_link", value=False, interactive=False, visible=False)
-                    perlin_w = gr.Slider(label="Perlin W", minimum=0.1, maximum=16, step=0.1, value=da.perlin_w, interactive=True)
-                    perlin_h = gr.Slider(label="Perlin H", minimum=0.1, maximum=16, step=0.1, value=da.perlin_h, interactive=True)
-                    filename_format = gr.Textbox(label="Filename format", lines=1, interactive=True, value = d.filename_format, visible=False)
-                    save_settings = gr.Checkbox(label="save_settings", value=d.save_settings, interactive=True)
-                    save_samples = gr.Checkbox(label="save_samples", value=d.save_samples, interactive=True)
-                    display_samples = gr.Checkbox(label="display_samples", value=False, interactive=False)
-                    seed_enable_extras = gr.Checkbox(label="Enable subseed controls", value=False)
-                    n_batch = gr.Number(label="N Batch", value=d.n_batch, interactive=True, precision=0, visible=False)
-                    save_sample_per_step = gr.Checkbox(label="Save sample per step", value=d.save_sample_per_step, interactive=True)
-                    show_sample_per_step = gr.Checkbox(label="Show sample per step", value=d.show_sample_per_step, interactive=True)
+                    depth_btn.click(upload_vid_to_depth,inputs=[vid_to_depth_chosen_file, mode, thresholding, threshold_value, threshold_value_max, adapt_block_size, adapt_c, invert, end_blur, midas_weight_vid2depth, depth_keep_imgs, ffmpeg_location, ffmpeg_crf, ffmpeg_preset])
+                # STITCH FRAMES TO VID TAB
+                with gr.TabItem('Frames to Video') as stitch_imgs_to_vid_row:
+                    with gr.Row(visible=False):
+                        path_name_modifier = gr.Dropdown(label="Path name modifier", choices=['x0_pred', 'x'], value=dv.path_name_modifier, type="value", elem_id="path_name_modifier", interactive=True, visible=False) 
+                    gr.HTML("""
+                     <p style="margin-top:0em">
+                        Important Notes:
+                        <ul style="list-style-type:circle; margin-left:1em; margin-bottom:0.25em">
+                            <li>Enter relative to webui folder or Full-Absolute path, and make sure it ends with something like this: '20230124234916_%09d.png', just replace 20230124234916 with your batch ID. The %05d is important, don't forget it!</li>
+                        </ul>
+                        """)
+                    with gr.Row(variant='compact'):
+                          image_path = gr.Textbox(label="Image path", lines=1, interactive=True, value = dv.image_path)
+                    ffmpeg_stitch_imgs_but = gr.Button(value="*Stitch frames to video*")
+                    ffmpeg_stitch_imgs_but.click(direct_stitch_vid_from_frames,inputs=[image_path, fps, ffmpeg_location, ffmpeg_crf, ffmpeg_preset, add_soundtrack, soundtrack_path])
+                # **OLD + NON ACTIVES AREA**
+                with gr.Accordion(visible=False, label='INVISIBLE') as not_in_use_accordion:
+                        mp4_path = gr.Textbox(label="MP4 path", lines=1, interactive=True, value = dv.mp4_path)
+                        render_steps = gr.Checkbox(label="Render steps", value=dv.render_steps, interactive=True, visible=False)
+                        from_img2img_instead_of_link = gr.Checkbox(label="from_img2img_instead_of_link", value=False, interactive=False, visible=False)
+                        perlin_w = gr.Slider(label="Perlin W", minimum=0.1, maximum=16, step=0.1, value=da.perlin_w, interactive=True)
+                        perlin_h = gr.Slider(label="Perlin H", minimum=0.1, maximum=16, step=0.1, value=da.perlin_h, interactive=True)
+                        filename_format = gr.Textbox(label="Filename format", lines=1, interactive=True, value = d.filename_format, visible=False)
+                        save_settings = gr.Checkbox(label="save_settings", value=d.save_settings, interactive=True)
+                        save_samples = gr.Checkbox(label="save_samples", value=d.save_samples, interactive=True)
+                        display_samples = gr.Checkbox(label="display_samples", value=False, interactive=False)
+                        seed_enable_extras = gr.Checkbox(label="Enable subseed controls", value=False)
+                        n_batch = gr.Number(label="N Batch", value=d.n_batch, interactive=True, precision=0, visible=False)
+                        save_sample_per_step = gr.Checkbox(label="Save sample per step", value=d.save_sample_per_step, interactive=True)
+                        show_sample_per_step = gr.Checkbox(label="Show sample per step", value=d.show_sample_per_step, interactive=True)
     # Gradio's Change functions - hiding and renaming elements based on other elements
     fps.change(fn=change_gif_button_visibility, inputs=fps, outputs=make_gif)
     r_upscale_model.change(fn=update_r_upscale_factor, inputs=r_upscale_model, outputs=r_upscale_factor)

--- a/style.css
+++ b/style.css
@@ -59,8 +59,3 @@
 	grid-gap:2px;
 	gap:2px; 
 }
-
-/* #tab_deforum_interface #output_tab .flex { */
-	/* grid-gap:3px; */
-	/* gap:3px;  */
-/* } */

--- a/style.css
+++ b/style.css
@@ -54,3 +54,8 @@
 #deforum_results .flex {
 	gap:0px;
 }
+
+#tab_deforum_interface #motion_noise_etc .flex, #tab_deforum_interface #extra_schedules .flex {
+	grid-gap:2px;
+	gap:2px; 
+}

--- a/style.css
+++ b/style.css
@@ -59,3 +59,8 @@
 	grid-gap:2px;
 	gap:2px; 
 }
+
+/* #tab_deforum_interface #output_tab .flex { */
+	/* grid-gap:3px; */
+	/* gap:3px;  */
+/* } */


### PR DESCRIPTION
And code changes to allow more UI-CSS related changes in the future, mainly by moving from using gr.Tab to gr.Tabs with gr.TabItem, that can accept an (html) elem_id. 

Before, you had to scroll:
![image](https://user-images.githubusercontent.com/121192995/224390211-9871e8e6-1734-41e5-afca-c3a8c8e765d4.png)

Now, you don't:
![image](https://user-images.githubusercontent.com/121192995/224390252-4efced7e-9e08-4b00-b4ad-bf14a454b068.png)
