### PR TITLE
Allow Parseq to control guided images schedules

### DIFF
--- a/scripts/deforum_helpers/deforum_tqdm.py
+++ b/scripts/deforum_helpers/deforum_tqdm.py
@@ -16,7 +16,7 @@ class DeforumTQDM:
         from .parseq_adapter import ParseqAdapter
         deforum_total = 0
         # FIXME: get only amount of steps
-        parseq_adapter = ParseqAdapter(self._parseq_args, self._anim_args, self._video_args, None, mute=True)
+        parseq_adapter = ParseqAdapter(self._parseq_args, self._anim_args, self._video_args, None, None, mute=True)
         keys = DeformAnimKeys(self._anim_args) if not parseq_adapter.use_parseq else parseq_adapter.anim_keys
 
         start_frame = 0

--- a/scripts/deforum_helpers/parseq_adapter.py
+++ b/scripts/deforum_helpers/parseq_adapter.py
@@ -6,13 +6,13 @@ from operator import itemgetter
 import numpy as np
 import pandas as pd
 import requests
-from .animation_key_frames import DeformAnimKeys, ControlNetKeys
+from .animation_key_frames import DeformAnimKeys, ControlNetKeys, LooperAnimKeys
 from .rich import console
 
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
 
 class ParseqAdapter():
-    def __init__(self, parseq_args, anim_args, video_args, controlnet_args, mute=False):
+    def __init__(self, parseq_args, anim_args, video_args, controlnet_args, loop_args, mute=False):
 
         # Basic data extraction
         self.use_parseq = parseq_args.parseq_manifest and parseq_args.parseq_manifest.strip()
@@ -26,6 +26,8 @@ class ParseqAdapter():
         # Wrap the original schedules with Parseq decorators, so that Parseq values will override the original values IFF appropriate.
         self.anim_keys = ParseqAnimKeysDecorator(self, DeformAnimKeys(anim_args))
         self.cn_keys = ParseqControlNetKeysDecorator(self, ControlNetKeys(anim_args, controlnet_args)) if controlnet_args else None
+        # -1 because seed seems to be unused in LooperAnimKeys
+        self.looper_keys = ParseqLooperKeysDecorator(self, LooperAnimKeys(loop_args, anim_args, -1)) if loop_args else None
 
         # Validation
         if (self.use_parseq):
@@ -78,9 +80,11 @@ class ParseqAdapter():
         table.add_column("Parseq", style="cyan")
         table.add_column("Deforum", style="green")
 
-        table.add_row("Anim Fields", '\n'.join(self.anim_keys.managed_fields()), '\n'.join(self.anim_keys.unmanaged_fields()))
+        table.add_row("Animation", '\n'.join(self.anim_keys.managed_fields()), '\n'.join(self.anim_keys.unmanaged_fields()))
         if self.cn_keys:
-            table.add_row("Cn Fields", '\n'.join(self.cn_keys.managed_fields()), '\n'.join(self.cn_keys.unmanaged_fields()))
+            table.add_row("ControlNet", '\n'.join(self.cn_keys.managed_fields()), '\n'.join(self.cn_keys.unmanaged_fields()))
+        if self.looper_keys:
+            table.add_row("Guided Images", '\n'.join(self.looper_keys.managed_fields()), '\n'.join(self.looper_keys.unmanaged_fields()))            
         table.add_row("Prompts", "✅" if self.manages_prompts() else "❌", "✅" if not self.manages_prompts() else "❌")
         table.add_row("Frames", str(len(self.rendered_frames)), str(self.required_frames) + (" ⚠️" if str(self.required_frames) != str(len(self.rendered_frames))+"" else ""))
         table.add_row("FPS", str(self.config_output_fps), str(self.required_fps) + (" ⚠️" if str(self.required_fps) != str(self.config_output_fps) else ""))
@@ -239,5 +243,19 @@ class ParseqAnimKeysDecorator(ParseqAbstractDecorator):
         self.prompts = super().parseq_to_series('deforum_prompt') # formatted as "{positive} --neg {negative}"
 
 
+class ParseqLooperKeysDecorator(ParseqAbstractDecorator):
+    def __init__(self, adapter: ParseqAdapter, looper_keys):
+        super().__init__(adapter, looper_keys)
 
+        # The Deforum UI offers an "Image strength schedule" in the Guided Images section,
+        # which simply overrides the strength schedule if guided images is enabled.
+        # In Parseq, we just re-use the same strength schedule.
+        self.image_strength_schedule_series = super().parseq_to_series('strength')
+
+        # We explicitly state the mapping for all other guided images fields so we can strip the prefix
+        # that we use in Parseq.
+        self.blendFactorMax_series = super().parseq_to_series('guided_blendFactorMax')
+        self.blendFactorSlope_series = super().parseq_to_series('guided_blendFactorSlope')
+        self.tweening_frames_schedule_series = super().parseq_to_series('guided_tweening_frames')
+        self.color_correction_factor_series = super().parseq_to_series('guidedcolor_correction_factor')
 

--- a/scripts/deforum_helpers/parseq_adapter.py
+++ b/scripts/deforum_helpers/parseq_adapter.py
@@ -11,6 +11,8 @@ from .rich import console
 
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
 
+IGNORED_FIELDS = ['fi', 'use_looper', 'imagesToKeyframe', 'schedules']
+
 class ParseqAdapter():
     def __init__(self, parseq_args, anim_args, video_args, controlnet_args, loop_args, mute=False):
 
@@ -184,12 +186,12 @@ class ParseqAbstractDecorator():
 
     def managed_fields(self):
         all_parseq_fields = self.all_parseq_fields()
-        deforum_fields = [self.strip_suffixes(property) for property, _ in vars(self.fallback_keys).items() if property not in ['fi'] and not property.startswith('_')]
+        deforum_fields = [self.strip_suffixes(property) for property, _ in vars(self.fallback_keys).items() if property not in IGNORED_FIELDS and not property.startswith('_')]
         return [field for field in deforum_fields if field in all_parseq_fields]
 
     def unmanaged_fields(self):
         all_parseq_fields = self.all_parseq_fields()
-        deforum_fields = [self.strip_suffixes(property) for property, _ in vars(self.fallback_keys).items() if property not in ['fi'] and not property.startswith('_')]
+        deforum_fields = [self.strip_suffixes(property) for property, _ in vars(self.fallback_keys).items() if property not in IGNORED_FIELDS and not property.startswith('_')]
         return [field for field in deforum_fields if field not in all_parseq_fields]
 
 

--- a/scripts/deforum_helpers/parseq_adapter_test.py
+++ b/scripts/deforum_helpers/parseq_adapter_test.py
@@ -12,19 +12,20 @@ from types import SimpleNamespace
 DEFAULT_ARGS = SimpleNamespace(anim_args = SimpleNamespace(max_frames=2),
                                video_args = SimpleNamespace(fps=30),
                                args = SimpleNamespace(seed=-1),
-                               loop_args = SimpleNamespace(),
-                               controlnet_args = SimpleNamespace())
+                               controlnet_args = SimpleNamespace(),
+                               loop_args = SimpleNamespace())
 
 
 def buildParseqAdapter(parseq_use_deltas, parseq_manifest, setup_args=DEFAULT_ARGS):
     return ParseqAdapter(SimpleNamespace(parseq_use_deltas=parseq_use_deltas, parseq_manifest=parseq_manifest),
-                         setup_args.anim_args, setup_args.video_args, setup_args.controlnet_args)
+                         setup_args.anim_args, setup_args.video_args, setup_args.controlnet_args, setup_args.loop_args)
 
 class TestParseqAnimKeys(unittest.TestCase):
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_withprompt(self, mock_deformanimkeys, mock_controlnetkeys):
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    def test_withprompt(self,  mock_deformanimkeys, mock_controlnetkeys, mock_looperanimkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=True, parseq_manifest=""" 
             {                
                 "options": {
@@ -47,7 +48,8 @@ class TestParseqAnimKeys(unittest.TestCase):
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_withoutprompt(self, mock_deformanimkeys, mock_controlnetkeys):
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    def test_withoutprompt(self,  mock_deformanimkeys, mock_controlnetkeys, mock_looperanimkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=True, parseq_manifest=""" 
             {                
                 "options": {
@@ -67,7 +69,8 @@ class TestParseqAnimKeys(unittest.TestCase):
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_withseed(self, mock_deformanimkeys, mock_controlnetkeys):
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    def test_withseed(self,  mock_deformanimkeys, mock_controlnetkeys, mock_looperanimkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=True, parseq_manifest=""" 
             {                
                 "options": {
@@ -90,7 +93,8 @@ class TestParseqAnimKeys(unittest.TestCase):
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_withoutseed(self, mock_deformanimkeys, mock_controlnetkeys):
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    def test_withoutseed(self,  mock_deformanimkeys, mock_controlnetkeys, mock_looperanimkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=True, parseq_manifest=""" 
             {                
                 "options": {
@@ -111,7 +115,8 @@ class TestParseqAnimKeys(unittest.TestCase):
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_usedelta(self, mock_deformanimkeys, mock_controlnetkeys):
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    def test_usedelta(self,  mock_deformanimkeys, mock_controlnetkeys, mock_looperanimkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=True, parseq_manifest=""" 
             {                
                 "options": {
@@ -135,7 +140,8 @@ class TestParseqAnimKeys(unittest.TestCase):
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_usenondelta(self, mock_deformanimkeys, mock_controlnetkeys):
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    def test_usenondelta(self,  mock_deformanimkeys, mock_controlnetkeys, mock_looperanimkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
             {                
                 "options": {
@@ -159,7 +165,8 @@ class TestParseqAnimKeys(unittest.TestCase):
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_fallbackonundefined(self, mock_deformanimkeys, mock_controlnetkeys):
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    def test_fallbackonundefined(self,  mock_deformanimkeys, mock_controlnetkeys, mock_looperanimkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
             {                
                 "options": {
@@ -181,7 +188,8 @@ class TestParseqAnimKeys(unittest.TestCase):
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_cn(self, mock_deformanimkeys, mock_controlnetkeys):
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    def test_cn(self,  mock_deformanimkeys, mock_controlnetkeys, mock_looperanimkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
             {                
                 "options": {
@@ -203,7 +211,8 @@ class TestParseqAnimKeys(unittest.TestCase):
 
     @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
     @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
-    def test_cn_fallback(self, mock_deformanimkeys, mock_controlnetkeys):
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    def test_cn_fallback(self,  mock_deformanimkeys, mock_controlnetkeys, mock_looperanimkeys):
         parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
             {                
                 "options": {
@@ -223,5 +232,51 @@ class TestParseqAnimKeys(unittest.TestCase):
         #There must be a better way to inject an expected value via patch and check for that...
         self.assertRegex(str(parseq_adapter.cn_keys.cn_1_weight_schedule_series[0]), r'MagicMock')           
         
+    @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
+    def test_looper(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+        parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
+            {                
+                "options": {
+                    "output_fps": 30
+                },
+                "rendered_frames": [
+                    {
+                        "frame": 0,
+                        "guided_blendFactorMax": 0.4
+                    },
+                    {
+                        "frame": 1,
+                        "guided_blendFactorMax": 0.4
+                    }
+                ]
+            }
+            """)
+        self.assertEqual(parseq_adapter.looper_keys.blendFactorMax_series[0], 0.4)
+
+    @patch('deforum_helpers.parseq_adapter.DeformAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.LooperAnimKeys')
+    @patch('deforum_helpers.parseq_adapter.ControlNetKeys')
+    def test_looper_fallback(self, mock_deformanimkeys, mock_looperanimkeys, mock_controlnetkeys):
+        parseq_adapter = buildParseqAdapter(parseq_use_deltas=False, parseq_manifest=""" 
+            {                
+                "options": {
+                    "output_fps": 30
+                },
+                "rendered_frames": [
+                    {
+                        "frame": 0
+                    },
+                    {
+                        "frame": 1
+                    }
+                ]
+            }
+            """)
+        #TODO - this is a hacky check to make sure we're falling back to the mock.
+        #There must be a better way to inject an expected value via patch and check for that...
+        self.assertRegex(str(parseq_adapter.looper_keys.blendFactorMax_series[0]), r'MagicMock') 
+
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/deforum_helpers/render.py
+++ b/scripts/deforum_helpers/render.py
@@ -63,11 +63,11 @@ def render_animation(args, anim_args, video_args, parseq_args, loop_args, contro
         unpack_controlnet_vids(args, anim_args, controlnet_args)
 
     # initialise Parseq adapter
-    parseq_adapter = ParseqAdapter(parseq_args, anim_args, video_args, controlnet_args)
+    parseq_adapter = ParseqAdapter(parseq_args, anim_args, video_args, controlnet_args, loop_args)
 
     # expand key frame strings to values
     keys = DeformAnimKeys(anim_args, args.seed) if not parseq_adapter.use_parseq else parseq_adapter.anim_keys
-    loopSchedulesAndData = LooperAnimKeys(loop_args, anim_args, args.seed)
+    loopSchedulesAndData = LooperAnimKeys(loop_args, anim_args, args.seed) if not parseq_adapter.use_parseq else parseq_adapter.looper_keys
 
     # create output folder for the batch
     os.makedirs(args.outdir, exist_ok=True)

--- a/scripts/deforum_helpers/render_modes.py
+++ b/scripts/deforum_helpers/render_modes.py
@@ -80,7 +80,7 @@ def get_parsed_value(value, frame_idx, max_f):
 def render_interpolation(args, anim_args, video_args, parseq_args, loop_args, controlnet_args, root):
 
     # use parseq if manifest is provided
-    parseq_adapter = ParseqAdapter(parseq_args, anim_args, video_args, controlnet_args)
+    parseq_adapter = ParseqAdapter(parseq_args, anim_args, video_args, controlnet_args, loop_args)
 
     # expand key frame strings to values
     keys = DeformAnimKeys(anim_args) if not parseq_adapter.use_parseq else parseq_adapter.anim_keys


### PR DESCRIPTION
As discussed in https://github.com/deforum-art/sd-webui-deforum/pull/790, this is a continuation of https://github.com/deforum-art/sd-webui-deforum/pull/791 to add support for Parseq to control guided images schedules.