### PR TITLE
Don't save outdir param to setting files

### DIFF
--- a/scripts/deforum_helpers/settings.py
+++ b/scripts/deforum_helpers/settings.py
@@ -17,7 +17,7 @@ def get_keys_to_exclude():
         "show_sample_per_step", "filename_format", "from_img2img_instead_of_link",
         "scale", "subseed", "subseed_strength", "C", "f", "init_latent", "init_sample",
         "init_c", "noise_mask", "seed_internal", "perlin_w", "perlin_h", "mp4_path",
-        "image_path", "output_format","render_steps","path_name_modifier"
+        "image_path", "output_format","render_steps","path_name_modifier", "outdir"
     ]
        
 def load_args(args_dict_main, args_dict, anim_args_dict, parseq_args_dict, loop_args_dict, controlnet_args_dict, video_args_dict, custom_settings_file, root, run_id):


### PR DESCRIPTION
We don't use it as it is, but I didn't want to remove it from the code at that stage.