### PR TITLE
Added color_coherence 'Image'

### DIFF
--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -95,7 +95,8 @@ def DeforumAnimArgs():
     hybrid_comp_mask_auto_contrast_cutoff_high_schedule =  "0:(100)" 
     hybrid_comp_mask_auto_contrast_cutoff_low_schedule =  "0:(0)" 
     #Coherence
-    color_coherence = 'Match Frame 0 LAB' #['None', 'Match Frame 0 HSV', 'Match Frame 0 LAB', 'Match Frame 0 RGB', 'Video Input'] {type:'string'}
+    color_coherence = 'Match Frame 0 LAB' #['None', 'Match Frame 0 HSV', 'Match Frame 0 LAB', 'Match Frame 0 RGB', 'Video Input', 'Image'] {type:'string'}
+    color_coherence_image_path = ""
     color_coherence_video_every_N_frames = 1
     color_force_grayscale = False 
     diffusion_cadence = '2' #['1','2','3','4','5','6','7','8']
@@ -541,8 +542,10 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                     with gr.TabItem('Coherence', open=False) as coherence_accord:
                         with gr.Row(variant='compact'):
                             # Future TODO: remove 'match frame 0' prefix (after we manage the deprecated-names settings import), then convert from Dropdown to Radio!
-                            color_coherence = gr.Dropdown(label="Color coherence", choices=['None', 'Match Frame 0 HSV', 'Match Frame 0 LAB', 'Match Frame 0 RGB', 'Video Input'], value=da.color_coherence, type="value", elem_id="color_coherence", interactive=True)
+                            color_coherence = gr.Dropdown(label="Color coherence", choices=['None', 'Match Frame 0 HSV', 'Match Frame 0 LAB', 'Match Frame 0 RGB', 'Video Input', 'Image'], value=da.color_coherence, type="value", elem_id="color_coherence", interactive=True)
                             color_force_grayscale = gr.Checkbox(label="Color force Grayscale", value=da.color_force_grayscale, interactive=True)
+                        with gr.Row(visible=False) as color_coherence_image_path_row:
+                            color_coherence_image_path = gr.Textbox(label="Color coherence image path", lines=1, value=da.color_coherence_image_path, interactive=True)
                         with gr.Row(visible=False) as color_coherence_video_every_N_frames_row:
                             color_coherence_video_every_N_frames = gr.Number(label="Color coherence video every N frames", value=1, interactive=True)
                         with gr.Row(variant='compact'):
@@ -973,6 +976,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
     seed_behavior.change(fn=change_seed_iter_visibility, inputs=seed_behavior, outputs=seed_iter_N_row) 
     seed_behavior.change(fn=change_seed_schedule_visibility, inputs=seed_behavior, outputs=seed_schedule_row)
     color_coherence.change(fn=change_color_coherence_video_every_N_frames_visibility, inputs=color_coherence, outputs=color_coherence_video_every_N_frames_row)
+    color_coherence.change(fn=change_color_coherence_image_path_visibility, inputs=color_coherence, outputs=color_coherence_image_path_row)
     noise_type.change(fn=change_perlin_visibility, inputs=noise_type, outputs=perlin_row)
     skip_video_creation_outputs = [fps_out_format_row, soundtrack_row, ffmpeg_quality_accordion, store_frames_in_ram, make_gif, r_upscale_row, delete_imgs]
     for output in skip_video_creation_outputs:
@@ -1017,7 +1021,7 @@ anim_args_names =   str(r'''animation_mode, max_frames, border,
                         enable_checkpoint_scheduling, checkpoint_schedule,
                         enable_clipskip_scheduling, clipskip_schedule, enable_noise_multiplier_scheduling, noise_multiplier_schedule,
                         kernel_schedule, sigma_schedule, amount_schedule, threshold_schedule,
-                        color_coherence, color_coherence_video_every_N_frames, color_force_grayscale,
+                        color_coherence, color_coherence_image_path, color_coherence_video_every_N_frames, color_force_grayscale,
                         diffusion_cadence, optical_flow_cadence,
                         noise_type, perlin_w, perlin_h, perlin_octaves, perlin_persistence,
                         use_depth_warping, midas_weight,

--- a/scripts/deforum_helpers/gradio_funcs.py
+++ b/scripts/deforum_helpers/gradio_funcs.py
@@ -10,6 +10,9 @@ def update_r_upscale_factor(choice):
 def change_perlin_visibility(choice):
     return gr.update(visible=choice=="perlin")
 
+def change_color_coherence_image_path_visibility(choice):
+    return gr.update(visible=choice=="Image")
+
 def change_color_coherence_video_every_N_frames_visibility(choice):
     return gr.update(visible=choice=="Video Input")
 


### PR DESCRIPTION
You can now color match against an image!
- the one caveat is that normal color matching is done with the prev_img. There is no prev_img for the 1st frame, so for first frame only I have to force the color match on the output rather than the input. It makes the first frame look sharpened at times, since the histogram is forced on it. But, if you use the same color match as your init image, it looks fine.

I also fixed video color coherence
- I realized that it was never color matching on the first frame for video. You usually just wouldn't notice, since you're using the video.
- I also realized it was one frame off, fixed.

![vlcsnap-2023-03-11-19h18m02s126](https://user-images.githubusercontent.com/6529731/225145868-4221b7d4-1e63-4a52-8a9c-f93211c871f7.png)

https://user-images.githubusercontent.com/6529731/225145851-fac938a7-d2e9-40b6-9885-3ee84b30d03e.mp4

![360_F_393336128_TBpWZmTC8tHdAXUThg7UmilSr4ULsw2C](https://user-images.githubusercontent.com/6529731/225145865-502e39d0-af16-4fcf-a2d8-7ba105694c82.jpg)

https://user-images.githubusercontent.com/6529731/225147405-95d86354-de1b-4acd-a871-9be161f54a41.mp4



![screenshot-127 0 0 1_7860-2023 03 11-17_47_42](https://user-images.githubusercontent.com/6529731/225145890-3b7cdbf1-c227-4cb4-bd2e-5adbefa8de1d.jpg)
https://user-images.githubusercontent.com/6529731/225145844-3c3af8c6-e971-4e71-9c25-927c497ad18a.mp4

https://user-images.githubusercontent.com/6529731/225145808-c7dca051-17ab-43c4-8c2b-302d3e73a4bc.mp4

![download](https://user-images.githubusercontent.com/6529731/225145892-03fd66ef-d871-4aee-9e5c-d308eb727814.png)

https://user-images.githubusercontent.com/6529731/225145825-5da84898-fdae-406d-919e-60b44b3f796f.mp4



