### PR TITLE
Set cadence to 1 by default

### DIFF
--- a/scripts/deforum_helpers/args.py
+++ b/scripts/deforum_helpers/args.py
@@ -410,7 +410,7 @@ def DeforumAnimArgs():
             "minimum": 1,
             "maximum": 50,
             "step": 1,
-            "value": 2,
+            "value": 1,
             "info": "# of in-between frames that will not be directly diffused"
         },
         "optical_flow_cadence": {


### PR DESCRIPTION
Will allow novice users to experience more surreal and astonishing transitions (with real prompt->prompt tranformation and not just a slideshow at the border frame) at a cost of doubling rendering time.

However, the default rabbit video is already quite short, so I don't thing there will be much of an impact in this regard