### PR TITLE
Made Optical flow cadence work in 2D mode

### DIFF
--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -572,7 +572,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                             color_coherence_image_path = gr.Textbox(label="Color coherence image path", lines=1, value=da.color_coherence_image_path, interactive=True)
                         with gr.Row(visible=False) as color_coherence_video_every_N_frames_row:
                             color_coherence_video_every_N_frames = gr.Number(label="Color coherence video every N frames", value=1, interactive=True)
-                        with gr.Row(variant='compact', visible=False) as optical_flow_cadence_row:
+                        with gr.Row(variant='compact', visible=True) as optical_flow_cadence_row:
                             with gr.Column(min_width=220):
                                 optical_flow_cadence = gr.Dropdown(choices=['None', 'DIS Fine', 'DIS Medium', 'Farneback'], label="Optical flow cadence", value=da.optical_flow_cadence, elem_id="optical_flow_cadence", interactive=True, info="use optical flow estimation for your in-between (cadence) frames")
                             with gr.Column(min_width=220, visible=False) as cadence_flow_factor_schedule_column:
@@ -974,7 +974,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
     optical_flow_redo_generation,redo_flow_factor_schedule,diffusion_redo]
     for output in diffusion_cadence_outputs:
         animation_mode.change(fn=change_diffusion_cadence_visibility, inputs=animation_mode, outputs=output)
-    three_d_related_outputs = [depth_3d_warping_accord,fov_accord,optical_flow_cadence_row,cadence_flow_factor_schedule,only_3d_motion_column]
+    three_d_related_outputs = [depth_3d_warping_accord,fov_accord,only_3d_motion_column]
     for output in three_d_related_outputs:
         animation_mode.change(fn=disble_3d_related_stuff, inputs=animation_mode, outputs=output)
     animation_mode.change(fn=enable_2d_related_stuff, inputs=animation_mode, outputs=only_2d_motion_column) 

--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -572,7 +572,7 @@ def setup_deforum_setting_dictionary(self, is_img2img, is_extension = True):
                             color_coherence_image_path = gr.Textbox(label="Color coherence image path", lines=1, value=da.color_coherence_image_path, interactive=True)
                         with gr.Row(visible=False) as color_coherence_video_every_N_frames_row:
                             color_coherence_video_every_N_frames = gr.Number(label="Color coherence video every N frames", value=1, interactive=True)
-                        with gr.Row(variant='compact', visible=True) as optical_flow_cadence_row:
+                        with gr.Row(variant='compact') as optical_flow_cadence_row:
                             with gr.Column(min_width=220):
                                 optical_flow_cadence = gr.Dropdown(choices=['None', 'DIS Fine', 'DIS Medium', 'Farneback'], label="Optical flow cadence", value=da.optical_flow_cadence, elem_id="optical_flow_cadence", interactive=True, info="use optical flow estimation for your in-between (cadence) frames")
                             with gr.Column(min_width=220, visible=False) as cadence_flow_factor_schedule_column:

--- a/scripts/deforum_helpers/hybrid_video.py
+++ b/scripts/deforum_helpers/hybrid_video.py
@@ -471,24 +471,24 @@ def extend_flow(flow, w, h):
     # Return the extended image
     return new_flow
 
-def abs_flow_to_rel_flow(flow):
-    h, w = flow.shape[:2]
+# in order to use the 2d warp function, we scale the relative flow down with the scale factor
+def abs_flow_to_rel_flow(flow, scale_factor = 1):
     fx, fy = flow[:,:,0], flow[:,:,1]
     flow_magnitude = np.sqrt(fx*fx + fy*fy)
     flow_angle = np.arctan2(fy, fx)
-
+    flow_magnitude /= scale_factor
+    flow_angle /= scale_factor
     rel_fx = flow_magnitude * np.cos(flow_angle - np.pi/2)
     rel_fy = flow_magnitude * np.sin(flow_angle - np.pi/2)
-
     return np.dstack((rel_fx, rel_fy))
 
-def rel_flow_to_abs_flow(rel_flow):
-    h, w = rel_flow.shape[:2]
+# in order to use the 2d warp function, we restore the relative flow down with the scale factor 
+def rel_flow_to_abs_flow(rel_flow, scale_factor = 1):
     rel_fx, rel_fy = rel_flow[:,:,0], rel_flow[:,:,1]
     flow_magnitude = np.sqrt(rel_fx*rel_fx + rel_fy*rel_fy)
     flow_angle = np.arctan2(rel_fy, rel_fx)
-
+    flow_magnitude *= scale_factor
+    flow_angle *= scale_factor
     abs_fx = flow_magnitude * np.cos(flow_angle + np.pi/2)
     abs_fy = flow_magnitude * np.sin(flow_angle + np.pi/2)
-
     return np.dstack((abs_fx, abs_fy))


### PR DESCRIPTION
I figured out a hack to make optical flow cadence work in 2D. 

- To do optical flow cadence, I have to warp the flow field.  But, the 2D animation warping function, usually used on images, would mess with the values of the flow (as if they were colors).  So, I scaled them down by 1000 going in and scaled them back up going out, and it eliminates the effect it had which would make parts of the image wobble around.

- The 1000 scaling actually messes with 3D optical flow cadence, so I leave that working at the normal scale factor of 1.

- I also made one modification to 3D optical flow cadence where it temporarily changes the sampling mehod (used by 3d warping function) to 'nearest' just for the flow warping, then restores it to it's previous value. This should help to minimize any pixel effects from warping.