### PR TITLE
Add option to keep settings persistent upon relaunch of webui

### DIFF
--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -280,25 +280,39 @@ def on_ui_tabs():
         video_settings_component_list = [components[name] for name in deforum_args.video_args_names]
         stuff = gr.HTML("") # wrap gradio call garbage
         stuff.visible = False
-        
+
         save_settings_btn.click(
-                    fn=wrap_gradio_call(deforum_settings.save_settings),
-                    inputs=[settings_path] + settings_component_list + video_settings_component_list,
-                    outputs=[stuff],
-                )
+            fn=wrap_gradio_call(deforum_settings.save_settings),
+            inputs=[settings_path] + settings_component_list + video_settings_component_list,
+            outputs=[stuff],
+        )
         
         load_settings_btn.click(
-                    fn=wrap_gradio_call(deforum_settings.load_settings),
-                    inputs=[settings_path]+ settings_component_list,
-                    outputs=settings_component_list + [stuff],
-                )
-        
-        load_video_settings_btn.click(
-                    fn=wrap_gradio_call(deforum_settings.load_video_settings),
-                    inputs=[settings_path] + video_settings_component_list,
-                    outputs=video_settings_component_list + [stuff],
-                )
+            fn=wrap_gradio_call(deforum_settings.load_settings),
+            inputs=[settings_path]+ settings_component_list,
+            outputs=settings_component_list + [stuff],
+        )
 
+        load_video_settings_btn.click(
+            fn=wrap_gradio_call(deforum_settings.load_video_settings),
+            inputs=[settings_path] + video_settings_component_list,
+            outputs=video_settings_component_list + [stuff],
+        )
+        
+    def trigger_load_general_settings():
+        print("Loading general settings...")
+        wrapped_fn = wrap_gradio_call(deforum_settings.load_settings_on_ui_launch)
+        inputs = [settings_path.value] + [component.value for component in settings_component_list]
+        outputs = settings_component_list + [stuff]
+        updated_values = wrapped_fn(*inputs, *outputs)[0]
+
+        settings_component_name_to_obj = {name: component for name, component in zip(deforum_args.get_settings_component_names(), settings_component_list)}
+        for key, value in updated_values.items():
+            settings_component_name_to_obj[key].value = value['value']
+            
+    if opts.data.get("deforum_enable_persistent_settings"):
+        trigger_load_general_settings()
+        
     return [(deforum_interface, "Deforum", "deforum_interface")]
 
 def on_ui_settings():

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -288,9 +288,9 @@ def on_ui_tabs():
         )
         
         load_settings_btn.click(
-            fn=wrap_gradio_call(deforum_settings.load_settings),
-            inputs=[settings_path]+ settings_component_list,
-            outputs=settings_component_list + [stuff],
+        fn=wrap_gradio_call(lambda *args, **kwargs: deforum_settings.load_all_settings(*args, ui_launch=False, **kwargs)),
+        inputs=[settings_path] + settings_component_list,
+        outputs=settings_component_list + [stuff],
         )
 
         load_video_settings_btn.click(
@@ -301,7 +301,7 @@ def on_ui_tabs():
         
     def trigger_load_general_settings():
         print("Loading general settings...")
-        wrapped_fn = wrap_gradio_call(deforum_settings.load_settings_on_ui_launch)
+        wrapped_fn = wrap_gradio_call(lambda *args, **kwargs: deforum_settings.load_all_settings(*args, ui_launch=True, **kwargs))
         inputs = [settings_path.value] + [component.value for component in settings_component_list]
         outputs = settings_component_list + [stuff]
         updated_values = wrapped_fn(*inputs, *outputs)[0]
@@ -309,6 +309,7 @@ def on_ui_tabs():
         settings_component_name_to_obj = {name: component for name, component in zip(deforum_args.get_settings_component_names(), settings_component_list)}
         for key, value in updated_values.items():
             settings_component_name_to_obj[key].value = value['value']
+
             
     if opts.data.get("deforum_enable_persistent_settings"):
         trigger_load_general_settings()

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -320,7 +320,7 @@ def on_ui_settings():
     shared.opts.add_option("deforum_keep_3d_models_in_vram", shared.OptionInfo(
         False, "Keep 3D models in VRAM between runs", gr.Checkbox, {"interactive": True, "visible": True if not (cmd_opts.lowvram or cmd_opts.medvram) else False}, section=section))
     shared.opts.add_option("deforum_enable_persistent_settings", shared.OptionInfo(
-        False, "Keep settings persistent upon refresh/relaunch of webui", gr.Checkbox, {"interactive": True}, section=section))
+        False, "Keep settings persistent upon relaunch of webui", gr.Checkbox, {"interactive": True}, section=section))
     shared.opts.add_option("deforum_persistent_settings_path", shared.OptionInfo(
         "models/Deforum/deforum_persistent_settings.txt", "Path for saving your persistent settings file:", section=section))
         

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -20,6 +20,8 @@ def Root():
     mask_preset_names = ['everywhere','video_mask']
     p = None
     frames_cache = []
+    raw_batch_name = None
+    raw_seed = None
     initial_seed = None
     initial_info = None
     first_frame = None
@@ -1168,7 +1170,11 @@ def process_args(args_dict_main):
     p.seed_resize_from_h = args.seed_resize_from_h
     p.fill = args.fill
     p.ddim_eta = args.ddim_eta
+    if args.seed == -1:
+        root.raw_seed = -1
     args.seed = get_fixed_seed(args.seed)
+    if root.raw_seed != -1:
+        root.raw_seed = args.seed
     args.timestring = time.strftime('%Y%m%d%H%M%S')
     args.strength = max(0.0, min(1.0, args.strength))
     args.prompts = json.loads(args_dict_main['animation_prompts'])
@@ -1182,9 +1188,10 @@ def process_args(args_dict_main):
         anim_args.max_frames = 1
     elif anim_args.animation_mode == 'Video Input':
         args.use_init = True
-
+    
     current_arg_list = [args, anim_args, video_args, parseq_args]
     full_base_folder_path = os.path.join(os.getcwd(), p.outpath_samples)
+    root.raw_batch_name = args.batch_name
     args.batch_name = substitute_placeholders(args.batch_name, current_arg_list, full_base_folder_path)
     args.outdir = os.path.join(p.outpath_samples, str(args.batch_name))
     root.outpath_samples = args.outdir

--- a/scripts/deforum_helpers/settings.py
+++ b/scripts/deforum_helpers/settings.py
@@ -72,7 +72,7 @@ def save_settings(*args, **kwargs):
     
     return [""]
 
-def load_settings_on_ui_launch(*args, **kwargs):
+def load_all_settings(*args, ui_launch=False, **kwargs):
     import gradio as gr
     settings_path = args[0].strip()
     settings_component_names = deforum_args.get_settings_component_names()
@@ -81,15 +81,18 @@ def load_settings_on_ui_launch(*args, **kwargs):
 
     if not os.path.isfile(settings_path):
         print('The custom settings file does not exist. The values will be unchanged.')
-        return ({key: gr.update(value=value) for key, value in data.items()},)
-    
+        if ui_launch:
+            return ({key: gr.update(value=value) for key, value in data.items()},)
+        else:
+            return list(data.values()) + [""]
+
     with open(settings_path, "r", encoding='utf-8') as f:
         jdata = json.load(f)
         handle_deprecated_settings(jdata)
         if 'animation_prompts' in jdata:
             jdata['prompts'] = jdata['animation_prompts']
 
-    updated_values = {}
+    result = {}
     for key, default_val in data.items():
         val = jdata.get(key, default_val)
         if key == 'sampler' and isinstance(val, int):
@@ -105,48 +108,13 @@ def load_settings_on_ui_launch(*args, **kwargs):
             val = jdata.get(key, default_val)
         elif key == 'animation_prompts':
             val = json.dumps(jdata['prompts'], ensure_ascii=False, indent=4)
-        
-        updated_values[key] = gr.update(value=val)
 
-    return (updated_values,)
+        result[key] = val
 
-def load_settings(*args, **kwargs):
-    settings_path = args[0].strip()
-    settings_component_names = deforum_args.get_settings_component_names()
-    data = {settings_component_names[i]: args[i+1] for i in range(len(settings_component_names))}
-    print(f"reading custom settings from {settings_path}")
-
-    if not os.path.isfile(settings_path):
-        print('The custom settings file does not exist. The values will be unchanged.')
-        return list(data.values()) + [""]
-    
-    with open(settings_path, "r", encoding='utf-8') as f:
-        jdata = json.load(f)
-        handle_deprecated_settings(jdata)
-        if 'animation_prompts' in jdata:
-            jdata['prompts'] = jdata['animation_prompts']
-
-    ret = []
-    for key, default_val in data.items():
-        val = jdata.get(key, default_val)
-        if key == 'sampler' and isinstance(val, int):
-            from modules.sd_samplers import samplers_for_img2img
-            val = samplers_for_img2img[val].name
-        elif key == 'fill' and isinstance(val, int):
-            val = mask_fill_choices[val]
-        elif key in {'reroll_blank_frames', 'noise_type'} and key not in jdata:
-            default_key_val = (DeforumArgs if key != 'noise_type' else DeforumAnimArgs)[key]
-            logging.debug(f"{key} not found in load file, using default value: {default_key_val}")
-            val = default_key_val
-        elif key in {'animation_prompts_positive', 'animation_prompts_negative'}:
-            val = jdata.get(key, default_val)
-        elif key == 'animation_prompts':
-            val = json.dumps(jdata['prompts'], ensure_ascii=False, indent=4)
-        
-        ret.append(val)
-
-    ret.append("")
-    return ret
+    if ui_launch:
+        return ({key: gr.update(value=value) for key, value in result.items()},)
+    else:
+        return list(result.values()) + [""]
 
 def load_video_settings(*args, **kwargs):
     video_settings_path = args[0].strip()

--- a/scripts/deforum_helpers/settings.py
+++ b/scripts/deforum_helpers/settings.py
@@ -32,8 +32,7 @@ def load_args(args_dict, anim_args_dict, parseq_args_dict, loop_args_dict, contr
         print(args_dict, anim_args_dict, parseq_args_dict, loop_args_dict)
 
 def save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args, root, full_out_file_path = None):
-    print(full_out_file_path)
-    if full_out_file_path is not None:
+    if full_out_file_path:
         args.__dict__["seed"] = root.raw_seed
         args.__dict__["batch_name"] = root.raw_batch_name
     args.__dict__["prompts"] = root.animation_prompts

--- a/scripts/deforum_helpers/settings.py
+++ b/scripts/deforum_helpers/settings.py
@@ -31,12 +31,16 @@ def load_args(args_dict, anim_args_dict, parseq_args_dict, loop_args_dict, contr
                     print(f"Key {k} doesn't exist in the custom settings data! Using default value of {v}")
         print(args_dict, anim_args_dict, parseq_args_dict, loop_args_dict)
 
-def save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args, root):
+def save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args, root, full_out_file_path = None):
+    print(full_out_file_path)
+    if full_out_file_path is not None:
+        args.__dict__["seed"] = root.raw_seed
+        args.__dict__["batch_name"] = root.raw_batch_name
     args.__dict__["prompts"] = root.animation_prompts
     args.__dict__["positive_prompts"] = root.positive_prompts
     args.__dict__["negative_prompts"] = root.negative_prompts
     exclude_keys = get_keys_to_exclude() + ['controlnet_input_video_chosen_file', 'controlnet_input_video_mask_chosen_file']
-    settings_filename = os.path.join(args.outdir, f"{args.timestring}_settings.txt")
+    settings_filename = full_out_file_path if full_out_file_path else os.path.join(args.outdir, f"{args.timestring}_settings.txt")
     with open(settings_filename, "w+", encoding="utf-8") as f:
         s = {}
         for d in (args.__dict__, anim_args.__dict__, parseq_args.__dict__, loop_args.__dict__, controlnet_args.__dict__, video_args.__dict__):


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/121192995/226474571-1d8eecc8-754f-40af-b5b3-d6e29625e3e3.png)

If enabled, will auto-load the last generation settings upon launching webui.

F5/ refresh won't trigger it for now. Still considering the behaviour there. 

Closes https://github.com/deforum-art/deforum-for-automatic1111-webui/issues/483
