### PR TITLE
Feature: Add loopback mode to ControlNet 

### DIFF
--- a/scripts/deforum_helpers/deforum_controlnet.py
+++ b/scripts/deforum_helpers/deforum_controlnet.py
@@ -87,7 +87,9 @@ def setup_controlnet_ui_raw():
             control_mode = gr.Radio(choices=["Balanced", "My prompt is more important", "ControlNet is more important"], value="Balanced", label="Control Mode", interactive=True)            
         with gr.Row(visible=False) as env_row:
             resize_mode = gr.Radio(choices=["Outer Fit (Shrink to Fit)", "Inner Fit (Scale to Fit)", "Just Resize"], value="Inner Fit (Scale to Fit)", label="Resize Mode", interactive=True)
-        hide_output_list = [pixel_perfect,low_vram,mod_row,module,weight_row,env_row,overwrite_frames,vid_path_row,control_mode_row, mask_vid_path_row] # add mask_vid_path_row when masks are working again
+        with gr.Row(visible=False) as control_loopback_row:
+            loopback_mode = gr.Checkbox(label="LoopBack mode", value=False, interactive=True)
+        hide_output_list = [pixel_perfect,low_vram,mod_row,module,weight_row,env_row,overwrite_frames,vid_path_row,control_mode_row, mask_vid_path_row, control_loopback_row] # add mask_vid_path_row when masks are working again
         for cn_output in hide_output_list:
             enabled.change(fn=hide_ui_by_cn_status, inputs=enabled,outputs=cn_output)
         module.change(build_sliders, inputs=[module, pixel_perfect], outputs=[processor_res, threshold_a, threshold_b, advanced_column])
@@ -101,7 +103,7 @@ def setup_controlnet_ui_raw():
         return {key: value for key, value in locals().items() if key in [
             "enabled", "pixel_perfect","low_vram", "module", "model", "weight",
             "guidance_start", "guidance_end", "processor_res", "threshold_a", "threshold_b", "resize_mode", "control_mode",
-            "overwrite_frames", "vid_path", "mask_vid_path"
+            "overwrite_frames", "vid_path", "mask_vid_path", "loopback_mode"
         ]}
         
     def refresh_all_models(*inputs):
@@ -142,41 +144,49 @@ def controlnet_component_names():
         'overwrite_frames', 'vid_path', 'mask_vid_path', 'enabled',
         'low_vram', 'pixel_perfect',
         'module', 'model', 'weight', 'guidance_start', 'guidance_end',
-        'processor_res', 'threshold_a', 'threshold_b', 'resize_mode', 'control_mode'
+        'processor_res', 'threshold_a', 'threshold_b', 'resize_mode', 'control_mode', 'loopback_mode'
     ]]
     
 def process_with_controlnet(p, args, anim_args, loop_args, controlnet_args, root, is_img2img=True, frame_idx=1):
     CnSchKeys = ControlNetKeys(anim_args, controlnet_args)
     def read_cn_data(cn_idx):
         cn_mask_np, cn_image_np = None, None
-        cn_inputframes = os.path.join(args.outdir, f'controlnet_{cn_idx}_inputframes') # set input frames folder path
-        if os.path.exists(cn_inputframes):
-            if count_files_in_folder(cn_inputframes) == 1:
-                cn_frame_path = os.path.join(cn_inputframes, "000000001.jpg")
-                print(f'Reading ControlNet *static* base frame at {cn_frame_path}')
-            else:
-                cn_frame_path = os.path.join(cn_inputframes, f"{frame_idx:09}.jpg")
-                print(f'Reading ControlNet {cn_idx} base frame #{frame_idx} at {cn_frame_path}')
-            if os.path.exists(cn_frame_path):
-                cn_image_np = np.array(Image.open(cn_frame_path).convert("RGB")).astype('uint8')
-        cn_maskframes = os.path.join(args.outdir, f'controlnet_{cn_idx}_maskframes') # set mask frames folder path        
-        if os.path.exists(cn_maskframes):
-            if count_files_in_folder(cn_maskframes) == 1:
-                cn_mask_frame_path = os.path.join(cn_inputframes, "000000001.jpg")
-                print(f'Reading ControlNet *static* mask frame at {cn_mask_frame_path}')
-            else:
-                cn_mask_frame_path = os.path.join(args.outdir, f'controlnet_{cn_idx}_maskframes', f"{frame_idx:09}.jpg")
-                print(f'Reading ControlNet {cn_idx} mask frame #{frame_idx} at {cn_mask_frame_path}')
-            if os.path.exists(cn_mask_frame_path):
-                cn_mask_np = np.array(Image.open(cn_mask_frame_path).convert("RGB")).astype('uint8')
+        if getattr(controlnet_args, f'cn_{cn_idx}_loopback_mode') and args.init_sample and frame_idx > 1:
+            cn_mask_np = None
+            cn_image_np = np.array(args.init_sample).astype('uint8')
+        else:
+            cn_inputframes = os.path.join(args.outdir, f'controlnet_{cn_idx}_inputframes') # set input frames folder path
+            if os.path.exists(cn_inputframes):
+                if count_files_in_folder(cn_inputframes) == 1:
+                    cn_frame_path = os.path.join(cn_inputframes, "000000001.jpg")
+                    print(f'Reading ControlNet *static* base frame at {cn_frame_path}')
+                else:
+                    cn_frame_path = os.path.join(cn_inputframes, f"{frame_idx:09}.jpg")
+                    print(f'Reading ControlNet {cn_idx} base frame #{frame_idx} at {cn_frame_path}')
+                if os.path.exists(cn_frame_path):
+                    cn_image_np = np.array(Image.open(cn_frame_path).convert("RGB")).astype('uint8')
+            cn_maskframes = os.path.join(args.outdir, f'controlnet_{cn_idx}_maskframes') # set mask frames folder path        
+            if os.path.exists(cn_maskframes):
+                if count_files_in_folder(cn_maskframes) == 1:
+                    cn_mask_frame_path = os.path.join(cn_inputframes, "000000001.jpg")
+                    print(f'Reading ControlNet *static* mask frame at {cn_mask_frame_path}')
+                else:
+                    cn_mask_frame_path = os.path.join(args.outdir, f'controlnet_{cn_idx}_maskframes', f"{frame_idx:09}.jpg")
+                    print(f'Reading ControlNet {cn_idx} mask frame #{frame_idx} at {cn_mask_frame_path}')
+                if os.path.exists(cn_mask_frame_path):
+                    cn_mask_np = np.array(Image.open(cn_mask_frame_path).convert("RGB")).astype('uint8')
 
         return cn_mask_np, cn_image_np
 
     cnet = find_controlnet()
     cn_data = [read_cn_data(i) for i in range(1, num_of_models+1)]
+    
+    # Check if any loopback_mode is set to True
+    any_loopback_mode = any(getattr(controlnet_args, f'cn_{i}_loopback_mode') for i in range(1, num_of_models + 1))
+    
     cn_inputframes_list = [os.path.join(args.outdir, f'controlnet_{i}_inputframes') for i in range(1, num_of_models+1)]
 
-    if not any(os.path.exists(cn_inputframes) for cn_inputframes in cn_inputframes_list):
+    if not any(os.path.exists(cn_inputframes) for cn_inputframes in cn_inputframes_list) and not any_loopback_mode:
         print(f'\033[33mNeither the base nor the masking frames for ControlNet were found. Using the regular pipeline\033[0m')
 
     p.scripts = scripts.scripts_img2img if is_img2img else scripts.scripts_txt2img
@@ -191,10 +201,13 @@ def process_with_controlnet(p, args, anim_args, loop_args, controlnet_args, root
         # Dynamic weight assignment for models 1 to 5
         model_num = int(prefix.split('_')[-1])  # Extract model number from prefix (e.g., "cn_1" -> 1)
         if 1 <= model_num <= 5:
-            cnu['weight'] = getattr(CnSchKeys, f"cn_{model_num}_weight_schedule_series")[frame_idx-1]
-            cnu['guidance_start'] = getattr(CnSchKeys, f"cn_{model_num}_guidance_start_schedule_series")[frame_idx-1]
-            cnu['guidance_end'] = getattr(CnSchKeys, f"cn_{model_num}_guidance_end_schedule_series")[frame_idx-1]
+            if getattr(cn_args, f"cn_{model_num}_loopback_mode") and frame_idx == 1:
+                cnu['enabled'] = False
+            cnu['weight'] = getattr(CnSchKeys, f"cn_{model_num}_weight_schedule_series")[frame_idx]
+            cnu['guidance_start'] = getattr(CnSchKeys, f"cn_{model_num}_guidance_start_schedule_series")[frame_idx]
+            cnu['guidance_end'] = getattr(CnSchKeys, f"cn_{model_num}_guidance_end_schedule_series")[frame_idx]
         cnu['image'] = {'image': img_np, 'mask': mask_np} if mask_np is not None else img_np
+
         return cnu
 
     masks_np, images_np = zip(*cn_data)
@@ -236,6 +249,10 @@ def unpack_controlnet_vids(args, anim_args, video_args, parseq_args, loop_args, 
     # this func gets called from render.py once for an entire animation run -->
     # tries to trigger an extraction of CN input frames (regular + masks) from video or image
     for i in range(1, num_of_models+1):
+        # LoopBack mode is enabled, no need to extract a video or copy an init image
+        if getattr(controlnet_args, f'cn_{i}_loopback_mode'):
+            print(f"ControlNet #{i} is in LoopBack mode, skipping video/ image extraction stage.")
+            continue
         vid_path = clean_gradio_path_strings(getattr(controlnet_args, f'cn_{i}_vid_path', None))
         mask_path = clean_gradio_path_strings(getattr(controlnet_args, f'cn_{i}_mask_vid_path', None))
 

--- a/scripts/deforum_helpers/deforum_controlnet.py
+++ b/scripts/deforum_helpers/deforum_controlnet.py
@@ -147,18 +147,18 @@ def controlnet_component_names():
         'processor_res', 'threshold_a', 'threshold_b', 'resize_mode', 'control_mode', 'loopback_mode'
     ]]
     
-def process_with_controlnet(p, args, anim_args, loop_args, controlnet_args, root, is_img2img=True, frame_idx=1):
+def process_with_controlnet(p, args, anim_args, loop_args, controlnet_args, root, is_img2img=True, frame_idx=0):
     CnSchKeys = ControlNetKeys(anim_args, controlnet_args)
     def read_cn_data(cn_idx):
         cn_mask_np, cn_image_np = None, None
-        if getattr(controlnet_args, f'cn_{cn_idx}_loopback_mode') and args.init_sample and frame_idx > 1:
+        if getattr(controlnet_args, f'cn_{cn_idx}_loopback_mode') and args.init_sample and frame_idx > 0:
             cn_mask_np = None
             cn_image_np = np.array(args.init_sample).astype('uint8')
         else:
             cn_inputframes = os.path.join(args.outdir, f'controlnet_{cn_idx}_inputframes') # set input frames folder path
             if os.path.exists(cn_inputframes):
                 if count_files_in_folder(cn_inputframes) == 1:
-                    cn_frame_path = os.path.join(cn_inputframes, "000000001.jpg")
+                    cn_frame_path = os.path.join(cn_inputframes, "000000000.jpg")
                     print(f'Reading ControlNet *static* base frame at {cn_frame_path}')
                 else:
                     cn_frame_path = os.path.join(cn_inputframes, f"{frame_idx:09}.jpg")
@@ -168,7 +168,7 @@ def process_with_controlnet(p, args, anim_args, loop_args, controlnet_args, root
             cn_maskframes = os.path.join(args.outdir, f'controlnet_{cn_idx}_maskframes') # set mask frames folder path        
             if os.path.exists(cn_maskframes):
                 if count_files_in_folder(cn_maskframes) == 1:
-                    cn_mask_frame_path = os.path.join(cn_inputframes, "000000001.jpg")
+                    cn_mask_frame_path = os.path.join(cn_inputframes, "000000000.jpg")
                     print(f'Reading ControlNet *static* mask frame at {cn_mask_frame_path}')
                 else:
                     cn_mask_frame_path = os.path.join(args.outdir, f'controlnet_{cn_idx}_maskframes', f"{frame_idx:09}.jpg")
@@ -201,7 +201,7 @@ def process_with_controlnet(p, args, anim_args, loop_args, controlnet_args, root
         # Dynamic weight assignment for models 1 to 5
         model_num = int(prefix.split('_')[-1])  # Extract model number from prefix (e.g., "cn_1" -> 1)
         if 1 <= model_num <= 5:
-            if getattr(cn_args, f"cn_{model_num}_loopback_mode") and frame_idx == 1:
+            if getattr(cn_args, f"cn_{model_num}_loopback_mode") and frame_idx == 0:
                 cnu['enabled'] = False
             cnu['weight'] = getattr(CnSchKeys, f"cn_{model_num}_weight_schedule_series")[frame_idx]
             cnu['guidance_start'] = getattr(CnSchKeys, f"cn_{model_num}_guidance_start_schedule_series")[frame_idx]

--- a/scripts/deforum_helpers/deforum_controlnet.py
+++ b/scripts/deforum_helpers/deforum_controlnet.py
@@ -84,7 +84,7 @@ def setup_controlnet_ui_raw():
         with gr.Row(visible=False) as mask_vid_path_row: # invisible temporarily since 26-04-23 until masks are fixed
             mask_vid_path = gr.Textbox(value='', label="ControlNet Mask Video/ Image Path (*NOT WORKING, kept in UI for CN's devs testing!*)", interactive=True)
         with gr.Row(visible=False) as control_mode_row:
-            control_mode = gr.Radio(choices=["Balanced", "My prompt is more important", "ControlNet is more important"], value="Balanced", label="Control Mode", interactive=True)            
+            control_mode = gr.Radio(choices=["Balanced", "My prompt is more important", "ControlNet is more important"], value="Balanced", label="Control Mode", interactive=True)
         with gr.Row(visible=False) as env_row:
             resize_mode = gr.Radio(choices=["Outer Fit (Shrink to Fit)", "Inner Fit (Scale to Fit)", "Just Resize"], value="Inner Fit (Scale to Fit)", label="Resize Mode", interactive=True)
         with gr.Row(visible=False) as control_loopback_row:
@@ -93,6 +93,11 @@ def setup_controlnet_ui_raw():
         for cn_output in hide_output_list:
             enabled.change(fn=hide_ui_by_cn_status, inputs=enabled,outputs=cn_output)
         module.change(build_sliders, inputs=[module, pixel_perfect], outputs=[processor_res, threshold_a, threshold_b, advanced_column])
+        # hide vid/image input fields
+        loopback_outs = [vid_path_row, mask_vid_path_row]
+        for loopback_output in loopback_outs:
+            loopback_mode.change(fn=hide_file_textboxes, inputs=loopback_mode, outputs=loopback_output)
+        # handle pixel perfect ui changes
         pixel_perfect.change(build_sliders, inputs=[module, pixel_perfect], outputs=[processor_res, threshold_a, threshold_b, advanced_column])
         infotext_fields.extend([
                 (module, f"ControlNet Preprocessor"),
@@ -225,10 +230,10 @@ def process_controlnet_input_frames(args, anim_args, controlnet_args, video_path
         
         accepted_image_extensions = ('.jpg', '.jpeg', '.png', '.bmp')
         if video_path and video_path.lower().endswith(accepted_image_extensions):
-            convert_image(video_path, os.path.join(frame_path, '000000001.jpg'))
+            convert_image(video_path, os.path.join(frame_path, '000000000.jpg'))
             print(f"Copied CN Model {id}'s single input image to inputframes folder!")
         elif mask_path and mask_path.lower().endswith(accepted_image_extensions):
-            convert_image(mask_path, os.path.join(frame_path, '000000001.jpg'))
+            convert_image(mask_path, os.path.join(frame_path, '000000000.jpg'))
             print(f"Copied CN Model {id}'s single input image to inputframes *mask* folder!")
         else:
             print(f'Unpacking ControlNet {id} {"video mask" if mask_path else "base video"}')

--- a/scripts/deforum_helpers/deforum_controlnet_gradio.py
+++ b/scripts/deforum_helpers/deforum_controlnet_gradio.py
@@ -26,6 +26,9 @@ import gradio as gr
 def hide_ui_by_cn_status(choice):
     return gr.update(visible=True) if choice else gr.update(visible=False)
     
+def hide_file_textboxes(choice):
+    return gr.update(visible=False) if choice else gr.update(visible=True)
+    
 class ToolButton(gr.Button, gr.components.FormComponent):
         """Small button with single emoji as text, fits inside gradio forms"""
         def __init__(self, **kwargs):

--- a/scripts/deforum_helpers/generate.py
+++ b/scripts/deforum_helpers/generate.py
@@ -230,7 +230,7 @@ def generate_inner(args, keys, anim_args, loop_args, controlnet_args, root, fram
         print_combined_table(args, anim_args, p_txt, keys, frame) # print dynamic table to cli
 
         if is_controlnet_enabled(controlnet_args):
-            process_with_controlnet(p_txt, args, anim_args, loop_args, controlnet_args, root, is_img2img=False, frame_idx=frame+1)
+            process_with_controlnet(p_txt, args, anim_args, loop_args, controlnet_args, root, is_img2img=False, frame_idx=frame)
     
         processed = processing.process_images(p_txt)
 
@@ -262,7 +262,7 @@ def generate_inner(args, keys, anim_args, loop_args, controlnet_args, root, fram
         print_combined_table(args, anim_args, p, keys, frame) # print dynamic table to cli
        
         if is_controlnet_enabled(controlnet_args):
-            process_with_controlnet(p, args, anim_args, loop_args, controlnet_args, root, is_img2img=True, frame_idx=frame+1)
+            process_with_controlnet(p, args, anim_args, loop_args, controlnet_args, root, is_img2img=True, frame_idx=frame)
     
         processed = processing.process_images(p)
     

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -91,7 +91,7 @@ def vid2frames(video_path, video_in_frame_path, n=1, overwrite=True, extract_fro
             vidcap.set(cv2.CAP_PROP_POS_FRAMES, extract_from_frame) # Set the starting frame
             success,image = vidcap.read()
             count = extract_from_frame
-            t=1
+            t=0
             success = True
             max_workers = int(max(1, (os.cpu_count() / 2) - 1)) # set max threads to cpu cores halved, minus 1. minimum is 1
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:


### PR DESCRIPTION
When enabled, that CN model (1-5) will only be enabled after the very first frame creation, then the previous generated deforum frame will be provided to that CN unit as its image input. 

~~Small Todo: hide vid/image input textboxes when LP is enabled, cuz they will not be used at all in that case.~~ DONE