### PR TITLE
FIXED optical flow cadence

### DIFF
--- a/scripts/deforum_helpers/hybrid_video.py
+++ b/scripts/deforum_helpers/hybrid_video.py
@@ -578,24 +578,23 @@ def extend_flow(flow, w, h):
     # Return the extended image
     return new_flow
 
-# in order to use the 2d warp function, we scale the relative flow down with the scale factor
-def abs_flow_to_rel_flow(flow, scale_factor = 1):
+def abs_flow_to_rel_flow(flow, width, height):
     fx, fy = flow[:,:,0], flow[:,:,1]
-    flow_magnitude = np.sqrt(fx*fx + fy*fy)
-    flow_angle = np.arctan2(fy, fx)
-    flow_magnitude /= scale_factor
-    flow_angle /= scale_factor
-    rel_fx = flow_magnitude * np.cos(flow_angle - np.pi/2)
-    rel_fy = flow_magnitude * np.sin(flow_angle - np.pi/2)
+    max_flow_x = np.max(np.abs(fx))
+    max_flow_y = np.max(np.abs(fy))
+    max_flow = max(max_flow_x, max_flow_y)
+
+    rel_fx = fx / (max_flow * width)
+    rel_fy = fy / (max_flow * height)
     return np.dstack((rel_fx, rel_fy))
 
-# in order to use the 2d warp function, we restore the relative flow down with the scale factor 
-def rel_flow_to_abs_flow(rel_flow, scale_factor = 1):
+def rel_flow_to_abs_flow(rel_flow, width, height):
     rel_fx, rel_fy = rel_flow[:,:,0], rel_flow[:,:,1]
-    flow_magnitude = np.sqrt(rel_fx*rel_fx + rel_fy*rel_fy)
-    flow_angle = np.arctan2(rel_fy, rel_fx)
-    flow_magnitude *= scale_factor
-    flow_angle *= scale_factor
-    abs_fx = flow_magnitude * np.cos(flow_angle + np.pi/2)
-    abs_fy = flow_magnitude * np.sin(flow_angle + np.pi/2)
-    return np.dstack((abs_fx, abs_fy))
+    
+    max_flow_x = np.max(np.abs(rel_fx * width))
+    max_flow_y = np.max(np.abs(rel_fy * height))
+    max_flow = max(max_flow_x, max_flow_y)
+
+    fx = rel_fx * (max_flow * width)
+    fy = rel_fy * (max_flow * height)
+    return np.dstack((fx, fy))

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -301,16 +301,9 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
 
                 # do optical flow cadence after animation warping
                 if cadence_flow is not None:
-                    # scale down relative flow for 2D to avoid warping function's effect on relative flow
-                    scale_factor = 1000 if anim_args.animation_mode == '2D' else 1
-                    cadence_flow = abs_flow_to_rel_flow(cadence_flow, scale_factor)
-                    # store sampling mode and restore after (for 3D cadence, does nothing in 2D)
-                    current_sampling_mode = anim_args.sampling_mode
-                    anim_args.sampling_mode = "nearest"
+                    cadence_flow = abs_flow_to_rel_flow(cadence_flow, args.W, args.H)
                     cadence_flow, _ = anim_frame_warp(cadence_flow, args, anim_args, keys, tween_frame_idx, depth_model, depth=depth, device=root.device, half_precision=root.half_precision)
-                    anim_args.sampling_mode = current_sampling_mode
-                    # determing flow increment and apply
-                    cadence_flow_inc = rel_flow_to_abs_flow(cadence_flow, scale_factor) * tween
+                    cadence_flow_inc = rel_flow_to_abs_flow(cadence_flow, args.W, args.H) * tween
                     if advance_prev:
                         turbo_prev_image = image_transform_optical_flow(turbo_prev_image, cadence_flow_inc, cadence_flow_factor)
                     if advance_next:


### PR DESCRIPTION
Properly normalized the optical flow field before warping and after warping based on width and height.  Now, because the range of the values are between -1 and 1 (usually much smaller), the flow doesn't get corrupted by the grid_sample for 3D or the warpPerspective for 2D anymore. So, I was able to remove all workarounds and just fix the abs to rel and rel to abs functions.