### PR TITLE
Made overlay_mask work

### DIFF
--- a/scripts/deforum_helpers/hybrid_video.py
+++ b/scripts/deforum_helpers/hybrid_video.py
@@ -78,7 +78,7 @@ def hybrid_generation(args, anim_args, root):
     return args, anim_args, inputfiles
 
 def hybrid_composite(args, anim_args, frame_idx, prev_img, depth_model, hybrid_comp_schedules, root):
-    video_frame = os.path.join(args.outdir, 'inputframes', get_frame_name(anim_args.video_init_path) + f"{frame_idx:09}.jpg")
+    video_frame = os.path.join(args.outdir, 'inputframes', get_frame_name(anim_args.video_init_path) + f"{frame_idx+1:09}.jpg")
     video_depth_frame = os.path.join(args.outdir, 'hybridframes', get_frame_name(anim_args.video_init_path) + f"_vid_depth{frame_idx:09}.jpg")
     depth_frame = os.path.join(args.outdir, f"{args.timestring}_depth_{frame_idx-1:09}.png")
     mask_frame = os.path.join(args.outdir, 'hybridframes', get_frame_name(anim_args.video_init_path) + f"_mask{frame_idx:09}.jpg")

--- a/scripts/deforum_helpers/masks.py
+++ b/scripts/deforum_helpers/masks.py
@@ -4,6 +4,7 @@ import gc
 import numpy as np
 from PIL import Image, ImageOps
 from .video_audio_utilities import get_frame_name
+from .load_images import load_image
 
 def do_overlay_mask(args, anim_args, img, frame_idx, is_bgr_array=False):
     if is_bgr_array:
@@ -14,8 +15,11 @@ def do_overlay_mask(args, anim_args, img, frame_idx, is_bgr_array=False):
         current_mask = Image.open(os.path.join(args.outdir, 'maskframes', get_frame_name(anim_args.video_mask_path) + f"{frame_idx+1:09}.jpg"))
         current_frame = Image.open(os.path.join(args.outdir, 'inputframes', get_frame_name(anim_args.video_init_path) + f"{frame_idx+1:09}.jpg"))
     elif args.use_mask:
-        current_mask = Image.open(args.mask_file)
-        current_frame = Image.open(args.init_image)
+        current_mask = load_image(args.mask_file)
+        if args.init_image is None:
+            current_frame = img
+        else:
+            current_frame = load_image(args.init_image)
 
     current_mask = current_mask.resize((args.W, args.H), Image.LANCZOS)
     current_frame = current_frame.resize((args.W, args.H), Image.LANCZOS)

--- a/scripts/deforum_helpers/masks.py
+++ b/scripts/deforum_helpers/masks.py
@@ -1,0 +1,33 @@
+import os
+import cv2
+import gc
+import numpy as np
+from PIL import Image, ImageOps
+from .video_audio_utilities import get_frame_name
+
+def do_overlay_mask(args, anim_args, img, frame_idx, is_bgr_array=False):
+    if is_bgr_array:
+        img = cv2.cvtColor(img.astype(np.uint8), cv2.COLOR_BGR2RGB)
+        img = Image.fromarray(img)
+
+    if anim_args.use_mask_video:
+        current_mask = Image.open(os.path.join(args.outdir, 'maskframes', get_frame_name(anim_args.video_mask_path) + f"{frame_idx+1:09}.jpg"))
+        current_frame = Image.open(os.path.join(args.outdir, 'inputframes', get_frame_name(anim_args.video_init_path) + f"{frame_idx+1:09}.jpg"))
+    elif args.use_mask:
+        current_mask = Image.open(args.mask_file)
+        current_frame = Image.open(args.init_image)
+
+    current_mask = current_mask.resize((args.W, args.H), Image.LANCZOS)
+    current_frame = current_frame.resize((args.W, args.H), Image.LANCZOS)
+    current_mask = ImageOps.grayscale(current_mask)
+
+    img = Image.composite(img, current_frame, current_mask)
+
+    if is_bgr_array:
+        img = np.array(img)
+        img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+
+    del(current_mask, current_frame)
+    gc.collect()
+
+    return img

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -31,6 +31,7 @@ from .composable_masks import compose_mask_with_check
 from .settings import save_settings_from_animation_run
 from .deforum_controlnet import unpack_controlnet_vids, is_controlnet_enabled
 from .resume import get_resume_vars
+from .masks import do_overlay_mask
 # Webui
 from modules.shared import opts, cmd_opts, state, sd_model
 from modules import lowvram, devices, sd_hijack
@@ -221,7 +222,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
             "mask_auto_contrast_cutoff_low": int(keys.hybrid_comp_mask_auto_contrast_cutoff_low_schedule_series[frame_idx]),
             "mask_auto_contrast_cutoff_high": int(keys.hybrid_comp_mask_auto_contrast_cutoff_high_schedule_series[frame_idx]),
             "flow_factor": keys.hybrid_flow_factor_schedule_series[frame_idx]
-        }        
+        }
         scheduled_sampler_name = None
         scheduled_clipskip = None
         scheduled_noise_multiplier = None
@@ -334,6 +335,10 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
                     img = cv2.cvtColor(img.astype(np.uint8), cv2.COLOR_BGR2GRAY)
                     img = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
 
+                # overlay mask
+                if args.overlay_mask and (anim_args.use_mask_video or args.use_mask):
+                    img = do_overlay_mask(args, anim_args, img, tween_frame_idx, True)
+
                 filename = f"{args.timestring}_{tween_frame_idx:09}.png"
                 cv2.imwrite(os.path.join(args.outdir, filename), img)
                 if anim_args.save_depth_maps:
@@ -350,8 +355,9 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
                 color_match_sample = np.asarray(prev_vid_img)
                 color_match_sample = cv2.cvtColor(color_match_sample, cv2.COLOR_RGB2BGR)
 
-        # apply transforms to previous frame
+        # after 1st frame, prev_img exists
         if prev_img is not None:
+            # apply transforms to previous frame
             prev_img, depth = anim_frame_warp(prev_img, args, anim_args, keys, frame_idx, depth_model, depth=None, device=root.device, half_precision=root.half_precision)
 
             # do hybrid compositing before motion
@@ -492,7 +498,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
             devices.torch_gc()
             lowvram.setup_for_low_vram(sd_model, cmd_opts.medvram)
             sd_hijack.model_hijack.hijack(sd_model)
-        
+
         # optical flow redo before generation
         if anim_args.optical_flow_redo_generation != 'None' and prev_img is not None and strength > 0:
             print(f"Optical flow redo is diffusing and warping using {anim_args.optical_flow_redo_generation} optical flow before final diffusion.")
@@ -548,6 +554,10 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
         if anim_args.color_force_grayscale:
             image = ImageOps.grayscale(image)
             image = ImageOps.colorize(image, black ="black", white ="white")
+
+        # overlay mask
+        if args.overlay_mask and (anim_args.use_mask_video or args.use_mask):
+            image = do_overlay_mask(args, anim_args, image, frame_idx)
 
         # on strength 0, set color match to generation
         if strength == 0 and not anim_args.color_coherence in ['Image', 'Video Input']:


### PR DESCRIPTION
Overlay mask working properly with static mask or video mask.
- made new masks.py file that we can use to consolidate other mask functions from main render code
- Overlay mask NOW WORKS WITH CADENCE.  I made the function switchable between PIL rgb and np bgr and inject the function during cadence and for normal saves
- I didn't use old code. I just made this work myself.

Fixed one-off issue with hybrid video where the first frame was duplicated. (it became obvious when doing overlay video masking)

re-commented a few lines, removed some whitespace