### PR TITLE
adding video output option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,4 @@ As a part of the Deforum team I (kabachuha) want this script extension to remain
 
 Thus, if you want to submit feature request or bugfix, unless it only relates to automatic1111's porting issues, consider making a PR first to the parent repository notebook https://github.com/deforum/stable-diffusion.
 
-Also, you may want to inforum the dev team about your work via Discord https://discord.gg/deforum to ensure that no one else is working on the same stuff.
+Also, you may want to inform the dev team about your work via Discord https://discord.gg/deforum to ensure that no one else is working on the same stuff.

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -114,18 +114,24 @@ def run_deforum(*args, **kwargs):
     else:
         import subprocess
 
+        # create video output directory if it doesn't exist
+        if video_args.ffmpeg_output_location:
+          os.makedirs(video_args.ffmpeg_output_location, exist_ok=True)
+        ffmpeg_output_directory = video_args.ffmpeg_output_location or args.outdir
+
         path_name_modifier = video_args.path_name_modifier
+        # This is DEPRECATED, should be deleted 
         if video_args.render_steps: # render steps from a single image
             fname = f"{path_name_modifier}_%09d.png"
             all_step_dirs = [os.path.join(args.outdir, d) for d in os.listdir(args.outdir) if os.path.isdir(os.path.join(args.outdir,d))]
             newest_dir = max(all_step_dirs, key=os.path.getmtime)
             image_path = os.path.join(newest_dir, fname)
             print(f"Reading images from {image_path}")
-            mp4_path = os.path.join(newest_dir, f"{args.timestring}_{path_name_modifier}.mp4")
+            mp4_path = os.path.join(video_args.ffmpeg_output_location or newest_dir, f"{args.timestring}_{path_name_modifier}.mp4")
             max_video_frames = args.steps
         else: # render images for a video
             image_path = os.path.join(args.outdir, f"{args.timestring}_%09d.png")
-            mp4_path = os.path.join(args.outdir, f"{args.timestring}.mp4")
+            mp4_path = os.path.join(ffmpeg_output_directory, f"{args.timestring}.mp4")
             max_video_frames = anim_args.max_frames
 
         # Stitch video using ffmpeg!

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -260,6 +260,7 @@ def DeforumOutputArgs():
     image_path = "C:/SD/20230124234916_%09d.png" 
     mp4_path = "testvidmanualsettings.mp4" 
     ffmpeg_location = find_ffmpeg_binary()
+    ffmpeg_output_location = ""
     ffmpeg_crf = '17'
     ffmpeg_preset = 'slow'
     add_soundtrack = 'None' # ["File","Init Video"]
@@ -779,19 +780,21 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                             ffmpeg_crf = gr.Slider(minimum=0, maximum=51, step=1, label="CRF", value=dv.ffmpeg_crf, interactive=True)
                             ffmpeg_preset = gr.Dropdown(label="Preset", choices=['veryslow', 'slower', 'slow', 'medium', 'fast', 'faster', 'veryfast', 'superfast', 'ultrafast'], interactive=True, value = dv.ffmpeg_preset, type="value")
                         with gr.Row(equal_height=True, variant='compact', visible=True) as ffmpeg_location_row:
-                            ffmpeg_location = gr.Textbox(label="Location", lines=1, interactive=True, value = dv.ffmpeg_location)
+                            ffmpeg_location = gr.Textbox(label="Executible location", lines=1, interactive=True, value = dv.ffmpeg_location)
+                        with gr.Row(equal_height=True, variant='compact', visible=True) as ffmpeg_output_location_row:
+                            ffmpeg_output_location = gr.Textbox(label="Output location", lines=1, interactive=True, value = dv.ffmpeg_output_location)
                 # FRAME INTERPOLATION TAB
                 with gr.Tab('Frame Interpolation') as frame_interp_tab:
                     with gr.Accordion('Important notes and Help', open=False):
                         gr.HTML("""
                         Use <a href="https://github.com/megvii-research/ECCV2022-RIFE">RIFE</a> / <a href="https://film-net.github.io/">FILM</a> Frame Interpolation to smooth out, slow-mo (or both) any video.</p>
-                         <p style="margin-top:1em">
+                          <p style="margin-top:1em">
                             Supported engines:
                             <ul style="list-style-type:circle; margin-left:1em; margin-bottom:1em">
                                 <li>RIFE v4.6 and FILM.</li>
                             </ul>
                         </p>
-                         <p style="margin-top:1em">
+                          <p style="margin-top:1em">
                             Important notes:
                             <ul style="list-style-type:circle; margin-left:1em; margin-bottom:1em">
                                 <li>Frame Interpolation will *not* run if any of the following are enabled: 'Store frames in ram' / 'Skip video for run all'.</li>
@@ -918,7 +921,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                     with gr.Row(visible=False):
                         path_name_modifier = gr.Dropdown(label="Path name modifier", choices=['x0_pred', 'x'], value=dv.path_name_modifier, type="value", elem_id="path_name_modifier", interactive=True, visible=False) 
                     gr.HTML("""
-                     <p style="margin-top:0em">
+                      <p style="margin-top:0em">
                         Important Notes:
                         <ul style="list-style-type:circle; margin-left:1em; margin-bottom:0.25em">
                             <li>Enter relative to webui folder or Full-Absolute path, and make sure it ends with something like this: '20230124234916_%09d.png', just replace 20230124234916 with your batch ID. The %05d is important, don't forget it!</li>
@@ -1056,7 +1059,7 @@ args_names =    str(r'''W, H, tiling, restore_faces,
                         reroll_blank_frames'''
                     ).replace("\n", "").replace("\r", "").replace(" ", "").split(',')
 video_args_names =  str(r'''skip_video_creation,
-                            fps, make_gif, delete_imgs, output_format, ffmpeg_location, ffmpeg_crf, ffmpeg_preset,
+                            fps, make_gif, delete_imgs, output_format, ffmpeg_location, ffmpeg_output_location, ffmpeg_crf, ffmpeg_preset,
                             add_soundtrack, soundtrack_path,
                             r_upscale_video, r_upscale_model, r_upscale_factor, r_upscale_keep_imgs,
                             render_steps,
@@ -1188,7 +1191,7 @@ def print_args(args):
     print("ARGS: /n")
     for key, value in args.__dict__.items():
         print(f"{key}: {value}")
- 
+
 # Local gradio-to-frame-interoplation function. *Needs* to stay here since we do Root() and use gradio elements directly, to be changed in the future
 def upload_vid_to_interpolate(file, engine, x_am, sl_enabled, sl_am, keep_imgs, f_location, f_crf, f_preset, in_vid_fps):
     # print msg and do nothing if vid not uploaded or interp_x not provided
@@ -1212,7 +1215,7 @@ def upload_pics_to_interpolate(pic_list, engine, x_am, sl_enabled, sl_am, keep_i
         return print("All uploaded pics need to be of the same Width and Height / resolution.")
         
     resolution = pic_sizes[0]
-     
+
     root_params = Root()
     f_models_path = root_params['models_path']
     


### PR DESCRIPTION
Feature: Ability to specify the output location of the video output when generating (absolute or relative to the AUTO1111 root)
- [x] Makes dir if doesn't exist
- [x] Doesn't care if already exists
- [x] Only a setting within Video Output Settings so doesn't affect frame interpolation etc.
- [x] path of testing_output will make it in the AUTO1111 root
- [x] no value will generate as normal

![image](https://user-images.githubusercontent.com/1436841/224516418-8b038ae6-8cf2-40dc-b001-95a9c233b96e.png)
![image](https://user-images.githubusercontent.com/1436841/224516423-56374958-c5b6-4211-8098-837870b8e440.png)
