### PR TITLE
bugfix for wrong mask being used

### DIFF
--- a/scripts/deforum_helpers/generate.py
+++ b/scripts/deforum_helpers/generate.py
@@ -237,6 +237,7 @@ def generate_inner(args, keys, anim_args, loop_args, controlnet_args, root, fram
     if processed is None:
         # Mask functions
         if args.use_mask:
+            mask_image = args.mask_image
             mask = prepare_mask(args.mask_file if mask_image is None else mask_image, 
                                 (args.W, args.H),
                                 args.mask_contrast_adjust, 

--- a/scripts/deforum_helpers/masks.py
+++ b/scripts/deforum_helpers/masks.py
@@ -15,7 +15,7 @@ def do_overlay_mask(args, anim_args, img, frame_idx, is_bgr_array=False):
         current_mask = Image.open(os.path.join(args.outdir, 'maskframes', get_frame_name(anim_args.video_mask_path) + f"{frame_idx:09}.jpg"))
         current_frame = Image.open(os.path.join(args.outdir, 'inputframes', get_frame_name(anim_args.video_init_path) + f"{frame_idx:09}.jpg"))
     elif args.use_mask:
-        current_mask = load_image(args.mask_file)
+        current_mask = args.mask_image if args.mask_image is not None else load_image(args.mask_file)
         if args.init_image is None:
             current_frame = img
         else:

--- a/scripts/deforum_helpers/word_masking.py
+++ b/scripts/deforum_helpers/word_masking.py
@@ -41,6 +41,6 @@ def get_word_mask(root, frame, word_mask):
         preds = root.clipseg_model(img.repeat(len(word_masks),1,1,1), word_masks)[0]
 
     mask = torch.sigmoid(preds[0][0]).unsqueeze(0).unsqueeze(0) # add batch, channels dims
-    resized_mask = interpolate(mask, size=(frame.size[1], frame.size[0])).squeeze() # rescale mask back to the target resolution
+    resized_mask = interpolate(mask, size=(frame.size[1], frame.size[0]), mode='bicubic').squeeze() # rescale mask back to the target resolution
     numpy_array = resized_mask.multiply(255).to(dtype=torch.uint8,device='cpu').numpy()
     return Image.fromarray(cv2.threshold(numpy_array, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)[1])

--- a/scripts/deforum_helpers/word_masking.py
+++ b/scripts/deforum_helpers/word_masking.py
@@ -43,4 +43,4 @@ def get_word_mask(root, frame, word_mask):
     mask = torch.sigmoid(preds[0][0]).unsqueeze(0).unsqueeze(0) # add batch, channels dims
     resized_mask = interpolate(mask, size=(frame.size[1], frame.size[0]), mode='bicubic').squeeze() # rescale mask back to the target resolution
     numpy_array = resized_mask.multiply(255).to(dtype=torch.uint8,device='cpu').numpy()
-    return Image.fromarray(cv2.threshold(numpy_array, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)[1])
+    return Image.fromarray(cv2.threshold(numpy_array, 32, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)[1])


### PR DESCRIPTION
Only the `Init Mask` was ever being used for masking even though a "correct" mask was already being calculated and stored in `args.mask_image`. This fixes `Composable Mask scheduling` not working and possibly more.

I honestly have no idea what `do_overlay_mask.py` even does but I saw the same error being made there so decided to fix it there as well.

