### PR TITLE
Make deforum folder name dynamic in code handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pims
 imageio_ffmpeg
 rich
 gdown
+py3d

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -91,9 +91,7 @@ def run_deforum(*args, **kwargs):
 
         for basedir in basedirs:
             sys.path.extend([
-                basedir + '/scripts/deforum_helpers/src',
-                basedir + '/extensions/deforum/scripts/deforum_helpers/src',
-                basedir + '/extensions/deforum-for-automatic1111-webui/scripts/deforum_helpers/src',
+                os.path.join(deforum_folder_name, 'scripts', 'deforum_helpers', 'src')
             ])
         
         # clean up unused memory

--- a/scripts/deforum.py
+++ b/scripts/deforum.py
@@ -2,12 +2,17 @@
 # causing Deforum's tab not show up in some cases when you've might've broken the environment with webui packages updates
 import sys, os, shutil
 
+deforum_folder_name = os.path.sep.join(os.path.abspath(__file__).split(os.path.sep)[:-2])
+
 basedirs = [os.getcwd()]
 if 'google.colab' in sys.modules:
     basedirs.append('/content/gdrive/MyDrive/sd/stable-diffusion-webui') #hardcode as TheLastBen's colab seems to be the primal source
 
 for basedir in basedirs:
-    deforum_paths_to_ensure = [basedir + '/extensions/sd-webui-deforum/scripts', basedir +'/extensions/sd-webui-deforum/scripts/deforum_helpers/src', basedir + '/extensions/deforum-for-automatic1111-webui/scripts', basedir + '/extensions/sd-webui-controlnet', basedir + '/extensions/deforum/scripts', basedir + '/scripts/deforum_helpers/src', basedir + '/extensions/deforum/scripts/deforum_helpers/src', basedir +'/extensions/deforum-for-automatic1111-webui/scripts/deforum_helpers/src',basedir]
+    deforum_paths_to_ensure = [
+        os.path.join(deforum_folder_name, 'scripts'),
+        os.path.join(deforum_folder_name, 'scripts', 'deforum_helpers', 'src')
+        ]
 
     for deforum_scripts_path_fix in deforum_paths_to_ensure:
         if not deforum_scripts_path_fix in sys.path:

--- a/scripts/deforum_helpers/animation.py
+++ b/scripts/deforum_helpers/animation.py
@@ -2,7 +2,7 @@ import numpy as np
 import cv2
 from functools import reduce
 import math
-import py3d as p3d
+import py3d_tools as p3d
 import torch
 from einops import rearrange
 from .prompt import check_is_number

--- a/scripts/deforum_helpers/animation.py
+++ b/scripts/deforum_helpers/animation.py
@@ -2,7 +2,7 @@ import numpy as np
 import cv2
 from functools import reduce
 import math
-import py3d_tools as p3d
+import py3d as p3d
 import torch
 from einops import rearrange
 from .prompt import check_is_number

--- a/scripts/deforum_helpers/word_masking.py
+++ b/scripts/deforum_helpers/word_masking.py
@@ -5,8 +5,6 @@ from torchvision import transforms
 from clipseg.models.clipseg import CLIPDensePredT
 from modules.shared import opts
 
-DEBUG_MODE = opts.data.get("deforum_debug_mode_enabled", False)
-
 preclipseg_transform = transforms.Compose([
       transforms.ToTensor(),
       transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
@@ -16,9 +14,7 @@ preclipseg_transform = transforms.Compose([
 def find_clipseg(root):
     src_basedirs = []
     for basedir in root.basedirs:
-        src_basedirs.append(basedir + '/scripts/deforum_helpers/src')
-        src_basedirs.append(basedir + '/extensions/deforum/scripts/deforum_helpers/src')
-        src_basedirs.append(basedir + '/extensions/deforum-for-automatic1111-webui/scripts/deforum_helpers/src')
+        src_basedirs.append(os.path.join(os.path.sep.join(os.path.abspath(__file__).split(os.path.sep)[:-2]), 'deforum_helpers', 'src'))
 
     for basedir in src_basedirs:
         pth = os.path.join(basedir, './clipseg/weights/rd64-uni.pth')


### PR DESCRIPTION
So that we won't have to hard code a few folder names in deforum.py. 

Made the most minimal change I could to not mess things up. 

Tested working in deforum extensions folder named as KAKAKA