### PR TITLE
Parseq: fix error when when delegating seed control from Parseq to Deforum

### DIFF
--- a/scripts/deforum_helpers/parseq_adapter.py
+++ b/scripts/deforum_helpers/parseq_adapter.py
@@ -95,8 +95,8 @@ class ParseqAnimKeys():
         self.near_series = self.parseq_to_anim_series('near')
         self.far_series = self.parseq_to_anim_series('far')
         self.prompts = self.parseq_to_anim_series('deforum_prompt') # formatted as "{positive} --neg {negative}"
-        self.subseed_series = self.parseq_to_anim_series('subseed')
-        self.subseed_strength_series = self.parseq_to_anim_series('subseed_strength')
+        self.subseed_schedule_series = self.parseq_to_anim_series('subseed')
+        self.subseed_strength_schedule_series = self.parseq_to_anim_series('subseed_strength')
         self.kernel_schedule_series = self.parseq_to_anim_series('antiblur_kernel')
         self.sigma_schedule_series = self.parseq_to_anim_series('antiblur_sigma')
         self.amount_schedule_series = self.parseq_to_anim_series('antiblur_amount')

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -471,8 +471,9 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
 
         if use_parseq:
             args.seed_enable_extras = True
-            args.subseed = int(keys.subseed_series[frame_idx])
-            args.subseed_strength = keys.subseed_strength_series[frame_idx]
+            anim_args.enable_subseed_scheduling = True
+            args.subseed = int(keys.subseed_schedule_series[frame_idx])
+            args.subseed_strength = keys.subseed_strength_schedule_series[frame_idx]
         
         max_f = anim_args.max_frames - 1
         pattern = r'`.*?`'

--- a/scripts/deforum_helpers/render_modes.py
+++ b/scripts/deforum_helpers/render_modes.py
@@ -147,7 +147,7 @@ def render_interpolation(args, anim_args, video_args, parseq_args, loop_args, co
             args.subseed, args.subseed_strength = keys.subseed_schedule_series[frame_idx], keys.subseed_strength_schedule_series[frame_idx]
         if use_parseq:
             anim_args.enable_subseed_scheduling = True
-            args.subseed, args.subseed_strength = int(keys.subseed_series[frame_idx]), keys.subseed_strength_series[frame_idx]
+            args.subseed, args.subseed_strength = int(keys.subseed_schedule_series[frame_idx]), keys.subseed_strength_schedule_series[frame_idx]
         args.seed = int(keys.seed_schedule_series[frame_idx]) if args.seed_behavior == 'schedule' or use_parseq else args.seed
         opts.data["CLIP_stop_at_last_layers"] = scheduled_clipskip if scheduled_clipskip is not None else opts.data["CLIP_stop_at_last_layers"]
 


### PR DESCRIPTION
Parseq users who unselect `seed` as a managed field in Parseq with the intent of controlling the seed, subseed and subseed strength params directly in Deforum may encounter the following error.

```
AttributeError: 'DeformAnimKeys' object has no attribute 'subseed_series'
```

This is because Parseq looks for members `subseed_series` and `subseed_strength_series` on the `DeformAnimKeys` instead of `subseed_schedule_series` and `subseed_strength_schedule_series` (I mispredicted the names before subseed scheduling was introduced in Deforum. :) ).

This PR fixes the Parseq adapter and its client code to use the correct field names.