### PR TITLE
Re-add matisse's max_f and s PR with all the keyframe interpolation modes fixed now

### DIFF
--- a/scripts/deforum_helpers/animation_key_frames.py
+++ b/scripts/deforum_helpers/animation_key_frames.py
@@ -66,7 +66,7 @@ class FrameInterpolater():
         self.max_frames = max_frames
         self.seed = seed
 
-    def sanitize_value_for_check_is_number(value):
+    def sanitize_value_for_check_is_number(self, value):
         return value.replace("'","").replace('"',"").replace('(',"").replace(')',"")
 
     def get_inbetweens(self, key_frames, integer=False, interp_method='Linear', is_single_string = False):

--- a/scripts/deforum_helpers/animation_key_frames.py
+++ b/scripts/deforum_helpers/animation_key_frames.py
@@ -73,7 +73,7 @@ class FrameInterpolater():
         s = self.seed
         for i in range(0, self.max_frames):
             if i in key_frames:
-                value = key_frames[i]
+                value = key_frames[i].replace("'","").replace('"',"").replace('(',"").replace(')',"")
                 value_is_number = check_is_number(value)
                 if value_is_number: # if it's only a number, leave the rest for the default interpolation
                     key_frame_series[i] = value

--- a/scripts/deforum_helpers/animation_key_frames.py
+++ b/scripts/deforum_helpers/animation_key_frames.py
@@ -66,6 +66,9 @@ class FrameInterpolater():
         self.max_frames = max_frames
         self.seed = seed
 
+    def sanitize_value_for_check_is_number(value):
+        return value.replace("'","").replace('"',"").replace('(',"").replace(')',"")
+
     def get_inbetweens(self, key_frames, integer=False, interp_method='Linear', is_single_string = False):
         key_frame_series = pd.Series([np.nan for a in range(self.max_frames)])
         # get our ui variables set for numexpr.evaluate
@@ -73,14 +76,14 @@ class FrameInterpolater():
         s = self.seed
         for i in range(0, self.max_frames):
             if i in key_frames:
-                value = key_frames[i].replace("'","").replace('"',"").replace('(',"").replace(')',"")
-                value_is_number = check_is_number(value)
+                value = key_frames[i]
+                value_is_number = check_is_number(self.sanitize_value_for_check_is_number(value))
                 if value_is_number: # if it's only a number, leave the rest for the default interpolation
-                    key_frame_series[i] = value
+                    key_frame_series[i] = self.sanitize_value_for_check_is_number(value)
             if not value_is_number:
                 t = i
                 # workaround for values formatted like 0:("I am test") //used for sampler schedules
-                key_frame_series[i] = numexpr.evaluate(value) if not is_single_string else value.replace("'","").replace('"',"").replace('(',"").replace(')',"")
+                key_frame_series[i] = numexpr.evaluate(value) if not is_single_string else self.sanitize_value_for_check_is_number(value)
             elif is_single_string:# take previous string value and replicate it
                 key_frame_series[i] = key_frame_series[i-1]
         key_frame_series = key_frame_series.astype(float) if not is_single_string else key_frame_series # as string

--- a/scripts/deforum_helpers/animation_key_frames.py
+++ b/scripts/deforum_helpers/animation_key_frames.py
@@ -5,105 +5,110 @@ import pandas as pd
 from .prompt import check_is_number
 
 class DeformAnimKeys():
-    def __init__(self, anim_args):
-        self.angle_series = get_inbetweens(parse_key_frames(anim_args.angle), anim_args.max_frames)
-        self.zoom_series = get_inbetweens(parse_key_frames(anim_args.zoom), anim_args.max_frames)
-        self.translation_x_series = get_inbetweens(parse_key_frames(anim_args.translation_x), anim_args.max_frames)
-        self.translation_y_series = get_inbetweens(parse_key_frames(anim_args.translation_y), anim_args.max_frames)
-        self.transform_center_x_series = get_inbetweens(parse_key_frames(anim_args.transform_center_x), anim_args.max_frames)
-        self.transform_center_y_series = get_inbetweens(parse_key_frames(anim_args.transform_center_y), anim_args.max_frames)
-        self.translation_z_series = get_inbetweens(parse_key_frames(anim_args.translation_z), anim_args.max_frames)
-        self.rotation_3d_x_series = get_inbetweens(parse_key_frames(anim_args.rotation_3d_x), anim_args.max_frames)
-        self.rotation_3d_y_series = get_inbetweens(parse_key_frames(anim_args.rotation_3d_y), anim_args.max_frames)
-        self.rotation_3d_z_series = get_inbetweens(parse_key_frames(anim_args.rotation_3d_z), anim_args.max_frames)
-        self.perspective_flip_theta_series = get_inbetweens(parse_key_frames(anim_args.perspective_flip_theta), anim_args.max_frames)
-        self.perspective_flip_phi_series = get_inbetweens(parse_key_frames(anim_args.perspective_flip_phi), anim_args.max_frames)
-        self.perspective_flip_gamma_series = get_inbetweens(parse_key_frames(anim_args.perspective_flip_gamma), anim_args.max_frames)
-        self.perspective_flip_fv_series = get_inbetweens(parse_key_frames(anim_args.perspective_flip_fv), anim_args.max_frames)
-        self.noise_schedule_series = get_inbetweens(parse_key_frames(anim_args.noise_schedule), anim_args.max_frames)
-        self.strength_schedule_series = get_inbetweens(parse_key_frames(anim_args.strength_schedule), anim_args.max_frames)
-        self.contrast_schedule_series = get_inbetweens(parse_key_frames(anim_args.contrast_schedule), anim_args.max_frames)
-        self.cfg_scale_schedule_series = get_inbetweens(parse_key_frames(anim_args.cfg_scale_schedule), anim_args.max_frames)
-        self.pix2pix_img_cfg_scale_series = get_inbetweens(parse_key_frames(anim_args.pix2pix_img_cfg_scale_schedule), anim_args.max_frames)
-        self.subseed_schedule_series = get_inbetweens(parse_key_frames(anim_args.subseed_schedule), anim_args.max_frames)
-        self.subseed_strength_schedule_series = get_inbetweens(parse_key_frames(anim_args.subseed_strength_schedule), anim_args.max_frames)
-        self.checkpoint_schedule_series = get_inbetweens(parse_key_frames(anim_args.checkpoint_schedule), anim_args.max_frames, is_single_string = True)
-        self.steps_schedule_series = get_inbetweens(parse_key_frames(anim_args.steps_schedule), anim_args.max_frames)
-        self.seed_schedule_series = get_inbetweens(parse_key_frames(anim_args.seed_schedule), anim_args.max_frames)
-        self.sampler_schedule_series = get_inbetweens(parse_key_frames(anim_args.sampler_schedule), anim_args.max_frames, is_single_string = True)
-        self.clipskip_schedule_series = get_inbetweens(parse_key_frames(anim_args.clipskip_schedule), anim_args.max_frames)
-        self.noise_multiplier_schedule_series =  get_inbetweens(parse_key_frames(anim_args.noise_multiplier_schedule), anim_args.max_frames)
-        self.mask_schedule_series = get_inbetweens(parse_key_frames(anim_args.mask_schedule), anim_args.max_frames, is_single_string = True)
-        self.noise_mask_schedule_series = get_inbetweens(parse_key_frames(anim_args.noise_mask_schedule), anim_args.max_frames, is_single_string = True)
-        self.kernel_schedule_series = get_inbetweens(parse_key_frames(anim_args.kernel_schedule), anim_args.max_frames)
-        self.sigma_schedule_series = get_inbetweens(parse_key_frames(anim_args.sigma_schedule), anim_args.max_frames)
-        self.amount_schedule_series = get_inbetweens(parse_key_frames(anim_args.amount_schedule), anim_args.max_frames)
-        self.threshold_schedule_series = get_inbetweens(parse_key_frames(anim_args.threshold_schedule), anim_args.max_frames)
-        self.fov_series = get_inbetweens(parse_key_frames(anim_args.fov_schedule), anim_args.max_frames)
-        self.aspect_ratio_series = get_inbetweens(parse_key_frames(anim_args.aspect_ratio_schedule), anim_args.max_frames)
-        self.near_series = get_inbetweens(parse_key_frames(anim_args.near_schedule), anim_args.max_frames)
-        self.far_series = get_inbetweens(parse_key_frames(anim_args.far_schedule), anim_args.max_frames)
-        self.hybrid_comp_alpha_schedule_series = get_inbetweens(parse_key_frames(anim_args.hybrid_comp_alpha_schedule), anim_args.max_frames)
-        self.hybrid_comp_mask_blend_alpha_schedule_series = get_inbetweens(parse_key_frames(anim_args.hybrid_comp_mask_blend_alpha_schedule), anim_args.max_frames)
-        self.hybrid_comp_mask_contrast_schedule_series = get_inbetweens(parse_key_frames(anim_args.hybrid_comp_mask_contrast_schedule), anim_args.max_frames)
-        self.hybrid_comp_mask_auto_contrast_cutoff_high_schedule_series = get_inbetweens(parse_key_frames(anim_args.hybrid_comp_mask_auto_contrast_cutoff_high_schedule), anim_args.max_frames)
-        self.hybrid_comp_mask_auto_contrast_cutoff_low_schedule_series = get_inbetweens(parse_key_frames(anim_args.hybrid_comp_mask_auto_contrast_cutoff_low_schedule), anim_args.max_frames)
+    def __init__(self, anim_args, seed=-1):
+        self.fi = FrameInterpolater(anim_args.max_frames, seed)
+        self.angle_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.angle))
+        self.transform_center_x_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.transform_center_x))
+        self.transform_center_y_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.transform_center_y))
+        self.zoom_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.zoom))
+        self.translation_x_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.translation_x))
+        self.translation_y_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.translation_y))
+        self.translation_z_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.translation_z))
+        self.rotation_3d_x_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.rotation_3d_x))
+        self.rotation_3d_y_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.rotation_3d_y))
+        self.rotation_3d_z_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.rotation_3d_z))
+        self.perspective_flip_theta_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.perspective_flip_theta))
+        self.perspective_flip_phi_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.perspective_flip_phi))
+        self.perspective_flip_gamma_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.perspective_flip_gamma))
+        self.perspective_flip_fv_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.perspective_flip_fv))
+        self.noise_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.noise_schedule))
+        self.strength_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.strength_schedule))
+        self.contrast_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.contrast_schedule))
+        self.cfg_scale_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.cfg_scale_schedule))
+        self.pix2pix_img_cfg_scale_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.pix2pix_img_cfg_scale_schedule))
+        self.subseed_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.subseed_schedule))
+        self.subseed_strength_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.subseed_strength_schedule))
+        self.checkpoint_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.checkpoint_schedule), is_single_string = True)
+        self.steps_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.steps_schedule))
+        self.seed_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.seed_schedule))
+        self.sampler_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.sampler_schedule), is_single_string = True)
+        self.clipskip_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.clipskip_schedule))
+        self.noise_multiplier_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.noise_multiplier_schedule))
+        self.mask_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.mask_schedule), is_single_string = True)
+        self.noise_mask_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.noise_mask_schedule), is_single_string = True)
+        self.kernel_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.kernel_schedule))
+        self.sigma_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.sigma_schedule))
+        self.amount_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.amount_schedule))
+        self.threshold_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.threshold_schedule))
+        self.aspect_ratio_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.aspect_ratio_schedule))
+        self.fov_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.fov_schedule))
+        self.near_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.near_schedule))
+        self.far_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.far_schedule))
+        self.hybrid_comp_alpha_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.hybrid_comp_alpha_schedule))
+        self.hybrid_comp_mask_blend_alpha_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.hybrid_comp_mask_blend_alpha_schedule))
+        self.hybrid_comp_mask_contrast_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.hybrid_comp_mask_contrast_schedule))
+        self.hybrid_comp_mask_auto_contrast_cutoff_high_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.hybrid_comp_mask_auto_contrast_cutoff_high_schedule))
+        self.hybrid_comp_mask_auto_contrast_cutoff_low_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(anim_args.hybrid_comp_mask_auto_contrast_cutoff_low_schedule))
 
 class LooperAnimKeys():
-    def __init__(self, loop_args, anim_args):
+    def __init__(self, loop_args, anim_args, seed):
+        self.fi = FrameInterpolater(anim_args.max_frames, seed)
         self.use_looper = loop_args.use_looper
         self.imagesToKeyframe = loop_args.init_images
-        self.image_strength_schedule_series = get_inbetweens(parse_key_frames(loop_args.image_strength_schedule), anim_args.max_frames)
-        self.blendFactorMax_series = get_inbetweens(parse_key_frames(loop_args.blendFactorMax), anim_args.max_frames)
-        self.blendFactorSlope_series = get_inbetweens(parse_key_frames(loop_args.blendFactorSlope), anim_args.max_frames)
-        self.tweening_frames_schedule_series = get_inbetweens(parse_key_frames(loop_args.tweening_frames_schedule), anim_args.max_frames)
-        self.color_correction_factor_series = get_inbetweens(parse_key_frames(loop_args.color_correction_factor), anim_args.max_frames)
-def get_inbetweens(key_frames, max_frames, integer=False, interp_method='Linear', is_single_string = False):
-    key_frame_series = pd.Series([np.nan for a in range(max_frames)])
-    for i in range(0, max_frames):
-        if i in key_frames:
-            value = key_frames[i]
-            value_is_number = check_is_number(value)
-            # if it's only a number, leave the rest for the default interpolation
-            if value_is_number:
-                t = i
-                key_frame_series[i] = value
-        if not value_is_number:
-            t = i
-            if is_single_string:
-                if value.find("'") > -1:
-                    value = value.replace("'","")
-                if value.find('"') > -1:
-                    value = value.replace('"',"")
-            key_frame_series[i] = numexpr.evaluate(value) if not is_single_string else value # workaround for values formatted like 0:("I am test") //used for sampler schedules
-    key_frame_series = key_frame_series.astype(float) if not is_single_string else key_frame_series # as string
-    
-    if interp_method == 'Cubic' and len(key_frames.items()) <= 3:
-        interp_method = 'Quadratic'    
-    if interp_method == 'Quadratic' and len(key_frames.items()) <= 2:
-        interp_method = 'Linear'
-          
-    key_frame_series[0] = key_frame_series[key_frame_series.first_valid_index()]
-    key_frame_series[max_frames-1] = key_frame_series[key_frame_series.last_valid_index()]
-    key_frame_series = key_frame_series.interpolate(method=interp_method.lower(), limit_direction='both')
-    if integer:
-        return key_frame_series.astype(int)
-    return key_frame_series
+        self.image_strength_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(loop_args.image_strength_schedule))
+        self.blendFactorMax_series = self.fi.get_inbetweens(self.fi.parse_key_frames(loop_args.blendFactorMax))
+        self.blendFactorSlope_series = self.fi.get_inbetweens(self.fi.parse_key_frames(loop_args.blendFactorSlope))
+        self.tweening_frames_schedule_series = self.fi.get_inbetweens(self.fi.parse_key_frames(loop_args.tweening_frames_schedule))
+        self.color_correction_factor_series = self.fi.get_inbetweens(self.fi.parse_key_frames(loop_args.color_correction_factor))
 
-def parse_key_frames(string, prompt_parser=None):
-    # because math functions (i.e. sin(t)) can utilize brackets 
-    # it extracts the value in form of some stuff
-    # which has previously been enclosed with brackets and
-    # with a comma or end of line existing after the closing one
-    pattern = r'((?P<frame>[0-9]+):[\s]*\((?P<param>[\S\s]*?)\)([,][\s]?|[\s]?$))'
-    frames = dict()
-    for match_object in re.finditer(pattern, string):
-        frame = int(match_object.groupdict()['frame'])
-        param = match_object.groupdict()['param']
-        if prompt_parser:
-            frames[frame] = prompt_parser(param)
-        else:
-            frames[frame] = param
-    if frames == {} and len(string) != 0:
-        raise RuntimeError('Key Frame string not correctly formatted')
-    return frames
+class FrameInterpolater():
+    def __init__(self, max_frames=0, seed=-1) -> None:
+        self.max_frames = max_frames
+        self.seed = seed
+
+    def get_inbetweens(self, key_frames, integer=False, interp_method='Linear', is_single_string = False):
+        key_frame_series = pd.Series([np.nan for a in range(self.max_frames)])
+        # get our ui variables set for numexpr.evaluate
+        max_f = self.max_frames -1
+        s = self.seed
+        for i in range(0, self.max_frames):
+            if i in key_frames:
+                value = key_frames[i]
+                value_is_number = check_is_number(value)
+                if value_is_number: # if it's only a number, leave the rest for the default interpolation
+                    key_frame_series[i] = value
+            if not value_is_number:
+                t = i
+                # workaround for values formatted like 0:("I am test") //used for sampler schedules
+                key_frame_series[i] = numexpr.evaluate(value) if not is_single_string else value.replace("'","").replace('"',"").replace('(',"").replace(')',"")
+            elif is_single_string:# take previous string value and replicate it
+                key_frame_series[i] = key_frame_series[i-1]
+        key_frame_series = key_frame_series.astype(float) if not is_single_string else key_frame_series # as string
+        
+        if interp_method == 'Cubic' and len(key_frames.items()) <= 3:
+            interp_method = 'Quadratic'    
+        if interp_method == 'Quadratic' and len(key_frames.items()) <= 2:
+            interp_method = 'Linear'
+            
+        key_frame_series[0] = key_frame_series[key_frame_series.first_valid_index()]
+        key_frame_series[self.max_frames-1] = key_frame_series[key_frame_series.last_valid_index()]
+        key_frame_series = key_frame_series.interpolate(method=interp_method.lower(), limit_direction='both')
+        if integer:
+            return key_frame_series.astype(int)
+        return key_frame_series
+
+    def parse_key_frames(self, string):
+        # because math functions (i.e. sin(t)) can utilize brackets 
+        # it extracts the value in form of some stuff
+        # which has previously been enclosed with brackets and
+        # with a comma or end of line existing after the closing one
+        frames = dict()
+        for match_object in string.split(","):
+            frameParam = match_object.split(":")
+            max_f = self.max_frames -1
+            s = self.seed
+            frame = int(frameParam[0]) if check_is_number(frameParam[0].strip()) else int(numexpr.evaluate(frameParam[0].strip()))
+            frames[frame] = frameParam[1].strip()
+        if frames == {} and len(string) != 0:
+            raise RuntimeError('Key Frame string not correctly formatted')
+        return frames

--- a/scripts/deforum_helpers/animation_key_frames.py
+++ b/scripts/deforum_helpers/animation_key_frames.py
@@ -110,7 +110,7 @@ class FrameInterpolater():
             frameParam = match_object.split(":")
             max_f = self.max_frames -1
             s = self.seed
-            frame = int(self.sanitize_value(frameParam[0])) if check_is_number(self.sanitize_value(frameParam[0].strip())) else int(numexpr.evaluate(frameParam[0].strip().replace("'","").replace('"',"")[::-1].replace("'","").replace('"',"")[::-1]))
+            frame = int(self.sanitize_value(frameParam[0])) if check_is_number(self.sanitize_value(frameParam[0].strip())) else int(numexpr.evaluate(frameParam[0].strip().replace("'","",1).replace('"',"",1)[::-1].replace("'","",1).replace('"',"",1)[::-1]))
             frames[frame] = frameParam[1].strip()
         if frames == {} and len(string) != 0:
             raise RuntimeError('Key Frame string not correctly formatted')

--- a/scripts/deforum_helpers/animation_key_frames.py
+++ b/scripts/deforum_helpers/animation_key_frames.py
@@ -66,7 +66,7 @@ class FrameInterpolater():
         self.max_frames = max_frames
         self.seed = seed
 
-    def sanitize_value_for_check_is_number(self, value):
+    def sanitize_value(self, value):
         return value.replace("'","").replace('"',"").replace('(',"").replace(')',"")
 
     def get_inbetweens(self, key_frames, integer=False, interp_method='Linear', is_single_string = False):
@@ -77,13 +77,13 @@ class FrameInterpolater():
         for i in range(0, self.max_frames):
             if i in key_frames:
                 value = key_frames[i]
-                value_is_number = check_is_number(self.sanitize_value_for_check_is_number(value))
+                value_is_number = check_is_number(self.sanitize_value(value))
                 if value_is_number: # if it's only a number, leave the rest for the default interpolation
-                    key_frame_series[i] = self.sanitize_value_for_check_is_number(value)
+                    key_frame_series[i] = self.sanitize_value(value)
             if not value_is_number:
                 t = i
                 # workaround for values formatted like 0:("I am test") //used for sampler schedules
-                key_frame_series[i] = numexpr.evaluate(value) if not is_single_string else self.sanitize_value_for_check_is_number(value)
+                key_frame_series[i] = numexpr.evaluate(value) if not is_single_string else self.sanitize_value(value)
             elif is_single_string:# take previous string value and replicate it
                 key_frame_series[i] = key_frame_series[i-1]
         key_frame_series = key_frame_series.astype(float) if not is_single_string else key_frame_series # as string
@@ -110,7 +110,7 @@ class FrameInterpolater():
             frameParam = match_object.split(":")
             max_f = self.max_frames -1
             s = self.seed
-            frame = int(frameParam[0]) if check_is_number(frameParam[0].strip()) else int(numexpr.evaluate(frameParam[0].strip()))
+            frame = int(self.sanitize_value(frameParam[0])) if check_is_number(self.sanitize_value(frameParam[0].strip())) else int(numexpr.evaluate(frameParam[0].strip().replace("'","").replace('"',"")[::-1].replace("'","").replace('"',"")[::-1]))
             frames[frame] = frameParam[1].strip()
         if frames == {} and len(string) != 0:
             raise RuntimeError('Key Frame string not correctly formatted')

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -61,7 +61,7 @@ def DeforumAnimArgs():
     aspect_ratio_schedule = "0: (1)"
     near_schedule = "0: (200)"
     far_schedule = "0: (10000)"
-    seed_schedule = "0:(5), 1:(-1), 219:(-1), 220:(5)"
+    seed_schedule = '0:(s), 1:(-1), "max_f-2":(-1), "max_f-1":(s)'
     pix2pix_img_cfg_scale = "1.5"
     pix2pix_img_cfg_scale_schedule = "0:(1.5)"
     enable_subseed_scheduling = False
@@ -235,10 +235,10 @@ def DeforumArgs():
 def keyframeExamples():
     return '''{
     "0": "https://deforum.github.io/a1/Gi1.png",
-    "50": "https://deforum.github.io/a1/Gi2.png",
-    "100": "https://deforum.github.io/a1/Gi3.png",
-    "150": "https://deforum.github.io/a1/Gi4.jpg",
-    "200": "https://deforum.github.io/a1/Gi1.png"
+    "max_f/4-5": "https://deforum.github.io/a1/Gi2.png",
+    "max_f/2-10": "https://deforum.github.io/a1/Gi3.png",
+    "3*max_f/4-15": "https://deforum.github.io/a1/Gi4.jpg",
+    "max_f-20": "https://deforum.github.io/a1/Gi1.png"
 }'''
 
 def LoopArgs():

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -195,7 +195,7 @@ def DeforumArgs():
 
     #**Init Settings**
     use_init = False 
-    strength = 0.0 
+    strength = 0.8
     strength_0_no_init = True # Set the strength to 0 automatically when no init image is used
     init_image = "https://deforum.github.io/a1/I1.png" 
     # Whiter areas of the mask are areas that change more

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -390,8 +390,8 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         gr.HTML("""Prerequisites and Important Info: 
                                    <ul style="list-style-type:circle; margin-left:2em; margin-bottom:0em">
                                        <li>This mode works ONLY with 2D/3D animation modes. Interpolation and Video Input modes aren't supported.</ li>
-                                       <li>Set Init tab's strength slider greater than 0. Recommended value (.65 - .80).</ li>
-                                       <li>Set 'seed_behavior' to 'schedule' under the Seed Scheduling section below.</li>
+                                       <li>Init tab's strength slider should be greater than 0. Recommended value (.65 - .80).</ li>
+                                       <li>'seed_behavior' will be forcibly set to 'schedule'.</li>
                                     </ul>
                                 """)
                         gr.HTML("""Looping recommendations: 

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -605,9 +605,9 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         with gr.Column(min_width=150):
                             use_init = gr.Checkbox(label="Use init", value=d.use_init, interactive=True, visible=True)
                         with gr.Column(min_width=150):
-                            strength_0_no_init = gr.Checkbox(label="Strength 0 no init", value=True, interactive=True)
+                            strength_0_no_init = gr.Checkbox(label="Strength 0 no init", value=d.strength_0_no_init, interactive=True)
                         with gr.Column(min_width=170):
-                            strength = gr.Slider(label="Strength", minimum=0, maximum=1, step=0.01, value=0, interactive=True)
+                            strength = gr.Slider(label="Strength", minimum=0, maximum=1, step=0.01, value=d.strength, interactive=True)
                     with gr.Row(variant='compact'):
                         init_image = gr.Textbox(label="Init image", lines=1, interactive=True, value = d.init_image)
                 # VIDEO INIT INNER-TAB

--- a/scripts/deforum_helpers/generate.py
+++ b/scripts/deforum_helpers/generate.py
@@ -17,6 +17,9 @@ from .deforum_controlnet import is_controlnet_enabled, process_with_controlnet
 import math, json, itertools
 import requests
 
+import numexpr
+from .prompt import check_is_number
+
 def load_mask_latent(mask_input, shape):
     # mask_input (str or PIL Image.Image): Path to the mask image or a PIL Image object
     # shape (list-like len(4)): shape of the image to match, usually latent_image.shape
@@ -55,7 +58,7 @@ def generate(args, keys, anim_args, loop_args, controlnet_args, root, frame = 0,
 
     # Setup the pipeline
     p = get_webui_sd_pipeline(args, root, frame)
-    p.prompt, p.negative_prompt = split_weighted_subprompts(args.prompt, frame)
+    p.prompt, p.negative_prompt = split_weighted_subprompts(args.prompt, frame, anim_args.max_frames)
     
     if not args.use_init and args.strength > 0 and args.strength_0_no_init:
         print("\nNo init image, but strength > 0. Strength has been auto set to 0, since use_init is False.")
@@ -79,9 +82,19 @@ def generate(args, keys, anim_args, loop_args, controlnet_args, root, frame = 0,
         blendFactor = .07
         colorCorrectionFactor = loop_args.colorCorrectionFactor
         jsonImages = json.loads(loop_args.imagesToKeyframe)
-        framesToImageSwapOn = list(map(int, list(jsonImages.keys())))
         # find which image to show
+        parsedImages = {}
         frameToChoose = 0
+        max_f = anim_args.max_frames - 1
+        
+        for key, value in jsonImages.items():
+            if check_is_number(key):# default case 0:(1 + t %5), 30:(5-t%2)
+                parsedImages[key] = value
+            else:# math on the left hand side case 0:(1 + t %5), maxKeyframes/2:(5-t%2)
+                parsedImages[int(numexpr.evaluate(key))] = value
+
+        framesToImageSwapOn = list(map(int, list(parsedImages.keys())))
+
         for swappingFrame in framesToImageSwapOn[1:]:
             frameToChoose += (frame >= int(swappingFrame))
         

--- a/scripts/deforum_helpers/generate.py
+++ b/scripts/deforum_helpers/generate.py
@@ -70,13 +70,6 @@ def generate(args, keys, anim_args, loop_args, controlnet_args, root, frame = 0,
     image_init0 = None
 
     if loop_args.use_looper and anim_args.animation_mode in ['2D','3D']:
-        # TODO find out why we need to set this in the init tab
-        if args.strength == 0:
-            raise RuntimeError("Strength needs to be greater than 0 in Init tab and strength_0_no_init should *not* be checked")
-        if args.seed_behavior != "schedule":
-            raise RuntimeError("seed_behavior needs to be set to schedule in under 'Keyframes' tab --> 'Seed scheduling'")
-        if not isJson(loop_args.imagesToKeyframe):
-            raise RuntimeError("The images set for use with keyframe-guidance are not in a proper JSON format")
         args.strength = loop_args.imageStrength
         tweeningFrames = loop_args.tweeningFrameSchedule
         blendFactor = .07

--- a/scripts/deforum_helpers/prompt.py
+++ b/scripts/deforum_helpers/prompt.py
@@ -1,12 +1,13 @@
 import re
+import numexpr
 
 def check_is_number(value):
     float_pattern = r'^(?=.)([+-]?([0-9]*)(\.([0-9]+))?)$'
     return re.match(float_pattern, value)
 
-def parse_weight(match, frame = 0)->float:
-    import numexpr
+def parse_weight(match, frame = 0, max_frames = 0)->float:
     w_raw = match.group("weight")
+    max_f = max_frames
     if w_raw == None:
         return 1
     if check_is_number(w_raw):
@@ -18,7 +19,7 @@ def parse_weight(match, frame = 0)->float:
             return 1
         return float(numexpr.evaluate(w_raw[1:-1]))
 
-def split_weighted_subprompts(text, frame = 0):
+def split_weighted_subprompts(text, frame = 0, max_frames = 0):
     """
     splits the prompt based on deforum webui implementation, moved from generate.py 
     """
@@ -45,15 +46,22 @@ def split_weighted_subprompts(text, frame = 0):
 def interpolate_prompts(animation_prompts, max_frames):
     import numpy as np
     import pandas as pd
-    # Get prompts sorted by keyframe 
-    sorted_prompts = sorted(animation_prompts.items(), key=lambda item: int(item[0]))
+    # Get prompts sorted by keyframe
+    max_f = max_frames
+    parsed_animation_prompts = {}
+    for key, value in animation_prompts.items():
+        if check_is_number(key):# default case 0:(1 + t %5), 30:(5-t%2)
+            parsed_animation_prompts[key] = value
+        else:# math on the left hand side case 0:(1 + t %5), maxKeyframes/2:(5-t%2)
+            parsed_animation_prompts[int(numexpr.evaluate(key))] = value
+    
+    sorted_prompts = sorted(parsed_animation_prompts.items(), key=lambda item: int(item[0]))
 
     # Setup container for interpolated prompts
     prompt_series = pd.Series([np.nan for a in range(max_frames)])
 
     # For every keyframe prompt except the last
-    for i in range(0,len(sorted_prompts)-1):
-        
+    for i in range(0,len(sorted_prompts)-1):        
         # Get current and next keyframe
         current_frame = int(sorted_prompts[i][0])
         next_frame = int(sorted_prompts[i+1][0])
@@ -69,7 +77,6 @@ def interpolate_prompts(animation_prompts, max_frames):
         next_prompt = sorted_prompts[i+1][1]
         current_positive, current_negative, *_ = current_prompt.split("--neg") + [None]
         next_positive, next_negative, *_ = next_prompt.split("--neg") + [None]
-        
         # Calculate how much to shift the weight from current to next prompt at each frame
         weight_step = 1/(next_frame-current_frame)
         
@@ -85,26 +92,26 @@ def interpolate_prompts(animation_prompts, max_frames):
 
             # Cater for the case where neither, either or both current & next have positive prompts:
             if current_positive:
-                prompt_series[f] += f"{current_positive} :{current_weight}"
+                prompt_series[f] += f" ({current_positive}):{current_weight}"
             if current_positive and next_positive:
                 prompt_series[f] += f" AND "
             if next_positive:
-                prompt_series[f] += f"{next_positive} :{next_weight}"
+                prompt_series[f] += f" ({next_positive}):{next_weight}"
             
             # Cater for the case where neither, either or both current & next have negative prompts:
-            if current_negative or next_negative:
+            if len(current_negative) > 1 or len(next_negative) > 1:
                 prompt_series[f] += " --neg "
-                if current_negative:
-                    prompt_series[f] += f" {current_negative} :{current_weight}"
-                if current_negative and next_negative:
+                if len(current_negative) > 1:
+                    prompt_series[f] += f" ({current_negative}):{current_weight}"
+                if len(current_negative) > 1 and len(next_negative) > 1:
                     prompt_series[f] += f" AND "
-                if next_negative:
-                    prompt_series[f] += f" {next_negative} :{next_weight}"
+                if len(next_negative) > 1:
+                    prompt_series[f] += f" ({next_negative}):{next_weight}"
     
     # Set explicitly declared keyframe prompts (overwriting interpolated values at the keyframe idx). This ensures:
     # - That final prompt is set, and
     # - Gives us a chance to emit warnings if any keyframe prompts are already using composable diffusion
-    for i, prompt in animation_prompts.items():
+    for i, prompt in parsed_animation_prompts.items():
         prompt_series[int(i)] = prompt
         if ' AND ' in prompt:
             print(f"WARNING: keyframe {i}'s prompt is using composable diffusion (aka the 'AND' keyword). This will cause unexpected behaviour with interpolation.")

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -9,7 +9,7 @@ import numexpr
 from PIL import Image, ImageOps
 from .rich import console
 
-from .generate import generate
+from .generate import generate, isJson
 from .noise import add_noise
 from .animation import sample_from_cv2, sample_to_cv2, anim_frame_warp
 from .animation_key_frames import DeformAnimKeys, LooperAnimKeys
@@ -39,6 +39,15 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
             args, anim_args, inputfiles = hybrid_generation(args, anim_args, root)
             # path required by hybrid functions, even if hybrid_comp_save_extra_frames is False
             hybrid_frame_path = os.path.join(args.outdir, 'hybridframes')
+
+        if loop_args.use_looper:
+            print("Using Guided Images mode: seed_behavior will be set to 'schedule' and 'strength_0_no_init' to False")
+            if args.strength == 0:
+                raise RuntimeError("Strength needs to be greater than 0 in Init tab")
+            args.strength_0_no_init = False
+            args.seed_behavior = "schedule"
+            if not isJson(loop_args.imagesToKeyframe):
+                raise RuntimeError("The images set for use with keyframe-guidance are not in a proper JSON format")
 
     # handle controlnet video input frames generation
     if is_controlnet_enabled(controlnet_args):

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -2,7 +2,10 @@ import os
 import json
 import pandas as pd
 import cv2
+import re
 import numpy as np
+import itertools
+import numexpr
 from PIL import Image, ImageOps
 from .rich import console
 
@@ -44,8 +47,8 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
     # use parseq if manifest is provided
     use_parseq = parseq_args.parseq_manifest != None and parseq_args.parseq_manifest.strip()
     # expand key frame strings to values
-    keys = DeformAnimKeys(anim_args) if not use_parseq else ParseqAnimKeys(parseq_args, anim_args, video_args)
-    loopSchedulesAndData = LooperAnimKeys(loop_args, anim_args)
+    keys = DeformAnimKeys(anim_args, args.seed) if not use_parseq else ParseqAnimKeys(parseq_args, anim_args, video_args)
+    loopSchedulesAndData = LooperAnimKeys(loop_args, anim_args, args.seed)
     # resume animation
     start_frame = 0
     if anim_args.resume_from_timestring:
@@ -80,8 +83,12 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
         prompt_series = keys.prompts
     else:
         prompt_series = pd.Series([np.nan for a in range(anim_args.max_frames)])
+        max_f = anim_args.max_frames - 1
         for i, prompt in animation_prompts.items():
-            prompt_series[int(i)] = prompt
+            if str(i).isdigit():
+                prompt_series[int(i)] = prompt
+            else:
+                prompt_series[int(numexpr.evaluate(i))] = prompt
         prompt_series = prompt_series.ffill().bfill()
 
     # check for video inits
@@ -388,8 +395,18 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
             args.seed_enable_extras = True
             args.subseed = int(keys.subseed_series[frame_idx])
             args.subseed_strength = keys.subseed_strength_series[frame_idx]
-            
-        prompt_to_print, *after_neg = args.prompt.strip().split("--neg")
+        
+        max_f = anim_args.max_frames - 1
+        pattern = r'`.*?`'
+        regex = re.compile(pattern)
+        prompt_parsed = args.prompt
+        for match in regex.finditer(prompt_parsed):
+            matched_string = match.group(0)
+            parsed_string = matched_string.replace('t', f'{frame_idx}').replace("max_f" , f"{max_f}").replace('`','')
+            parsed_value = numexpr.evaluate(parsed_string)
+            prompt_parsed = prompt_parsed.replace(matched_string, str(parsed_value))
+
+        prompt_to_print, *after_neg = prompt_parsed.strip().split("--neg")
         prompt_to_print = prompt_to_print.strip()
         after_neg = "".join(after_neg).strip()
 
@@ -397,6 +414,10 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
         print(f"\033[35mPrompt: \033[0m{prompt_to_print}")
         if after_neg and after_neg.strip():
             print(f"\033[91mNeg Prompt: \033[0m{after_neg}")
+            prompt_to_print += f"--neg {after_neg}"
+
+        # set value back into the prompt
+        args.prompt = prompt_to_print
 
         # grab init image for current frame
         if using_vid_init:

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -46,7 +46,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
                 raise RuntimeError("Strength needs to be greater than 0 in Init tab")
             args.strength_0_no_init = False
             args.seed_behavior = "schedule"
-            if not isJson(loop_args.imagesToKeyframe):
+            if not isJson(loop_args.init_images):
                 raise RuntimeError("The images set for use with keyframe-guidance are not in a proper JSON format")
 
     # handle controlnet video input frames generation

--- a/scripts/deforum_helpers/render_modes.py
+++ b/scripts/deforum_helpers/render_modes.py
@@ -14,6 +14,8 @@ from .settings import save_settings_from_animation_run
 # Webui
 from modules.shared import opts, cmd_opts, state
 
+import re, numexpr
+
 def render_input_video(args, anim_args, video_args, parseq_args, loop_args, controlnet_args, animation_prompts, root):
     # create a folder for the video input frames to live in
     video_in_frame_path = os.path.join(args.outdir, 'inputframes') 
@@ -66,6 +68,16 @@ def render_animation_with_video_mask(args, anim_args, video_args, parseq_args, l
 
     render_animation(args, anim_args, video_args, parseq_args, loop_args, controlnet_args, animation_prompts, root)
 
+def get_parsed_value(value, frame_idx, max_f):
+    pattern = r'`.*?`'
+    regex = re.compile(pattern)
+    parsed_value = value
+    for match in regex.finditer(parsed_value):
+        matched_string = match.group(0)
+        parsed_string = matched_string.replace('t', f'{frame_idx}').replace("max_f" , f"{max_f}").replace('`','')
+        value = numexpr.evaluate(parsed_string)
+        parsed_value = parsed_value.replace(matched_string, str(value))
+    return parsed_value
 
 def render_interpolation(args, anim_args, video_args, parseq_args, loop_args, controlnet_args, animation_prompts, root):
 
@@ -94,9 +106,9 @@ def render_interpolation(args, anim_args, video_args, parseq_args, loop_args, co
     frame_idx = 0
     # INTERPOLATION MODE
     while frame_idx < anim_args.max_frames:
-    
         # print data to cli
-        prompt_to_print = prompt_series[frame_idx].strip()
+        prompt_to_print = get_parsed_value(prompt_series[frame_idx].strip(), frame_idx, anim_args.max_frames)
+        
         if prompt_to_print.endswith("--neg"):
             prompt_to_print = prompt_to_print[:-5]
         print(f"\033[36mInterpolation frame: \033[0m{frame_idx}/{anim_args.max_frames}  ")
@@ -107,11 +119,11 @@ def render_interpolation(args, anim_args, video_args, parseq_args, loop_args, co
         state.job_no = frame_idx + 1
         
         if state.interrupted:
-                break
+            break
         
         # grab inputs for current frame generation
         args.n_samples = 1
-        args.prompt = prompt_series[frame_idx]
+        args.prompt = prompt_to_print
         args.scale = keys.cfg_scale_schedule_series[frame_idx]
         args.pix2pix_img_cfg_scale = keys.pix2pix_img_cfg_scale_series[frame_idx]
 


### PR DESCRIPTION
Tested:
- Numexpr prompt frame numbers `"max_f/2":"prompt"`
- Numexpr keyframe values: `0:(1.0025+0.002*sin(1.25*3.14*t/30))`
- Numexpr keyframe frame numbers: `0:(0), (max_f/2):(10), (max_f-1):(0)`
- Numexpr prompt values insertion: ```best quality, attractive anime 1girl, (gigantic breasts:`1+t/max_f`) --neg nsfw```
- Numerical keyframe values: `0: (0.65), 50:(0.4), 100: (0.65)`
- Seed insertion: `0:(s), 1:(-1), "max_f-2":(-1), "max_f-1":(s)`

All working as intended