### PR TITLE
Allow Parseq to control ControlNet schedules

### DIFF
--- a/scripts/deforum_helpers/deforum_controlnet.py
+++ b/scripts/deforum_helpers/deforum_controlnet.py
@@ -13,6 +13,7 @@ from .general_utils import count_files_in_folder, clean_gradio_path_strings  # T
 from .video_audio_utilities import vid2frames, convert_image
 from .animation_key_frames import ControlNetKeys
 from .load_images import load_image
+from .general_utils import debug_print
 
 cnet = None
 # number of CN model tabs to show in the deforum gui
@@ -197,8 +198,8 @@ def controlnet_component_names():
         'processor_res', 'threshold_a', 'threshold_b', 'resize_mode', 'control_mode', 'loopback_mode'
     ]]
 
-def process_with_controlnet(p, args, anim_args, controlnet_args, root, is_img2img=True, frame_idx=0):
-    CnSchKeys = ControlNetKeys(anim_args, controlnet_args)
+def process_with_controlnet(p, args, anim_args, controlnet_args, root, parseq_adapter, is_img2img=True, frame_idx=0):
+    CnSchKeys = ControlNetKeys(anim_args, controlnet_args) if not parseq_adapter.use_parseq else parseq_adapter.cn_keys
 
     def read_cn_data(cn_idx):
         cn_mask_np, cn_image_np = None, None
@@ -264,6 +265,8 @@ def process_with_controlnet(p, args, anim_args, controlnet_args, root, is_img2im
             cnu['weight'] = getattr(CnSchKeys, f"cn_{model_num}_weight_schedule_series")[frame_idx]
             cnu['guidance_start'] = getattr(CnSchKeys, f"cn_{model_num}_guidance_start_schedule_series")[frame_idx]
             cnu['guidance_end'] = getattr(CnSchKeys, f"cn_{model_num}_guidance_end_schedule_series")[frame_idx]
+            if cnu['enabled']:
+                debug_print(f"ControlNet {model_num}: weight={cnu['weight']}, guidance_start={cnu['guidance_start']}, guidance_end={cnu['guidance_end']}")
         cnu['image'] = {'image': img_np, 'mask': mask_np} if mask_np is not None else img_np
 
         return cnu

--- a/scripts/deforum_helpers/deforum_tqdm.py
+++ b/scripts/deforum_helpers/deforum_tqdm.py
@@ -13,11 +13,11 @@ class DeforumTQDM:
 
     def reset(self):
         from .animation_key_frames import DeformAnimKeys
-        from .parseq_adapter import ParseqAnimKeys
+        from .parseq_adapter import ParseqAdapter
         deforum_total = 0
         # FIXME: get only amount of steps
-        use_parseq = self._parseq_args.parseq_manifest is not None and self._parseq_args.parseq_manifest.strip()
-        keys = DeformAnimKeys(self._anim_args) if not use_parseq else ParseqAnimKeys(self._parseq_args, self._anim_args, self._video_args, mute=True)
+        parseq_adapter = ParseqAdapter(self._parseq_args, self._args, self._anim_args, self._video_args, None, None, mute=True)
+        keys = DeformAnimKeys(self._anim_args) if not parseq_adapter.use_parseq else parseq_adapter.anim_keys
 
         start_frame = 0
         if self._anim_args.resume_from_timestring:

--- a/scripts/deforum_helpers/deforum_tqdm.py
+++ b/scripts/deforum_helpers/deforum_tqdm.py
@@ -16,7 +16,7 @@ class DeforumTQDM:
         from .parseq_adapter import ParseqAdapter
         deforum_total = 0
         # FIXME: get only amount of steps
-        parseq_adapter = ParseqAdapter(self._parseq_args, self._args, self._anim_args, self._video_args, None, None, mute=True)
+        parseq_adapter = ParseqAdapter(self._parseq_args, self._anim_args, self._video_args, None, mute=True)
         keys = DeformAnimKeys(self._anim_args) if not parseq_adapter.use_parseq else parseq_adapter.anim_keys
 
         start_frame = 0

--- a/scripts/deforum_helpers/parseq_adapter.py
+++ b/scripts/deforum_helpers/parseq_adapter.py
@@ -6,153 +6,133 @@ from operator import itemgetter
 import numpy as np
 import pandas as pd
 import requests
-from .animation_key_frames import DeformAnimKeys
+from .animation_key_frames import DeformAnimKeys, LooperAnimKeys, ControlNetKeys
 from .rich import console
 
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
 
-class ParseqAnimKeys():
-    def __init__(self, parseq_args, anim_args, video_args, mute=False):
+class ParseqAdapter():
+    def __init__(self, parseq_args, args, anim_args, video_args, loop_args, controlnet_args, mute=False):
 
-        # Resolve manifest either directly from supplied value
-        # or via supplied URL
-        manifestOrUrl = parseq_args.parseq_manifest.strip()
-        if (manifestOrUrl.startswith('http')):
-            logging.info(f"Loading Parseq manifest from URL: {manifestOrUrl}")
-            try:
-                body = requests.get(manifestOrUrl).text
-                logging.debug(f"Loaded remote manifest: {body}")
-                self.parseq_json = json.loads(body)
+        # Basic data extraction
+        self.use_parseq = parseq_args.parseq_manifest and parseq_args.parseq_manifest.strip()
+        self.use_deltas = parseq_args.parseq_use_deltas
 
-                # Add the parseq manifest without the detailed frame data to parseq_args.
-                # This ensures it will be saved in the settings file, so that you can always
-                # see exactly what parseq prompts and keyframes were used, even if what the URL
-                # points to changes.
-                parseq_args.fetched_parseq_manifest_summary = copy.deepcopy(self.parseq_json)
-                if parseq_args.fetched_parseq_manifest_summary['rendered_frames']:
-                    del parseq_args.fetched_parseq_manifest_summary['rendered_frames']
-                if parseq_args.fetched_parseq_manifest_summary['rendered_frames_meta']:
-                    del parseq_args.fetched_parseq_manifest_summary['rendered_frames_meta']
-
-            except Exception as e:
-                logging.error(f"Unable to load Parseq manifest from URL: {manifestOrUrl}")
-                raise e
-        else:
-            self.parseq_json = json.loads(manifestOrUrl)
-
-        self.default_anim_keys = DeformAnimKeys(anim_args)
+        self.parseq_json = self.load_manifest(parseq_args) if self.use_parseq else json.loads('{ rendered_frames: [{frame: 0}] }')
         self.rendered_frames = self.parseq_json['rendered_frames']       
         self.max_frame = self.get_max('frame')
-        self.required_frames = anim_args.max_frames
+        self.required_frames = anim_args.max_frames        
+
+        # Wrap the original schedules with Parseq decorators, so that Parseq values will override the original values IFF appropriate.
+        self.anim_keys = ParseqAnimKeysDecorator(self, DeformAnimKeys(anim_args))
+        self.looper_keys = ParseqLooperKeysDecorator(self, LooperAnimKeys(loop_args, anim_args, args.seed)) if loop_args else None
+        self.cn_keys = ParseqControlNetKeysDecorator(self, ControlNetKeys(anim_args, controlnet_args)) if loop_args else None
+
         # TODO these values are currently only used to emit a subtle warning. User must ensure the output FPS set in parseq
         # matches the one set in Deforum to avoid unexpected results.
         # In the future we may wish to override video_args.fps value with the one from parseq.
         self.required_fps = video_args.fps
         self.config_output_fps = self.parseq_json['options']['output_fps']
 
-        if not mute:
-            self.print_parseq_table()
-
-        count_defined_frames = len(self.rendered_frames)        
+        # Validation
+        count_defined_frames = len(self.rendered_frames)
         expected_defined_frames = self.max_frame+1 # frames are 0-indexed
         if (expected_defined_frames != count_defined_frames): 
             logging.warning(f"There may be duplicated or missing frame data in the Parseq input: expected {expected_defined_frames} frames including frame 0 because the highest frame number is {self.max_frame}, but there are {count_defined_frames} frames defined.")
+        if not mute:
+            self.print_parseq_table()
+    
+    # Resolve manifest either directly from supplied value or via supplied URL
+    def load_manifest(self, parseq_args):
+        manifestOrUrl = parseq_args.parseq_manifest.strip()
+        if (manifestOrUrl.startswith('http')):
+            logging.info(f"Loading Parseq manifest from URL: {manifestOrUrl}")
+            try:
+                body = requests.get(manifestOrUrl).text
+                logging.debug(f"Loaded remote manifest: {body}")
+                parseq_json = json.loads(body)
+                if not parseq_json or not parseq_json['rendered_frames']:
+                    raise Exception(f"The JSON data does not look like a Parseq manifest (missing field 'rendered_frames').")
 
-        # Parseq treats input values as absolute values. So if you want to 
-        # progressively rotate 180 degrees over 4 frames, you specify: 45, 90, 135, 180.
-        # However, many animation parameters are relative to the previous frame if there is enough
-        # loopback strength. So if you want to rotate 180 degrees over 5 frames, the animation engine expects:
-        # 45, 45, 45, 45. Therefore, for such parameter, we use the fact that Parseq supplies delta values.
-        optional_delta = '_delta' if parseq_args.parseq_use_deltas else ''
-        self.angle_series = self.parseq_to_anim_series('angle' + optional_delta)
-        self.zoom_series = self.parseq_to_anim_series('zoom' + optional_delta)        
-        self.translation_x_series = self.parseq_to_anim_series('translation_x' + optional_delta)
-        self.translation_y_series = self.parseq_to_anim_series('translation_y' + optional_delta)
-        self.translation_z_series = self.parseq_to_anim_series('translation_z' + optional_delta)
-        self.rotation_3d_x_series = self.parseq_to_anim_series('rotation_3d_x' + optional_delta)
-        self.rotation_3d_y_series = self.parseq_to_anim_series('rotation_3d_y' + optional_delta)
-        self.rotation_3d_z_series = self.parseq_to_anim_series('rotation_3d_z' + optional_delta)
-        self.perspective_flip_theta_series = self.parseq_to_anim_series('perspective_flip_theta' + optional_delta)
-        self.perspective_flip_phi_series = self.parseq_to_anim_series('perspective_flip_phi' + optional_delta)
-        self.perspective_flip_gamma_series = self.parseq_to_anim_series('perspective_flip_gamma' + optional_delta)
- 
-        # Non-motion animation args
-        self.perspective_flip_fv_series = self.parseq_to_anim_series('perspective_flip_fv')
-        self.noise_schedule_series = self.parseq_to_anim_series('noise')
-        self.strength_schedule_series = self.parseq_to_anim_series('strength')
-        self.sampler_schedule_series = self.parseq_to_anim_series('sampler_schedule')
-        self.contrast_schedule_series = self.parseq_to_anim_series('contrast')
-        self.cfg_scale_schedule_series = self.parseq_to_anim_series('scale')
-        self.steps_schedule_series = self.parseq_to_anim_series("steps_schedule")
-        self.seed_schedule_series = self.parseq_to_anim_series('seed')
-        self.fov_series = self.parseq_to_anim_series('fov')
-        self.near_series = self.parseq_to_anim_series('near')
-        self.far_series = self.parseq_to_anim_series('far')
-        self.prompts = self.parseq_to_anim_series('deforum_prompt') # formatted as "{positive} --neg {negative}"
-        self.subseed_schedule_series = self.parseq_to_anim_series('subseed')
-        self.subseed_strength_schedule_series = self.parseq_to_anim_series('subseed_strength')
-        self.kernel_schedule_series = self.parseq_to_anim_series('antiblur_kernel')
-        self.sigma_schedule_series = self.parseq_to_anim_series('antiblur_sigma')
-        self.amount_schedule_series = self.parseq_to_anim_series('antiblur_amount')
-        self.threshold_schedule_series = self.parseq_to_anim_series('antiblur_threshold')
+                # SIDE EFFECT!
+                # Add the parseq manifest without the detailed frame data to parseq_args.
+                # This ensures it will be saved in the settings file, so that you can always
+                # see exactly what parseq prompts and keyframes were used, even if what the URL
+                # points to changes.
+                parseq_args.fetched_parseq_manifest_summary = copy.deepcopy(parseq_json)
+                if parseq_args.fetched_parseq_manifest_summary['rendered_frames']:
+                    del parseq_args.fetched_parseq_manifest_summary['rendered_frames']
+                if parseq_args.fetched_parseq_manifest_summary['rendered_frames_meta']:
+                    del parseq_args.fetched_parseq_manifest_summary['rendered_frames_meta']
+
+                return parseq_json
+
+            except Exception as e:
+                logging.error(f"Unable to load Parseq manifest from URL: {manifestOrUrl}")
+                raise e
+        else:
+            return json.loads(manifestOrUrl)        
 
     def print_parseq_table(self):
         from rich.table import Table
         from rich import box
+        
         table = Table(padding=0, box=box.ROUNDED, show_lines=True)
         table.add_column("", style="white bold")
         table.add_column("Parseq", style="cyan")
         table.add_column("Deforum", style="green")
 
-        table.add_row("Fields", '\n'.join(self.managed_fields()), '\n'.join(self.unmanaged_fields()))
+        table.add_row("Anim Fields", '\n'.join(self.anim_keys.managed_fields()), '\n'.join(self.anim_keys.unmanaged_fields()))
+        if self.looper_keys:
+            table.add_row("Guided Imgs Fields", '\n'.join(self.looper_keys.managed_fields()), '\n'.join(self.looper_keys.unmanaged_fields()))
+        if self.cn_keys:
+            table.add_row("Cn Fields", '\n'.join(self.cn_keys.managed_fields()), '\n'.join(self.cn_keys.unmanaged_fields()))
         table.add_row("Prompts", "✅" if self.manages_prompts() else "❌", "✅" if not self.manages_prompts() else "❌")
-        table.add_row("Frames", str(len(self.rendered_frames)), str(self.required_frames) + (" ⚠️" if self.required_frames != len(self.rendered_frames) else ""))
-        table.add_row("FPS", str(self.config_output_fps), str(self.required_fps) + (" ⚠️" if self.required_fps != self.config_output_fps else ""))
+        table.add_row("Frames", str(len(self.rendered_frames)), str(self.required_frames) + (" ⚠️" if str(self.required_frames) != str(len(self.rendered_frames))+"" else ""))
+        table.add_row("FPS", str(self.config_output_fps), str(self.required_fps) + (" ⚠️" if str(self.required_fps) != str(self.config_output_fps) else ""))
 
         console.print("\nUse this table to validate your Parseq & Deforum setup:")
         console.print(table)
 
     def manages_prompts(self):
-        return 'deforum_prompt' in self.rendered_frames[0].keys()
-    
-    def managed_fields(self):
-        return [field for field in self.rendered_frames[0].keys()
-                            if (field not in ['frame', 'deforum_prompt']
-                                    and not field.endswith('_delta')
-                                    and not field.endswith('_pc'))]
-    
-    def unmanaged_fields(self):
-        managed_fields = self.managed_fields()
-        all_fields = [self.strip_suffixes(property) for property, _ in vars(self.default_anim_keys).items() if property not in ['fi'] and not property.startswith('_')]
-        return [field for field in all_fields if field not in managed_fields]
+        return self.use_parseq and 'deforum_prompt' in self.rendered_frames[0].keys()
 
-
+    def manages_seed(self):
+        return self.use_parseq and 'seed' in self.rendered_frames[0].keys()    
+    
     def get_max(self, seriesName):
         return max(self.rendered_frames, key=itemgetter(seriesName))[seriesName]
 
-    def parseq_to_anim_series(self, seriesName):
+
+class ParseqAbstractDecorator():  
+
+    def __init__(self, adapter: ParseqAdapter, fallback_keys):
+        self.adapter = adapter
+        self.fallback_keys = fallback_keys
+
+    def parseq_to_series(self, seriesName):
         
-        # Check if valus is present in first frame of JSON data. If not, assume it's undefined.
+        # Check if value is present in first frame of JSON data. If not, assume it's undefined.
         # The Parseq contract is that the first frame (at least) must define values for all fields.
         try:
-            if self.rendered_frames[0][seriesName] is not None:
+            if self.adapter.rendered_frames[0][seriesName] is not None:
                 logging.debug(f"Found {seriesName} in first frame of Parseq data. Assuming it's defined.")
         except KeyError:
             return None
 
-        key_frame_series = pd.Series([np.nan for a in range(self.required_frames)])
+        key_frame_series = pd.Series([np.nan for a in range(self.adapter.required_frames)])
         
-        for frame in self.rendered_frames:
+        for frame in self.adapter.rendered_frames:
             frame_idx = frame['frame']
-            if frame_idx < self.required_frames:                
+            if frame_idx < self.adapter.required_frames:                
                 if not np.isnan(key_frame_series[frame_idx]):
                     logging.warning(f"Duplicate frame definition {frame_idx} detected for data {seriesName}. Latest wins.")        
                 key_frame_series[frame_idx] = frame[seriesName]
 
         # If the animation will have more frames than Parseq defines,
         # duplicate final value to match the required frame count.
-        while (frame_idx < self.required_frames):
-            key_frame_series[frame_idx] = operator.itemgetter(-1)(self.rendered_frames)[seriesName]
+        while (frame_idx < self.adapter.required_frames):
+            key_frame_series[frame_idx] = operator.itemgetter(-1)(self.adapter.rendered_frames)[seriesName]
             frame_idx += 1
 
         return key_frame_series
@@ -160,7 +140,7 @@ class ParseqAnimKeys():
     # fallback to anim_args if the series is not defined in the Parseq data
     def __getattribute__(inst, name):
         try:
-            definedField = super(ParseqAnimKeys, inst).__getattribute__(name)
+            definedField = super(ParseqAbstractDecorator, inst).__getattribute__(name)
         except AttributeError:
             # No field with this name has been explicitly extracted from the JSON data.
             # It must be a new parameter. Let's see if it's in the raw JSON.
@@ -168,7 +148,7 @@ class ParseqAnimKeys():
             parseqName = inst.strip_suffixes(name)
             
             # returns None if not defined in Parseq JSON data
-            definedField = inst.parseq_to_anim_series(parseqName)
+            definedField = inst.parseq_to_series(parseqName)
             if (definedField is not None):
                 # add the field to the instance so we don't compute it again.
                 setattr(inst, name, definedField)
@@ -177,7 +157,7 @@ class ParseqAnimKeys():
             return definedField
         else:
             logging.debug(f"Data for {name} not defined in Parseq data. Falling back to standard Deforum values.")
-            return getattr(inst.default_anim_keys, name)
+            return getattr(inst.fallback_keys, name)
 
     
     # parseq doesn't use _series, _schedule or _schedule_series suffixes in the
@@ -190,4 +170,98 @@ class ParseqAnimKeys():
                 if parseqName.endswith(suffix):
                     parseqName = parseqName[:-len(suffix)]
         return parseqName
+    
+    # parseq prefixes some field names for clarity. These prefixes are not present in the original Deforum names.
+    def strip_parseq_prefixes(self, name):
+        strippablePrefixes = ['guided_']
+        parseqName = name
+        while any(parseqName.startswith(prefix) for prefix in strippablePrefixes):
+            for prefix in strippablePrefixes:
+                if parseqName.startswith(prefix):
+                    parseqName = parseqName[len(prefix):]
+        return parseqName    
+    
+    def all_parseq_fields(self):
+        return [self.strip_parseq_prefixes(field) for field in self.adapter.rendered_frames[0].keys() if (not field.endswith('_delta') and not field.endswith('_pc'))]
+
+    def managed_fields(self):
+        all_parseq_fields = self.all_parseq_fields()
+        deforum_fields = [self.strip_suffixes(property) for property, _ in vars(self.fallback_keys).items() if property not in ['fi'] and not property.startswith('_')]
+        return [field for field in deforum_fields if field in all_parseq_fields]
+
+    def unmanaged_fields(self):
+        all_parseq_fields = self.all_parseq_fields()
+        deforum_fields = [self.strip_suffixes(property) for property, _ in vars(self.fallback_keys).items() if property not in ['fi'] and not property.startswith('_')]
+        return [field for field in deforum_fields if field not in all_parseq_fields]
+
+
+
+class ParseqControlNetKeysDecorator(ParseqAbstractDecorator):
+    def __init__(self, adapter: ParseqAdapter, cn_keys):
+        super().__init__(adapter, cn_keys)
+
+class ParseqLooperKeysDecorator(ParseqAbstractDecorator):
+    def __init__(self, adapter: ParseqAdapter, looper_keys):
+        super().__init__(adapter, looper_keys)
+
+        # The Deforum UI offers an "Image strength schedule" in the Guided Images section,
+        # which simply overrides the strength schedule if guided images is enabled.
+        # In Parseq, we just re-use the same strength schedule.
+        self.image_strength_schedule_series = super().parseq_to_series('strength')
+
+        # We explicitly state the mapping for all other guided images fields so we can strip the prefix
+        # that we use in Parseq.
+        self.blendFactorMax_series = super().parseq_to_series('guided_blendFactorMax')
+        self.blendFactorSlope_series = super().parseq_to_series('guided_blendFactorSlope')
+        self.tweening_frames_schedule_series = super().parseq_to_series('guided_tweening_frames')
+        self.color_correction_factor_series = super().parseq_to_series('guidedcolor_correction_factor')        
+
+        
+
+class ParseqAnimKeysDecorator(ParseqAbstractDecorator):
+    def __init__(self, adapter: ParseqAdapter, anim_keys):
+        super().__init__(adapter, anim_keys)
+
+        # Parseq treats input values as absolute values. So if you want to 
+        # progressively rotate 180 degrees over 4 frames, you specify: 45, 90, 135, 180.
+        # However, many animation parameters are relative to the previous frame if there is enough
+        # loopback strength. So if you want to rotate 180 degrees over 5 frames, the animation engine expects:
+        # 45, 45, 45, 45. Therefore, for such parameter, we use the fact that Parseq supplies delta values.
+        optional_delta = '_delta' if self.adapter.use_deltas else ''
+        self.angle_series = super().parseq_to_series('angle' + optional_delta)
+        self.zoom_series = super().parseq_to_series('zoom' + optional_delta)        
+        self.translation_x_series = super().parseq_to_series('translation_x' + optional_delta)
+        self.translation_y_series = super().parseq_to_series('translation_y' + optional_delta)
+        self.translation_z_series = super().parseq_to_series('translation_z' + optional_delta)
+        self.rotation_3d_x_series = super().parseq_to_series('rotation_3d_x' + optional_delta)
+        self.rotation_3d_y_series = super().parseq_to_series('rotation_3d_y' + optional_delta)
+        self.rotation_3d_z_series = super().parseq_to_series('rotation_3d_z' + optional_delta)
+        self.perspective_flip_theta_series = super().parseq_to_series('perspective_flip_theta' + optional_delta)
+        self.perspective_flip_phi_series = super().parseq_to_series('perspective_flip_phi' + optional_delta)
+        self.perspective_flip_gamma_series = super().parseq_to_series('perspective_flip_gamma' + optional_delta)
+ 
+        # Non-motion animation args - never use deltas for these.
+        self.perspective_flip_fv_series = super().parseq_to_series('perspective_flip_fv')
+        self.noise_schedule_series = super().parseq_to_series('noise')
+        self.strength_schedule_series = super().parseq_to_series('strength')
+        self.sampler_schedule_series = super().parseq_to_series('sampler_schedule')
+        self.contrast_schedule_series = super().parseq_to_series('contrast')
+        self.cfg_scale_schedule_series = super().parseq_to_series('scale')
+        self.steps_schedule_series = super().parseq_to_series("steps_schedule")
+        self.seed_schedule_series = super().parseq_to_series('seed')
+        self.fov_series = super().parseq_to_series('fov')
+        self.near_series = super().parseq_to_series('near')
+        self.far_series = super().parseq_to_series('far')
+        self.subseed_schedule_series = super().parseq_to_series('subseed')
+        self.subseed_strength_schedule_series = super().parseq_to_series('subseed_strength')
+        self.kernel_schedule_series = super().parseq_to_series('antiblur_kernel')
+        self.sigma_schedule_series = super().parseq_to_series('antiblur_sigma')
+        self.amount_schedule_series = super().parseq_to_series('antiblur_amount')
+        self.threshold_schedule_series = super().parseq_to_series('antiblur_threshold')
+
+        # TODO - move to a different decorator?
+        self.prompts = super().parseq_to_series('deforum_prompt') # formatted as "{positive} --neg {negative}"
+
+
+
 

--- a/scripts/deforum_helpers/parseq_adapter_test.py
+++ b/scripts/deforum_helpers/parseq_adapter_test.py
@@ -3,18 +3,30 @@
 ##
 
 import unittest
-from .parseq_adapter import ParseqAnimKeys 
-from .animation_key_frames import DeformAnimKeys
+from .parseq_adapter import ParseqAdapter 
+from .animation_key_frames import DeformAnimKeys, LooperAnimKeys, ControlNetKeys
 from unittest.mock import patch
 from unittest.mock import MagicMock, PropertyMock
-
 from types import SimpleNamespace
+
+DEFAULT_ARGS = SimpleNamespace(anim_args = SimpleNamespace(max_frames=2),
+                               video_args = SimpleNamespace(fps=30),
+                               args = SimpleNamespace(seed=-1),
+                               loop_args = SimpleNamespace(),
+                               controlnet_args = SimpleNamespace())
+
+
+def buildParseqAdapter(parseq_use_deltas, parseq_manifest, setup_args=DEFAULT_ARGS):
+    return ParseqAdapter(SimpleNamespace(parseq_use_deltas=parseq_use_deltas, parseq_manifest=parseq_manifest),
+                         setup_args.args, setup_args.anim_args, setup_args.video_args, setup_args.loop_args, setup_args.controlnet_args)
 
 class TestParseqAnimKeys(unittest.TestCase):
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    def test_withprompt(self, mock_deformanimkeys):
-        parseq_args = SimpleNamespace(parseq_use_deltas=True, parseq_manifest=""" 
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
+    def test_withprompt(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+        parseq_adapter = buildParseqAdapter(parseq_use_deltas=True, parseq_manifest=""" 
             {                
                 "options": {
                     "output_fps": 30
@@ -31,15 +43,14 @@ class TestParseqAnimKeys(unittest.TestCase):
                 ]
             }
             """)
-        anim_args = SimpleNamespace(max_frames=2)
-        video_args = SimpleNamespace(fps=30)
-        parseq_anim_keys = ParseqAnimKeys(parseq_args, anim_args, video_args)
-        self.assertTrue(parseq_anim_keys.manages_prompts())
+        self.assertTrue(parseq_adapter.manages_prompts())
 
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    def test_withoutprompt(self, mock_deformanimkeys):
-        parseq_args = SimpleNamespace(parseq_use_deltas=True, parseq_manifest=""" 
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
+    def test_withoutprompt(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+        parseq_adapter = buildParseqAdapter(parseq_use_deltas=True, parseq_manifest=""" 
             {                
                 "options": {
                     "output_fps": 30
@@ -54,14 +65,59 @@ class TestParseqAnimKeys(unittest.TestCase):
                 ]
             }
             """)
-        anim_args = SimpleNamespace(max_frames=2)
-        video_args = SimpleNamespace(fps=30)
-        parseq_anim_keys = ParseqAnimKeys(parseq_args, anim_args, video_args)
-        self.assertFalse(parseq_anim_keys.manages_prompts())
+        self.assertFalse(parseq_adapter.manages_prompts())
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    def test_usedelta(self, mock_deformanimkeys):
-        parseq_args = SimpleNamespace(parseq_use_deltas=True, parseq_manifest=""" 
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
+    def test_withseed(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+        parseq_adapter = buildParseqAdapter(parseq_use_deltas=True, parseq_manifest=""" 
+            {                
+                "options": {
+                    "output_fps": 30
+                },
+                "rendered_frames": [
+                    {
+                        "frame": 0,
+                        "seed": 1
+                    },
+                    {
+                        "frame": 1,
+                        "seed": 2
+                    }
+                ]
+            }
+            """)
+        self.assertTrue(parseq_adapter.manages_seed())
+
+
+    @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
+    def test_withoutseed(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+        parseq_adapter = buildParseqAdapter(parseq_use_deltas=True, parseq_manifest=""" 
+            {                
+                "options": {
+                    "output_fps": 30
+                },
+                "rendered_frames": [
+                    {
+                        "frame": 0
+                    },
+                    {
+                        "frame": 1
+                    }
+                ]
+            }
+            """)
+        self.assertFalse(parseq_adapter.manages_seed())
+
+
+    @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
+    def test_usedelta(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+        parseq_adapter = buildParseqAdapter(parseq_use_deltas=True, parseq_manifest=""" 
             {                
                 "options": {
                     "output_fps": 30
@@ -80,14 +136,13 @@ class TestParseqAnimKeys(unittest.TestCase):
                 ]
             }
             """)
-        anim_args = SimpleNamespace(max_frames=2)
-        video_args = SimpleNamespace(fps=30)
-        parseq_anim_keys = ParseqAnimKeys(parseq_args, anim_args, video_args)
-        self.assertEqual(parseq_anim_keys.angle_series[1], 90)
+        self.assertEqual(parseq_adapter.anim_keys.angle_series[1], 90)
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    def test_usenondelta(self, mock_deformanimkeys):
-        parseq_args = SimpleNamespace(parseq_use_deltas=False, parseq_manifest=""" 
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
+    def test_usenondelta(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+        parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
             {                
                 "options": {
                     "output_fps": 30
@@ -106,14 +161,13 @@ class TestParseqAnimKeys(unittest.TestCase):
                 ]
             }
             """)
-        anim_args = SimpleNamespace(max_frames=2)
-        video_args = SimpleNamespace(fps=30)
-        parseq_anim_keys = ParseqAnimKeys(parseq_args, anim_args, video_args)
-        self.assertEqual(parseq_anim_keys.angle_series[1], 180)
+        self.assertEqual(parseq_adapter.anim_keys.angle_series[1], 180)
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    def test_fallbackonundefined(self, mock_deformanimkeys):
-        parseq_args = SimpleNamespace(parseq_use_deltas=False, parseq_manifest=""" 
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
+    def test_fallbackonundefined(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+        parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
             {                
                 "options": {
                     "output_fps": 30
@@ -128,13 +182,101 @@ class TestParseqAnimKeys(unittest.TestCase):
                 ]
             }
             """)
-        
-        anim_args = SimpleNamespace(max_frames=1)
-        video_args = SimpleNamespace(fps=20)
-        parseq_anim_keys = ParseqAnimKeys(parseq_args, anim_args, video_args)
         #TODO - this is a hacky check to make sure we're falling back to the mock.
         #There must be a better way to inject an expected value via patch and check for that...
-        self.assertRegex(str(parseq_anim_keys.angle_series[0]), r'MagicMock')
+        self.assertRegex(str(parseq_adapter.anim_keys.angle_series[0]), r'MagicMock')
+
+    @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
+    def test_cn(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+        parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
+            {                
+                "options": {
+                    "output_fps": 30
+                },
+                "rendered_frames": [
+                    {
+                        "frame": 0,
+                        "cn_1_weight": 1
+                    },
+                    {
+                        "frame": 1,
+                        "cn_1_weight": 1
+                    }
+                ]
+            }
+            """)
+        self.assertEqual(parseq_adapter.cn_keys.cn_1_weight_schedule_series[0], 1)
+
+    @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
+    def test_cn_fallback(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+        parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
+            {                
+                "options": {
+                    "output_fps": 30
+                },
+                "rendered_frames": [
+                    {
+                        "frame": 0
+                    },
+                    {
+                        "frame": 1
+                    }
+                ]
+            }
+            """)
+        #TODO - this is a hacky check to make sure we're falling back to the mock.
+        #There must be a better way to inject an expected value via patch and check for that...
+        self.assertRegex(str(parseq_adapter.cn_keys.cn_1_weight_schedule_series[0]), r'MagicMock')
+
+    @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
+    def test_looper(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+        parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
+            {                
+                "options": {
+                    "output_fps": 30
+                },
+                "rendered_frames": [
+                    {
+                        "frame": 0,
+                        "guided_blendFactorMax": 0.5
+                    },
+                    {
+                        "frame": 1,
+                        "guided_blendFactorMax": 0.5
+                    }
+                ]
+            }
+            """)
+        self.assertEqual(parseq_adapter.looper_keys.blendFactorMax_series[0], 0.5)
+
+    @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
+    def test_looper_fallback(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+        parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
+            {                
+                "options": {
+                    "output_fps": 30
+                },
+                "rendered_frames": [
+                    {
+                        "frame": 0
+                    },
+                    {
+                        "frame": 1
+                    }
+                ]
+            }
+            """)
+        #TODO - this is a hacky check to make sure we're falling back to the mock.
+        #There must be a better way to inject an expected value via patch and check for that...
+        self.assertRegex(str(parseq_adapter.looper_keys.blendFactorMax_series[0]), r'MagicMock')              
         
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/deforum_helpers/parseq_adapter_test.py
+++ b/scripts/deforum_helpers/parseq_adapter_test.py
@@ -18,7 +18,7 @@ DEFAULT_ARGS = SimpleNamespace(anim_args = SimpleNamespace(max_frames=2),
 
 def buildParseqAdapter(parseq_use_deltas, parseq_manifest, setup_args=DEFAULT_ARGS):
     return ParseqAdapter(SimpleNamespace(parseq_use_deltas=parseq_use_deltas, parseq_manifest=parseq_manifest),
-                         setup_args.args, setup_args.anim_args, setup_args.video_args, setup_args.loop_args, setup_args.controlnet_args)
+                         setup_args.anim_args, setup_args.video_args, setup_args.controlnet_args)
 
 class TestParseqAnimKeys(unittest.TestCase):
 
@@ -230,53 +230,7 @@ class TestParseqAnimKeys(unittest.TestCase):
             """)
         #TODO - this is a hacky check to make sure we're falling back to the mock.
         #There must be a better way to inject an expected value via patch and check for that...
-        self.assertRegex(str(parseq_adapter.cn_keys.cn_1_weight_schedule_series[0]), r'MagicMock')
-
-    @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
-    @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_looper(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
-        parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
-            {                
-                "options": {
-                    "output_fps": 30
-                },
-                "rendered_frames": [
-                    {
-                        "frame": 0,
-                        "guided_blendFactorMax": 0.5
-                    },
-                    {
-                        "frame": 1,
-                        "guided_blendFactorMax": 0.5
-                    }
-                ]
-            }
-            """)
-        self.assertEqual(parseq_adapter.looper_keys.blendFactorMax_series[0], 0.5)
-
-    @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
-    @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_looper_fallback(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
-        parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
-            {                
-                "options": {
-                    "output_fps": 30
-                },
-                "rendered_frames": [
-                    {
-                        "frame": 0
-                    },
-                    {
-                        "frame": 1
-                    }
-                ]
-            }
-            """)
-        #TODO - this is a hacky check to make sure we're falling back to the mock.
-        #There must be a better way to inject an expected value via patch and check for that...
-        self.assertRegex(str(parseq_adapter.looper_keys.blendFactorMax_series[0]), r'MagicMock')              
+        self.assertRegex(str(parseq_adapter.cn_keys.cn_1_weight_schedule_series[0]), r'MagicMock')           
         
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/deforum_helpers/parseq_adapter_test.py
+++ b/scripts/deforum_helpers/parseq_adapter_test.py
@@ -23,9 +23,8 @@ def buildParseqAdapter(parseq_use_deltas, parseq_manifest, setup_args=DEFAULT_AR
 class TestParseqAnimKeys(unittest.TestCase):
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_withprompt(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+    def test_withprompt(self, mock_deformanimkeys, mock_controlnetkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=True, parseq_manifest=""" 
             {                
                 "options": {
@@ -47,9 +46,8 @@ class TestParseqAnimKeys(unittest.TestCase):
 
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_withoutprompt(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+    def test_withoutprompt(self, mock_deformanimkeys, mock_controlnetkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=True, parseq_manifest=""" 
             {                
                 "options": {
@@ -68,9 +66,8 @@ class TestParseqAnimKeys(unittest.TestCase):
         self.assertFalse(parseq_adapter.manages_prompts())
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_withseed(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+    def test_withseed(self, mock_deformanimkeys, mock_controlnetkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=True, parseq_manifest=""" 
             {                
                 "options": {
@@ -92,9 +89,8 @@ class TestParseqAnimKeys(unittest.TestCase):
 
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_withoutseed(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+    def test_withoutseed(self, mock_deformanimkeys, mock_controlnetkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=True, parseq_manifest=""" 
             {                
                 "options": {
@@ -114,9 +110,8 @@ class TestParseqAnimKeys(unittest.TestCase):
 
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_usedelta(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+    def test_usedelta(self, mock_deformanimkeys, mock_controlnetkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=True, parseq_manifest=""" 
             {                
                 "options": {
@@ -139,9 +134,8 @@ class TestParseqAnimKeys(unittest.TestCase):
         self.assertEqual(parseq_adapter.anim_keys.angle_series[1], 90)
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_usenondelta(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+    def test_usenondelta(self, mock_deformanimkeys, mock_controlnetkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
             {                
                 "options": {
@@ -164,9 +158,8 @@ class TestParseqAnimKeys(unittest.TestCase):
         self.assertEqual(parseq_adapter.anim_keys.angle_series[1], 180)
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_fallbackonundefined(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+    def test_fallbackonundefined(self, mock_deformanimkeys, mock_controlnetkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
             {                
                 "options": {
@@ -187,9 +180,8 @@ class TestParseqAnimKeys(unittest.TestCase):
         self.assertRegex(str(parseq_adapter.anim_keys.angle_series[0]), r'MagicMock')
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_cn(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+    def test_cn(self, mock_deformanimkeys, mock_controlnetkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
             {                
                 "options": {
@@ -210,9 +202,8 @@ class TestParseqAnimKeys(unittest.TestCase):
         self.assertEqual(parseq_adapter.cn_keys.cn_1_weight_schedule_series[0], 1)
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
-    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_cn_fallback(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+    def test_cn_fallback(self, mock_deformanimkeys, mock_controlnetkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
             {                
                 "options": {

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -15,7 +15,7 @@ from .animation_key_frames import DeformAnimKeys, LooperAnimKeys
 from .video_audio_utilities import get_frame_name, get_next_frame
 from .depth import DepthModel
 from .colors import maintain_colors
-from .parseq_adapter import ParseqAnimKeys
+from .parseq_adapter import ParseqAdapter
 from .seed import next_seed
 from .image_sharpening import unsharp_mask
 from .load_images import get_mask, load_img, load_image, get_mask_from_file
@@ -62,11 +62,12 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
     if is_controlnet_enabled(controlnet_args):
         unpack_controlnet_vids(args, anim_args, controlnet_args)
 
-    # use parseq if manifest is provided
-    use_parseq = parseq_args.parseq_manifest is not None and parseq_args.parseq_manifest.strip()
+    # initialise Parseq adapter
+    parseq_adapter = ParseqAdapter(parseq_args, args, anim_args, video_args, loop_args, controlnet_args)
+
     # expand key frame strings to values
-    keys = DeformAnimKeys(anim_args, args.seed) if not use_parseq else ParseqAnimKeys(parseq_args, anim_args, video_args)
-    loopSchedulesAndData = LooperAnimKeys(loop_args, anim_args, args.seed)
+    keys = DeformAnimKeys(anim_args, args.seed) if not parseq_adapter.use_parseq else parseq_adapter.anim_keys
+    loopSchedulesAndData = LooperAnimKeys(loop_args, anim_args, args.seed) if not parseq_adapter.use_parseq else parseq_adapter.looper_keys
 
     # create output folder for the batch
     os.makedirs(args.outdir, exist_ok=True)
@@ -81,11 +82,11 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
 
     # Always enable pseudo-3d with parseq. No need for an extra toggle:
     # Whether it's used or not in practice is defined by the schedules
-    if use_parseq:
+    if parseq_adapter.use_parseq:
         anim_args.flip_2d_perspective = True
 
-        # expand prompts out to per-frame
-    if use_parseq and keys.manages_prompts():
+    # expand prompts out to per-frame
+    if parseq_adapter.manages_prompts():
         prompt_series = keys.prompts
     else:
         prompt_series = pd.Series([np.nan for a in range(anim_args.max_frames)])
@@ -450,7 +451,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
         # grab prompt for current frame
         args.prompt = prompt_series[frame_idx]
 
-        if args.seed_behavior == 'schedule' or use_parseq:
+        if args.seed_behavior == 'schedule' or parseq_adapter.manages_seed():
             args.seed = int(keys.seed_schedule_series[frame_idx])
 
         if anim_args.enable_checkpoint_scheduling:
@@ -463,7 +464,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
             root.subseed = int(keys.subseed_schedule_series[frame_idx])
             root.subseed_strength = float(keys.subseed_strength_schedule_series[frame_idx])
 
-        if use_parseq:
+        if parseq_adapter.manages_seed():
             anim_args.enable_subseed_scheduling = True
             root.subseed = int(keys.subseed_schedule_series[frame_idx])
             root.subseed_strength = keys.subseed_strength_schedule_series[frame_idx]
@@ -517,7 +518,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
             print(f"Optical flow redo is diffusing and warping using {anim_args.optical_flow_redo_generation} optical flow before generation.")
             stored_seed = args.seed
             args.seed = random.randint(0, 2 ** 32 - 1)
-            disposable_image = generate(args, keys, anim_args, loop_args, controlnet_args, root, frame_idx, sampler_name=scheduled_sampler_name)
+            disposable_image = generate(args, keys, anim_args, loop_args, controlnet_args, root, parseq_adapter, frame_idx, sampler_name=scheduled_sampler_name)
             disposable_image = cv2.cvtColor(np.array(disposable_image), cv2.COLOR_RGB2BGR)
             disposable_flow = get_flow_from_images(prev_img, disposable_image, anim_args.optical_flow_redo_generation, raft_model)
             disposable_image = cv2.cvtColor(disposable_image, cv2.COLOR_BGR2RGB)
@@ -533,7 +534,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
             for n in range(0, int(anim_args.diffusion_redo)):
                 print(f"Redo generation {n + 1} of {int(anim_args.diffusion_redo)} before final generation")
                 args.seed = random.randint(0, 2 ** 32 - 1)
-                disposable_image = generate(args, keys, anim_args, loop_args, controlnet_args, root, frame_idx, sampler_name=scheduled_sampler_name)
+                disposable_image = generate(args, keys, anim_args, loop_args, controlnet_args, root, parseq_adapter, frame_idx, sampler_name=scheduled_sampler_name)
                 disposable_image = cv2.cvtColor(np.array(disposable_image), cv2.COLOR_RGB2BGR)
                 # color match on last one only
                 if n == int(anim_args.diffusion_redo):
@@ -544,7 +545,7 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
             gc.collect()
 
         # generation
-        image = generate(args, keys, anim_args, loop_args, controlnet_args, root, frame_idx, sampler_name=scheduled_sampler_name)
+        image = generate(args, keys, anim_args, loop_args, controlnet_args, root, parseq_adapter, frame_idx, sampler_name=scheduled_sampler_name)
 
         if image is None:
             break

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -63,11 +63,11 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
         unpack_controlnet_vids(args, anim_args, controlnet_args)
 
     # initialise Parseq adapter
-    parseq_adapter = ParseqAdapter(parseq_args, args, anim_args, video_args, loop_args, controlnet_args)
+    parseq_adapter = ParseqAdapter(parseq_args, anim_args, video_args, controlnet_args)
 
     # expand key frame strings to values
     keys = DeformAnimKeys(anim_args, args.seed) if not parseq_adapter.use_parseq else parseq_adapter.anim_keys
-    loopSchedulesAndData = LooperAnimKeys(loop_args, anim_args, args.seed) if not parseq_adapter.use_parseq else parseq_adapter.looper_keys
+    loopSchedulesAndData = LooperAnimKeys(loop_args, anim_args, args.seed)
 
     # create output folder for the batch
     os.makedirs(args.outdir, exist_ok=True)

--- a/scripts/deforum_helpers/render_modes.py
+++ b/scripts/deforum_helpers/render_modes.py
@@ -80,7 +80,7 @@ def get_parsed_value(value, frame_idx, max_f):
 def render_interpolation(args, anim_args, video_args, parseq_args, loop_args, controlnet_args, root):
 
     # use parseq if manifest is provided
-    parseq_adapter = ParseqAdapter(parseq_args, args, anim_args, video_args, loop_args, controlnet_args)
+    parseq_adapter = ParseqAdapter(parseq_args, anim_args, video_args, controlnet_args)
 
     # expand key frame strings to values
     keys = DeformAnimKeys(anim_args) if not parseq_adapter.use_parseq else parseq_adapter.anim_keys

--- a/scripts/deforum_helpers/render_modes.py
+++ b/scripts/deforum_helpers/render_modes.py
@@ -10,7 +10,7 @@ from .video_audio_utilities import vid2frames
 from .prompt import interpolate_prompts
 from .generate import generate
 from .animation_key_frames import DeformAnimKeys
-from .parseq_adapter import ParseqAnimKeys
+from .parseq_adapter import ParseqAdapter
 from .save_images import save_image
 from .settings import save_settings_from_animation_run
 
@@ -80,10 +80,10 @@ def get_parsed_value(value, frame_idx, max_f):
 def render_interpolation(args, anim_args, video_args, parseq_args, loop_args, controlnet_args, root):
 
     # use parseq if manifest is provided
-    use_parseq = parseq_args.parseq_manifest != None and parseq_args.parseq_manifest.strip()
+    parseq_adapter = ParseqAdapter(parseq_args, args, anim_args, video_args, loop_args, controlnet_args)
 
     # expand key frame strings to values
-    keys = DeformAnimKeys(anim_args) if not use_parseq else ParseqAnimKeys(parseq_args, anim_args, video_args)
+    keys = DeformAnimKeys(anim_args) if not parseq_adapter.use_parseq else parseq_adapter.anim_keys
 
     # create output folder for the batch
     os.makedirs(args.outdir, exist_ok=True)
@@ -93,7 +93,7 @@ def render_interpolation(args, anim_args, video_args, parseq_args, loop_args, co
     save_settings_from_animation_run(args, anim_args, parseq_args, loop_args, controlnet_args, video_args, root)
         
     # Compute interpolated prompts
-    if use_parseq and keys.manages_prompts():
+    if parseq_adapter.manages_prompts():
         print("Parseq prompts are assumed to already be interpolated - not doing any additional prompt interpolation")
         prompt_series = keys.prompts
     else: 
@@ -139,13 +139,13 @@ def render_interpolation(args, anim_args, video_args, parseq_args, loop_args, co
             root.subseed_strength = keys.subseed_strength_schedule_series[frame_idx]
         else:
             root.subseed, root.subseed_strength = keys.subseed_schedule_series[frame_idx], keys.subseed_strength_schedule_series[frame_idx]
-        if use_parseq:
+        if parseq_adapter.manages_seed():
             anim_args.enable_subseed_scheduling = True
             root.subseed, root.subseed_strength = int(keys.subseed_schedule_series[frame_idx]), keys.subseed_strength_schedule_series[frame_idx]
-        args.seed = int(keys.seed_schedule_series[frame_idx]) if args.seed_behavior == 'schedule' or use_parseq else args.seed
+        args.seed = int(keys.seed_schedule_series[frame_idx]) if (args.seed_behavior == 'schedule' or parseq_adapter.manages_seed()) else args.seed
         opts.data["CLIP_stop_at_last_layers"] = scheduled_clipskip if scheduled_clipskip is not None else opts.data["CLIP_stop_at_last_layers"]
 
-        image = generate(args, keys, anim_args, loop_args, controlnet_args, root, frame_idx, sampler_name=scheduled_sampler_name)
+        image = generate(args, keys, anim_args, loop_args, controlnet_args, root, parseq_adapter, frame_idx, sampler_name=scheduled_sampler_name)
         filename = f"{root.timestring}_{frame_idx:09}.png"
 
         save_image(image, 'PIL', filename, args, video_args, root)


### PR DESCRIPTION
This is a simplified version of PR #790 to include only changes to allow Parseq to control ControlNet schedules. Guided images will be added as a separate PR once this one is approved.

This is now ready for review.