### PR TITLE
implemented new input for directory Textbox instead of gr.File in Frame Interpolation > Interpolate existing Video / Images

### DIFF
--- a/scripts/deforum_helpers/frame_interpolation.py
+++ b/scripts/deforum_helpers/frame_interpolation.py
@@ -214,3 +214,27 @@ def process_interp_pics_upload_logic(pic_list, engine, x_am, sl_enabled, sl_am, 
     
     # pass param so it won't duplicate the images at all as we already do it in here?!
     process_video_interpolation(frame_interpolation_engine=engine, frame_interpolation_x_amount=x_am, frame_interpolation_slow_mo_enabled = sl_enabled,frame_interpolation_slow_mo_amount=sl_am, orig_vid_fps=fps, deforum_models_path=f_models_path, real_audio_track=audio_file_to_pass, raw_output_imgs_path=outdir, img_batch_id=None, ffmpeg_location=f_location, ffmpeg_crf=f_crf, ffmpeg_preset=f_preset, keep_interp_imgs=keep_imgs, orig_vid_name=folder_name, resolution=resolution, dont_change_fps=True)
+
+def process_interp_pics_path_upload_logic(pic_list, engine, x_am, sl_enabled, sl_am, keep_imgs, f_location, f_crf, f_preset, fps, f_models_path, resolution, add_soundtrack, audio_track):
+    print(f"got a request to *frame interpolate* a set of {len(pic_list)} images.")
+    folder_name = clean_folder_name(Path(pic_list[0]).stem)
+    outdir_no_tmp = os.path.join(os.getcwd(), 'outputs', 'frame-interpolation', folder_name)
+    i = 1
+    while os.path.exists(outdir_no_tmp):
+        outdir_no_tmp = os.path.join(os.getcwd(), 'outputs', 'frame-interpolation', folder_name + '_' + str(i))
+        i += 1
+
+    outdir = os.path.join(outdir_no_tmp, 'tmp_input_frames')
+    os.makedirs(outdir, exist_ok=True)
+
+    convert_images_from_list(paths=pic_list, output_dir=outdir,format='png')
+
+    audio_file_to_pass = None
+    # todo? add handling of vid input sound? if needed at all...
+    if add_soundtrack == 'File':
+        audio_file_to_pass = audio_track
+         # todo: upgrade function so it takes url and check if audio really exist before passing? not crucial as ffmpeg sofly fallbacks if needed
+         # if media_file_has_audio(audio_track, f_location):
+    
+    # pass param so it won't duplicate the images at all as we already do it in here?!
+    process_video_interpolation(frame_interpolation_engine=engine, frame_interpolation_x_amount=x_am, frame_interpolation_slow_mo_enabled = sl_enabled,frame_interpolation_slow_mo_amount=sl_am, orig_vid_fps=fps, deforum_models_path=f_models_path, real_audio_track=audio_file_to_pass, raw_output_imgs_path=outdir, img_batch_id=None, ffmpeg_location=f_location, ffmpeg_crf=f_crf, ffmpeg_preset=f_preset, keep_interp_imgs=keep_imgs, orig_vid_name=folder_name, resolution=resolution, dont_change_fps=True)

--- a/style.css
+++ b/style.css
@@ -1,11 +1,11 @@
-#vid_to_interpolate_chosen_file .w-full, #pics_to_interpolate_chosen_file .w-full,  #vid_to_upscale_chosen_file .w-full, #controlnet_input_video_chosen_file .w-full, #controlnet_input_video_mask_chosen_file .w-full,#vid_to_depth_chosen_file .w-full {
+#vid_to_interpolate_chosen_file .w-full, #pics_to_interpolate_chosen_file .w-full, #pics_to_interpolate_chosen_path .w-full,  #vid_to_upscale_chosen_file .w-full, #controlnet_input_video_chosen_file .w-full, #controlnet_input_video_mask_chosen_file .w-full,#vid_to_depth_chosen_file .w-full {
 	display: flex !important;
 	align-items: flex-start !important;
 	justify-content: center !important;
 	height: 85px !important;
 }
 
-#vid_to_interpolate_chosen_file, #pics_to_interpolate_chosen_file, #vid_to_upscale_chosen_file,  #controlnet_input_video_chosen_file, #controlnet_input_video_mask_chosen_file, #vid_to_depth_chosen_file {
+#vid_to_interpolate_chosen_file, #pics_to_interpolate_chosen_file, #pics_to_interpolate_chosen_path, #vid_to_upscale_chosen_file,  #controlnet_input_video_chosen_file, #controlnet_input_video_mask_chosen_file, #vid_to_depth_chosen_file {
 	height: 85px !important;
 }
 


### PR DESCRIPTION
I had to interpolate multiple files in the webui deforum extension, but since there was no folder path option available, I had to use the gradio.File input for all required files. This worked fine for running the webui in localhost, but since I was using rented cloud GPUs, I needed a solution to avoid downloading and uploading the files through the webui interface.

The new input can be seen here:

<img width="855" alt="Screen Shot 2023-03-27 at 01 34 13" src="https://user-images.githubusercontent.com/20116813/227841770-b9d66063-4fbe-440c-8037-c2ed3440355c.png">

Hope this helps someone else.

Here's a video created with this implementation (for testing purposes):

https://user-images.githubusercontent.com/20116813/227842444-90a32ede-b97c-407e-8b40-6b190a3787a5.mp4

