### PR TITLE
Add option to keep 3d models in vram between generations

### DIFF
--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -296,4 +296,10 @@ def on_ui_tabs():
 
     return [(deforum_interface, "Deforum", "deforum_interface")]
 
+def on_ui_settings():
+    section = ('deforum', "Deforum")
+    shared.opts.add_option("deforum_save_3d_models_in_vram", shared.OptionInfo(
+        False, "Keep 3D models in VRAM between runs", gr.Checkbox, {"interactive": True}, section=section))
+        
 script_callbacks.on_ui_tabs(on_ui_tabs)
+script_callbacks.on_ui_settings(on_ui_settings)

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -298,7 +298,7 @@ def on_ui_tabs():
 
 def on_ui_settings():
     section = ('deforum', "Deforum")
-    shared.opts.add_option("deforum_save_3d_models_in_vram", shared.OptionInfo(
+    shared.opts.add_option("deforum_keep_3d_models_in_vram", shared.OptionInfo(
         False, "Keep 3D models in VRAM between runs", gr.Checkbox, {"interactive": True}, section=section))
         
 script_callbacks.on_ui_tabs(on_ui_tabs)

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -299,7 +299,7 @@ def on_ui_tabs():
 def on_ui_settings():
     section = ('deforum', "Deforum")
     shared.opts.add_option("deforum_keep_3d_models_in_vram", shared.OptionInfo(
-        False, "Keep 3D models in VRAM between runs", gr.Checkbox, {"interactive": True}, section=section))
+        False, "Keep 3D models in VRAM between runs", gr.Checkbox, {"interactive": True, "visible": True if not (cmd_opts.lowvram or cmd_opts.medvram) else False}, section=section))
         
 script_callbacks.on_ui_tabs(on_ui_tabs)
 script_callbacks.on_ui_settings(on_ui_settings)

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -360,7 +360,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         ddim_eta = gr.Number(label="DDIM Eta", value=d.ddim_eta, interactive=True)
                     with gr.Row(variant='compact') as pix2pix_img_cfg_scale_row:
                         pix2pix_img_cfg_scale_schedule = gr.Textbox(label="Pix2Pix img CFG schedule", value=da.pix2pix_img_cfg_scale_schedule, interactive=True)    
-                        keep_3d_models_in_vram = gr.Checkbox(label="keep_3d_models_in_vram", value=d.keep_3d_models_in_vram, interactive=True, visible=(True if not (sh.cmd_opts.lowvram or sh.cmd_opts.medvram) else False))
+                        keep_3d_models_in_vram = gr.Checkbox(label="Keep 3D models in VRAM", value=d.keep_3d_models_in_vram, interactive=True, visible=(True if not (sh.cmd_opts.lowvram or sh.cmd_opts.medvram) else False))
                 # RUN FROM SETTING FILE ACCORD
                 with gr.Accordion('Resume & Run from file', open=False):
                     with gr.Tab('Run from Settings file'):

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -360,7 +360,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         ddim_eta = gr.Number(label="DDIM Eta", value=d.ddim_eta, interactive=True)
                     with gr.Row(variant='compact') as pix2pix_img_cfg_scale_row:
                         pix2pix_img_cfg_scale_schedule = gr.Textbox(label="Pix2Pix img CFG schedule", value=da.pix2pix_img_cfg_scale_schedule, interactive=True)    
-                        keep_3d_models_in_vram = gr.Checkbox(label="keep_3d_models_in_vram", value=d.keep_3d_models_in_vram, interactive=True)
+                        keep_3d_models_in_vram = gr.Checkbox(label="keep_3d_models_in_vram", value=d.keep_3d_models_in_vram, interactive=True, visible=(True if not (sh.cmd_opts.lowvram or sh.cmd_opts.medvram) else False))
                 # RUN FROM SETTING FILE ACCORD
                 with gr.Accordion('Resume & Run from file', open=False):
                     with gr.Tab('Run from Settings file'):

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -151,7 +151,6 @@ def DeforumAnimPrompts():
     """
 
 def DeforumArgs():
-    keep_3d_models_in_vram = False
     #**Image Settings**
     W = 512 #
     H = 512 #
@@ -360,7 +359,6 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         ddim_eta = gr.Number(label="DDIM Eta", value=d.ddim_eta, interactive=True)
                     with gr.Row(variant='compact') as pix2pix_img_cfg_scale_row:
                         pix2pix_img_cfg_scale_schedule = gr.Textbox(label="Pix2Pix img CFG schedule", value=da.pix2pix_img_cfg_scale_schedule, interactive=True)    
-                        keep_3d_models_in_vram = gr.Checkbox(label="Keep 3D models in VRAM", value=d.keep_3d_models_in_vram, interactive=True, visible=(True if not (sh.cmd_opts.lowvram or sh.cmd_opts.medvram) else False))
                 # RUN FROM SETTING FILE ACCORD
                 with gr.Accordion('Resume & Run from file', open=False):
                     with gr.Tab('Run from Settings file'):
@@ -1037,7 +1035,7 @@ hybrid_args_names =   str(r'''hybrid_generate_inputframes, hybrid_generate_human
                         hybrid_comp_alpha_schedule, hybrid_comp_mask_blend_alpha_schedule, hybrid_comp_mask_contrast_schedule,
                         hybrid_comp_mask_auto_contrast_cutoff_high_schedule, hybrid_comp_mask_auto_contrast_cutoff_low_schedule'''
                     ).replace("\n", "").replace("\r", "").replace(" ", "").split(',')
-args_names =    str(r'''W, H, tiling, restore_faces, keep_3d_models_in_vram,
+args_names =    str(r'''W, H, tiling, restore_faces,
                         seed, sampler,
                         seed_enable_extras, seed_resize_from_w, seed_resize_from_h,
                         steps, ddim_eta,

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -151,6 +151,7 @@ def DeforumAnimPrompts():
     """
 
 def DeforumArgs():
+    keep_3d_models_in_vram = False
     #**Image Settings**
     W = 512 #
     H = 512 #
@@ -359,6 +360,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                         ddim_eta = gr.Number(label="DDIM Eta", value=d.ddim_eta, interactive=True)
                     with gr.Row(variant='compact') as pix2pix_img_cfg_scale_row:
                         pix2pix_img_cfg_scale_schedule = gr.Textbox(label="Pix2Pix img CFG schedule", value=da.pix2pix_img_cfg_scale_schedule, interactive=True)    
+                        keep_3d_models_in_vram = gr.Checkbox(label="keep_3d_models_in_vram", value=d.keep_3d_models_in_vram, interactive=True)
                 # RUN FROM SETTING FILE ACCORD
                 with gr.Accordion('Resume & Run from file', open=False):
                     with gr.Tab('Run from Settings file'):
@@ -1035,7 +1037,7 @@ hybrid_args_names =   str(r'''hybrid_generate_inputframes, hybrid_generate_human
                         hybrid_comp_alpha_schedule, hybrid_comp_mask_blend_alpha_schedule, hybrid_comp_mask_contrast_schedule,
                         hybrid_comp_mask_auto_contrast_cutoff_high_schedule, hybrid_comp_mask_auto_contrast_cutoff_low_schedule'''
                     ).replace("\n", "").replace("\r", "").replace(" ", "").split(',')
-args_names =    str(r'''W, H, tiling, restore_faces,
+args_names =    str(r'''W, H, tiling, restore_faces, keep_3d_models_in_vram,
                         seed, sampler,
                         seed_enable_extras, seed_resize_from_w, seed_resize_from_h,
                         steps, ddim_eta,

--- a/scripts/deforum_helpers/depth.py
+++ b/scripts/deforum_helpers/depth.py
@@ -18,9 +18,13 @@ class MidasModel:
     _instance = None
 
     def __new__(cls, *args, **kwargs):
-        if not cls._instance or not kwargs.get('keep_in_vram', True):
+        keep_in_vram = kwargs.get('keep_in_vram', False)
+        if not cls._instance:
             cls._instance = super().__new__(cls)
             cls._instance._initialize(*args, **kwargs)
+        elif not keep_in_vram or not hasattr(cls._instance, 'midas_model'):
+            cls._instance._initialize(*args, **kwargs)
+        
         return cls._instance
 
     def _initialize(self, models_path, device, half_precision=True, keep_in_vram=False):

--- a/scripts/deforum_helpers/depth.py
+++ b/scripts/deforum_helpers/depth.py
@@ -12,153 +12,116 @@ from midas.dpt_depth import DPTDepthModel
 from midas.transforms import Resize, NormalizeImage, PrepareForNet
 import torchvision.transforms.functional as TF
 from .general_utils import checksum
+from modules import lowvram, devices
 
-class DepthModel():
-    def __init__(self, device):
+class MidasModel:
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance or not kwargs.get('keep_in_vram', True):
+            cls._instance = super().__new__(cls)
+            cls._instance._initialize(*args, **kwargs)
+        return cls._instance
+
+    def _initialize(self, models_path, device, half_precision=True, keep_in_vram=False):
+        self.keep_in_vram = keep_in_vram
         self.adabins_helper = None
         self.depth_min = 1000
         self.depth_max = -1000
         self.device = device
-        self.midas_model = None
-        self.midas_transform = None
-    
-    def load_adabins(self, models_path):
-        if not os.path.exists(os.path.join(models_path,'AdaBins_nyu.pt')):
-            from basicsr.utils.download_util import load_file_from_url
-            load_file_from_url(r"https://cloudflare-ipfs.com/ipfs/Qmd2mMnDLWePKmgfS8m6ntAg4nhV5VkUyAydYBp8cWWeB7/AdaBins_nyu.pt", models_path)
-            if checksum(os.path.join(models_path,'AdaBins_nyu.pt')) != "643db9785c663aca72f66739427642726b03acc6c4c1d3755a4587aa2239962746410d63722d87b49fc73581dbc98ed8e3f7e996ff7b9c0d56d0fbc98e23e41a":
-                raise Exception(r"Error while downloading AdaBins_nyu.pt. Please download from here: https://drive.google.com/file/d/1lvyZZbC9NLcS8a__YPcUP7rDiIpbRpoF and place in: " + models_path)
-        self.adabins_helper = InferenceHelper(models_path=models_path, dataset='nyu', device=self.device)
 
-    def load_midas(self, models_path, half_precision=True):
-        if not os.path.exists(os.path.join(models_path, 'dpt_large-midas-2f21e586.pt')):
+        model_file = os.path.join(models_path, 'dpt_large-midas-2f21e586.pt')
+        if not os.path.exists(model_file):
             from basicsr.utils.download_util import load_file_from_url
             load_file_from_url(r"https://github.com/intel-isl/DPT/releases/download/1_0/dpt_large-midas-2f21e586.pt", models_path)
-            if checksum(os.path.join(models_path,'dpt_large-midas-2f21e586.pt')) != "fcc4829e65d00eeed0a38e9001770676535d2e95c8a16965223aba094936e1316d569563552a852d471f310f83f597e8a238987a26a950d667815e08adaebc06":
+            if checksum(model_file) != "fcc4829e65d00eeed0a38e9001770676535d2e95c8a16965223aba094936e1316d569563552a852d471f310f83f597e8a238987a26a950d667815e08adaebc06":
                 raise Exception(r"Error while downloading dpt_large-midas-2f21e586.pt. Please download from here: https://github.com/intel-isl/DPT/releases/download/1_0/dpt_large-midas-2f21e586.pt and place in: " + models_path)
 
-        self.midas_model = DPTDepthModel(
-            path=f"{models_path}/dpt_large-midas-2f21e586.pt",
-            backbone="vitl16_384",
-            non_negative=True,
-        )
-        normalization = NormalizeImage(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
+        if not self.keep_in_vram or not hasattr(self, 'midas_model'):
+            self.midas_model = DPTDepthModel(
+                path=model_file,
+                backbone="vitl16_384",
+                non_negative=True,
+            )
 
-        self.midas_transform = T.Compose([
-            Resize(
-                384, 384,
-                resize_target=None,
-                keep_aspect_ratio=True,
-                ensure_multiple_of=32,
-                resize_method="minimal",
-                image_interpolation_method=cv2.INTER_CUBIC,
-            ),
-            normalization,
-            PrepareForNet()
-        ])
+            normalization = NormalizeImage(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
 
-        self.midas_model.eval()    
-        if self.device == torch.device("cuda"):
-            self.midas_model = self.midas_model.to(memory_format=torch.channels_last)
+            self.midas_transform = T.Compose([
+                Resize(384, 384, resize_target=None, keep_aspect_ratio=True, ensure_multiple_of=32,
+                       resize_method="minimal", image_interpolation_method=cv2.INTER_CUBIC),
+                normalization,
+                PrepareForNet()
+            ])
+
+        self.midas_model.eval().to(self.device, memory_format=torch.channels_last if self.device == torch.device("cuda") else None)
         if half_precision:
             self.midas_model = self.midas_model.half()
-        self.midas_model.to(self.device)
 
     def predict(self, prev_img_cv2, midas_weight, half_precision) -> torch.Tensor:
         w, h = prev_img_cv2.shape[1], prev_img_cv2.shape[0]
 
-        # predict depth with AdaBins    
+        img_pil = Image.fromarray(cv2.cvtColor(prev_img_cv2.astype(np.uint8), cv2.COLOR_RGB2BGR))
         use_adabins = midas_weight < 1.0 and self.adabins_helper is not None
+
         if use_adabins:
             MAX_ADABINS_AREA = 500000
-            MIN_ADABINS_AREA = 448*448
-
-            # resize image if too large or too small
-            img_pil = Image.fromarray(cv2.cvtColor(prev_img_cv2.astype(np.uint8), cv2.COLOR_RGB2BGR))
-            image_pil_area = w*h
-            resized = True
-            if image_pil_area > MAX_ADABINS_AREA:
-                scale = math.sqrt(MAX_ADABINS_AREA) / math.sqrt(image_pil_area)
-                depth_input = img_pil.resize((int(w*scale), int(h*scale)), Image.LANCZOS) # LANCZOS is good for downsampling
-                print(f"  resized to {depth_input.width}x{depth_input.height}")
-            elif image_pil_area < MIN_ADABINS_AREA:
-                scale = math.sqrt(MIN_ADABINS_AREA) / math.sqrt(image_pil_area)
-                depth_input = img_pil.resize((int(w*scale), int(h*scale)), Image.BICUBIC)
-                print(f"  resized to {depth_input.width}x{depth_input.height}")
-            else:
-                depth_input = img_pil
-                resized = False
-
-            # predict depth and resize back to original dimensions
+            MIN_ADABINS_AREA = 448 * 448
+            image_pil_area = w * h
+            scale = math.sqrt(MIN_ADABINS_AREA) / math.sqrt(image_pil_area)
+            depth_input = img_pil.resize((int(w * scale), int(h * scale)), Image.LANCZOS if image_pil_area > MAX_ADABINS_AREA else Image.BICUBIC)
             try:
                 with torch.no_grad():
                     _, adabins_depth = self.adabins_helper.predict_pil(depth_input)
-                if resized:
-                    adabins_depth = TF.resize(
-                        torch.from_numpy(adabins_depth), 
-                        torch.Size([h, w]),
-                        interpolation=TF.InterpolationMode.BICUBIC
-                    )
-                    adabins_depth = adabins_depth.cpu().numpy()
-                adabins_depth = adabins_depth.squeeze()
+                adabins_depth = adabins_depth.squeeze().cpu().numpy()
+                if image_pil_area != MAX_ADABINS_AREA:
+                    adabins_depth = TF.resize(torch.from_numpy(adabins_depth),
+                                      torch.Size([h, w]),
+                                      interpolation=TF.InterpolationMode.BICUBIC).numpy()
             except:
-                print(f"  exception encountered, falling back to pure MiDaS")
+                print("  exception encountered, falling back to pure MiDaS")
                 use_adabins = False
             torch.cuda.empty_cache()
-
         if self.midas_model is not None:
-            # convert image from 0->255 uint8 to 0->1 float for feeding to MiDaS
             img_midas = prev_img_cv2.astype(np.float32) / 255.0
             img_midas_input = self.midas_transform({"image": img_midas})["image"]
-
-            # MiDaS depth estimation implementation
             sample = torch.from_numpy(img_midas_input).float().to(self.device).unsqueeze(0)
-            if self.device == torch.device("cuda") or self.device == torch.device("mps"):
-                sample = sample.to(memory_format=torch.channels_last)  
+
+            if self.device.type == "cuda" or self.device.type == "mps":
+                sample = sample.to(memory_format=torch.channels_last)
                 if half_precision:
                     sample = sample.half()
-            with torch.no_grad():            
+
+            with torch.no_grad():
                 midas_depth = self.midas_model.forward(sample)
             midas_depth = torch.nn.functional.interpolate(
                 midas_depth.unsqueeze(1),
                 size=img_midas.shape[:2],
                 mode="bicubic",
                 align_corners=False,
-            ).squeeze()
-            midas_depth = midas_depth.cpu().numpy()
+            ).squeeze().cpu().numpy()
+
             torch.cuda.empty_cache()
-
-            # MiDaS makes the near values greater, and the far values lesser. Let's reverse that and try to align with AdaBins a bit better.
-            midas_depth = np.subtract(50.0, midas_depth)
-            midas_depth = midas_depth / 19.0
-
-            # blend between MiDaS and AdaBins predictions
-            if use_adabins:
-                depth_map = midas_depth*midas_weight + adabins_depth*(1.0-midas_weight)
-            else:
-                depth_map = midas_depth
-
-            depth_map = np.expand_dims(depth_map, axis=0)
-            depth_tensor = torch.from_numpy(depth_map).squeeze().to(self.device)
+            midas_depth = np.subtract(50.0, midas_depth) / 19.0
+            depth_map = (midas_depth * midas_weight + adabins_depth * (1.0 - midas_weight)) if use_adabins else midas_depth
+            depth_tensor = torch.from_numpy(np.expand_dims(depth_map, axis=0)).squeeze().to(self.device)
         else:
             depth_tensor = torch.ones((h, w), device=self.device)
-        
+
         return depth_tensor
+
 
     def to_image(self, depth: torch.Tensor):
         depth = depth.cpu().numpy()
-        if len(depth.shape) == 2:
-            depth = np.expand_dims(depth, axis=0)
+        depth = np.expand_dims(depth, axis=0) if len(depth.shape) == 2 else depth
         self.depth_min = min(self.depth_min, depth.min())
         self.depth_max = max(self.depth_max, depth.max())
-        print(f"  depth min:{depth.min()} max:{depth.max()}")
         denom = max(1e-8, self.depth_max - self.depth_min)
         temp = rearrange((depth - self.depth_min) / denom * 255, 'c h w -> h w c')
         temp = repeat(temp, 'h w 1 -> h w c', c=3)
         return Image.fromarray(temp.astype(np.uint8))
-        
+
     def save(self, filename: str, depth: torch.Tensor):
-        self.to_image(depth).save(filename)    
+        self.to_image(depth).save(filename)
 
     def to(self, device):
         self.device = device
@@ -167,3 +130,38 @@ class DepthModel():
             self.adabins_helper.to(device)
         gc.collect()
         torch.cuda.empty_cache()
+
+    def delete_model(self):
+        del self.midas_model
+        torch.cuda.empty_cache()
+        
+        
+class AdaBinsModel:
+    _instance = None
+    
+    def __new__(cls, *args, **kwargs):
+        keep_in_vram = kwargs.get('keep_in_vram', True)
+        if cls._instance is None or not keep_in_vram:
+            cls._instance = super().__new__(cls)
+            cls._instance._initialize(*args, **kwargs)
+        return cls._instance
+
+    def _initialize(self, models_path, keep_in_vram=False):
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.keep_in_vram = keep_in_vram
+
+        if self.keep_in_vram or not hasattr(self, 'adabins_helper'):
+            if not os.path.exists(os.path.join(models_path, 'AdaBins_nyu.pt')):
+                from basicsr.utils.download_util import load_file_from_url
+                load_file_from_url(
+                    r"https://cloudflare-ipfs.com/ipfs/Qmd2mMnDLWePKmgfS8m6ntAg4nhV5VkUyAydYBp8cWWeB7/AdaBins_nyu.pt",
+                    models_path)
+                if checksum(os.path.join(models_path, 'AdaBins_nyu.pt')) != "643db9785c663aca72f66739427642726b03acc6c4c1d3755a4587aa2239962746410d63722d87b49fc73581dbc98ed8e3f7e996ff7b9c0d56d0fbc98e23e41a":
+                    raise Exception(
+                        r"Error while downloading AdaBins_nyu.pt. Please download from here: https://drive.google.com/file/d/1lvyZZbC9NLcS8a__YPcUP7rDiIpbRpoF and place in: " + models_path)
+            self.adabins_helper = InferenceHelper(models_path=models_path, dataset='nyu', device=self.device)
+            
+    def delete_model(self):
+        del self.adabins_helper
+        torch.cuda.empty_cache()
+        devices.torch_gc()

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -32,8 +32,6 @@ from modules.shared import opts, cmd_opts, state, sd_model
 from modules import lowvram, devices, sd_hijack
 
 def render_animation(args, anim_args, video_args, parseq_args, loop_args, controlnet_args, animation_prompts, root):
-    keep_in_vram = opts.data.get("deforum_keep_3d_models_in_vram")
-    
     # handle hybrid video generation
     if anim_args.animation_mode in ['2D','3D']:
         if anim_args.hybrid_composite or anim_args.hybrid_motion in ['Affine', 'Perspective', 'Optical Flow']:
@@ -108,6 +106,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
     predict_depths = (anim_args.animation_mode == '3D' and anim_args.use_depth_warping) or anim_args.save_depth_maps
     predict_depths = predict_depths or (anim_args.hybrid_composite and anim_args.hybrid_comp_mask_type in ['Depth','Video Depth'])
     if predict_depths:
+        keep_in_vram = opts.data.get("deforum_keep_3d_models_in_vram")
         
         device = ('cpu' if cmd_opts.lowvram or cmd_opts.medvram else root.device)
         depth_model = MidasModel(root.models_path, device, root.half_precision, keep_in_vram=keep_in_vram)
@@ -548,7 +547,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
 
         args.seed = next_seed(args)
         
-    if not keep_in_vram:
+    if predict_depths and not keep_in_vram:
         depth_model.delete_model
         if anim_args.midas_weight < 1.0:
             adabins_model.delete_model()

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -549,5 +549,6 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
         args.seed = next_seed(args)
         
     if not keep_in_vram:
-        depth_model.delete_model()
-        adabins_model.delete_model() # TODO: check if it works when midas higher than 1.0
+        depth_model.delete_model
+        if anim_args.midas_weight < 1.0:
+            adabins_model.delete_model()

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -33,7 +33,6 @@ from modules import lowvram, devices, sd_hijack
 
 def render_animation(args, anim_args, video_args, parseq_args, loop_args, controlnet_args, animation_prompts, root):
     keep_in_vram = opts.data.get("deforum_keep_3d_models_in_vram")
-    print(f"keep in vram: {keep_in_vram}") # TODO: remove me
     
     # handle hybrid video generation
     if anim_args.animation_mode in ['2D','3D']:

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -32,7 +32,7 @@ from modules.shared import opts, cmd_opts, state, sd_model
 from modules import lowvram, devices, sd_hijack
 
 def render_animation(args, anim_args, video_args, parseq_args, loop_args, controlnet_args, animation_prompts, root):
-    keep_in_vram = opts.data.get("deforum_save_3d_models_in_vram")
+    keep_in_vram = opts.data.get("deforum_keep_3d_models_in_vram")
     print(f"keep in vram: {keep_in_vram}") # TODO: remove me
     
     # handle hybrid video generation

--- a/scripts/deforum_helpers/vid2depth.py
+++ b/scripts/deforum_helpers/vid2depth.py
@@ -6,7 +6,7 @@ import cv2
 from pathlib import Path
 from tqdm import tqdm
 from PIL import Image, ImageOps, ImageChops
-from modules.shared import cmd_opts
+from modules.shared import cmd_opts, device as sh_device
 from modules.scripts_postprocessing import PostprocessedImage
 from modules import devices
 import shutil
@@ -176,10 +176,9 @@ def stitch_video(img_batch_id, fps, img_folder_path, audio_path, ffmpeg_location
 
 # Midas/Adabins Depth mode with the usual workflow
 def load_depth_model(models_path, midas_weight_vid2depth):
-    keep_in_vram = False
+    device = ('cpu' if cmd_opts.lowvram or cmd_opts.medvram else sh_device)
+    keep_in_vram = False # TODO: Future  - handle this too?
     print('Loading Depth Model')
-    import torch # TODO CHANGE THESE?!
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     depth_model = MidasModel(models_path, device, not cmd_opts.no_half, keep_in_vram=keep_in_vram)
     if midas_weight_vid2depth < 1.0:
         adabins_model = AdaBinsModel(models_path, keep_in_vram=keep_in_vram)

--- a/scripts/deforum_helpers/vid2depth.py
+++ b/scripts/deforum_helpers/vid2depth.py
@@ -12,7 +12,7 @@ from modules import devices
 import shutil
 from queue import Queue, Empty
 import modules.scripts as scr
-from .depth import DepthModel
+from .depth import MidasModel, AdaBinsModel
 from .frame_interpolation import clean_folder_name
 from rife.inference_video import duplicate_pngs_from_folder
 from .video_audio_utilities import get_quick_vid_info, vid2frames, ffmpeg_stitch_video
@@ -176,11 +176,13 @@ def stitch_video(img_batch_id, fps, img_folder_path, audio_path, ffmpeg_location
 
 # Midas/Adabins Depth mode with the usual workflow
 def load_depth_model(models_path, midas_weight_vid2depth):
+    keep_in_vram = False
     print('Loading Depth Model')
-    depth_model = DepthModel(devices.device)
-    depth_model.load_midas(models_path, not cmd_opts.no_half)
+    import torch # TODO CHANGE THESE?!
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    depth_model = MidasModel(models_path, device, not cmd_opts.no_half, keep_in_vram=keep_in_vram)
     if midas_weight_vid2depth < 1.0:
-        depth_model.load_adabins(models_path)
+        adabins_model = AdaBinsModel(models_path, keep_in_vram=keep_in_vram)
     return depth_model
 
 # Anime Remove Background by skytnt and onnx model


### PR DESCRIPTION
Under webui's setting tab --> Deforum (yes, it's new):
![image](https://user-images.githubusercontent.com/121192995/226146195-ad565f5e-6e49-446e-9040-087a43df5a29.png)
\* Default of the toggle is OFF.

Toggle will not show at all if webui is launched in medvram or lowvram modes.

With toggle off, it takes me around 3-4 seconds to start a new 3d animation.

WIth the toggle on, after the first 3d animation, it starts in no time - similar to 2D mode. 

Diff in Vram is around 700MB. 

Closes https://github.com/deforum-art/deforum-for-automatic1111-webui/issues/311
