### PR TITLE
Fixed resume

### DIFF
--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -137,11 +137,6 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
             cadence=turbo_steps
         )
 
-        # restore color match from first frame if necessary (0th frame on disk)
-        if anim_args.color_coherence not in ['None','Image','Video Input']:
-            path = os.path.join(args.outdir,f"{args.timestring}_{0:09}.png")
-            color_match_sample = cv2.imread(path)
-
         # set up turbo step vars
         if turbo_steps > 1:
             turbo_prev_image, turbo_prev_frame_idx = prev_img, prev_frame

--- a/scripts/deforum_helpers/resume.py
+++ b/scripts/deforum_helpers/resume.py
@@ -1,0 +1,53 @@
+import os
+import cv2
+
+# Resume requires at least two actual frames in order to work
+# 'Actual' frames are defined as frames that go through generation
+# - Can't resume from a single frame.
+# - If you have a cadence of 10, you need at least 10 frames in order to resume. 
+# - Resume grabs the last actual frame and the 2nd to last actual frame
+#   in order to work with cadence properly and feed it the prev_img/next_img
+
+def get_resume_vars(folder, timestring, cadence):
+    # count previous frames
+    frame_count = 0
+    for item in os.listdir(folder):
+        # don't count txt files or mp4 files
+        if ".txt" in item or ".mp4" in item: 
+            pass
+        else:
+            filename = item.split("_")
+            # other image file types may be supported in the future,
+            # so we just count files containing timestring
+            # that don't contain the depth keyword (depth maps are saved in same folder)
+            if timestring in filename and "depth" not in filename:
+                frame_count += 1
+                # add this to debugging var
+                print(f"\033[36mResuming:\033[0m File: {filename}")
+
+    print(f"\033[36mResuming:\033[0m Current frame count: {frame_count}")
+
+    # get last frame from frame count corrected for any trailing cadence frames
+    last_frame = frame_count - (frame_count % cadence)
+
+    # calculate previous actual frame
+    prev_frame = last_frame - cadence
+
+    # calculate next actual frame
+    next_frame = last_frame - 1
+   
+    # get prev_img/next_img from prev/next frame index (files start at 0, so subtract 1 for index var)
+    path = os.path.join(folder, f"{timestring}_{prev_frame:09}.png")  
+    prev_img = cv2.imread(path)
+    path = os.path.join(folder, f"{timestring}_{next_frame:09}.png")  
+    next_img = cv2.imread(path)
+
+    # report resume last/next in console
+    print(f"\033[36mResuming:\033[0m Last frame: {prev_frame} - Next frame: {next_frame} ")
+
+    # returns:
+    #   last frame count, accounting for cadence
+    #   next frame count, accounting for cadence
+    #   prev frame's image cv2 BGR
+    #   next frame's image cv2 BGR
+    return prev_frame, next_frame, prev_img, next_img


### PR DESCRIPTION
Now requires at least two actual frames to resume, but it works. So,
at cadence 1, you need 2 frames
at cadence 3, you need 3 frames
at cadence 10, you need 10 frames
etc.

It gets the first and last frames, reads them, and feeds them to cadence cycle properly for turbo_prev_img AND turbo_next_img, then it recreates the last frame cycle.

It automatically accounts for cadence interruptions, like if you ran out of disk space during cadence or it got interrupted. (or you delete the last few frames or whatever)

Basically, I can't make it fail now, no matter how many times I resume, or how many random frames I delete going backwards before resuming.

Try it out!

I did consider saving out any frames that were recreated, but then realized that has it's own issues with possible duplicates as well, and after testing, I just don't think it's necessary either.  It works, every time, as far as I can tell.