### PR TITLE
Allow as many CN slots as specified in A1111 Settings page

### DIFF
--- a/scripts/deforum_helpers/animation_key_frames.py
+++ b/scripts/deforum_helpers/animation_key_frames.py
@@ -76,10 +76,9 @@ class ControlNetKeys():
     def __init__(self, anim_args, controlnet_args):
         self.fi = FrameInterpolater(max_frames=anim_args.max_frames)
         self.schedules = {}
-        max_models = shared.opts.data.get("control_net_unit_count", 1) if shared.opts.data.get("control_net_unit_count", 1) is not None else shared.opts.data.get("control_net_max_models_num", 1)
+        max_models = shared.opts.data.get("control_net_unit_count", shared.opts.data.get("control_net_max_models_num", 5))
         num_of_models = 5
-        if (max_models is not None):
-            num_of_models = num_of_models if max_models <= 5 else max_models
+        num_of_models = num_of_models if max_models <= 5 else max_models
         for i in range(1, num_of_models + 1):
             for suffix in ['weight', 'guidance_start', 'guidance_end']:
                 prefix = f"cn_{i}"

--- a/scripts/deforum_helpers/animation_key_frames.py
+++ b/scripts/deforum_helpers/animation_key_frames.py
@@ -80,7 +80,7 @@ class ControlNetKeys():
         num_of_models = 5
         if (max_models is not None):
             num_of_models = 5 if max_models <= 5 else max_models
-        for i in range(1, num_of_models + 1): # 5 CN models in total
+        for i in range(1, num_of_models + 1):
             for suffix in ['weight', 'guidance_start', 'guidance_end']:
                 prefix = f"cn_{i}"
                 input_key = f"{prefix}_{suffix}"

--- a/scripts/deforum_helpers/animation_key_frames.py
+++ b/scripts/deforum_helpers/animation_key_frames.py
@@ -76,10 +76,10 @@ class ControlNetKeys():
     def __init__(self, anim_args, controlnet_args):
         self.fi = FrameInterpolater(max_frames=anim_args.max_frames)
         self.schedules = {}
-        max_models = shared.opts.data.get("control_net_max_models_num", 1)
+        max_models = shared.opts.data.get("control_net_unit_count", 1) if shared.opts.data.get("control_net_unit_count", 1) is not None else shared.opts.data.get("control_net_max_models_num", 1)
         num_of_models = 5
         if (max_models is not None):
-            num_of_models = 5 if max_models <= 5 else max_models
+            num_of_models = num_of_models if max_models <= 5 else max_models
         for i in range(1, num_of_models + 1):
             for suffix in ['weight', 'guidance_start', 'guidance_end']:
                 prefix = f"cn_{i}"

--- a/scripts/deforum_helpers/animation_key_frames.py
+++ b/scripts/deforum_helpers/animation_key_frames.py
@@ -19,6 +19,7 @@ import numpy as np
 import numexpr
 import pandas as pd
 from .prompt import check_is_number
+from modules import scripts, shared
 
 class DeformAnimKeys():
     def __init__(self, anim_args, seed=-1):
@@ -75,7 +76,11 @@ class ControlNetKeys():
     def __init__(self, anim_args, controlnet_args):
         self.fi = FrameInterpolater(max_frames=anim_args.max_frames)
         self.schedules = {}
-        for i in range(1, 6): # 5 CN models in total
+        max_models = shared.opts.data.get("control_net_max_models_num", 1)
+        num_of_models = 5
+        if (max_models is not None):
+            num_of_models = 5 if max_models <= 5 else max_models
+        for i in range(1, num_of_models + 1): # 5 CN models in total
             for suffix in ['weight', 'guidance_start', 'guidance_end']:
                 prefix = f"cn_{i}"
                 input_key = f"{prefix}_{suffix}"

--- a/scripts/deforum_helpers/deforum_controlnet.py
+++ b/scripts/deforum_helpers/deforum_controlnet.py
@@ -24,7 +24,7 @@ import scripts
 from PIL import Image
 import numpy as np
 import importlib
-from modules import scripts
+from modules import scripts, shared
 from .deforum_controlnet_gradio import hide_ui_by_cn_status, hide_file_textboxes, ToolButton
 from .general_utils import count_files_in_folder, clean_gradio_path_strings  # TODO: do it another way
 from .video_audio_utilities import vid2frames, convert_image
@@ -33,8 +33,12 @@ from .load_images import load_image
 from .general_utils import debug_print
 
 cnet = None
-# number of CN model tabs to show in the deforum gui
+# number of CN model tabs to show in the deforum gui. If the user has set it in the A1111 UI to a value less than 5
+# then we set it to 5. Else, we respect the value they specified
+max_models = shared.opts.data.get("control_net_max_models_num", 1)
 num_of_models = 5
+if (max_models is not None):
+    num_of_models = 5 if max_models <= 5 else max_models
 
 def find_controlnet():
     global cnet

--- a/scripts/deforum_helpers/deforum_controlnet.py
+++ b/scripts/deforum_helpers/deforum_controlnet.py
@@ -35,9 +35,8 @@ from .general_utils import debug_print
 cnet = None
 # number of CN model tabs to show in the deforum gui. If the user has set it in the A1111 UI to a value less than 5
 # then we set it to 5. Else, we respect the value they specified
-max_models = shared.opts.data.get("control_net_unit_count", 1) if shared.opts.data.get("control_net_unit_count", 1) is not None else shared.opts.data.get("control_net_max_models_num", 1)
-if (max_models is not None):
-    num_of_models = 5 if max_models <= 5 else max_models
+max_models = shared.opts.data.get("control_net_unit_count", shared.opts.data.get("control_net_max_models_num", 5))
+num_of_models = 5 if max_models <= 5 else max_models
 
 def find_controlnet():
     global cnet

--- a/scripts/deforum_helpers/deforum_controlnet.py
+++ b/scripts/deforum_helpers/deforum_controlnet.py
@@ -35,8 +35,7 @@ from .general_utils import debug_print
 cnet = None
 # number of CN model tabs to show in the deforum gui. If the user has set it in the A1111 UI to a value less than 5
 # then we set it to 5. Else, we respect the value they specified
-max_models = shared.opts.data.get("control_net_max_models_num", 1)
-num_of_models = 5
+max_models = shared.opts.data.get("control_net_unit_count", 1) if shared.opts.data.get("control_net_unit_count", 1) is not None else shared.opts.data.get("control_net_max_models_num", 1)
 if (max_models is not None):
     num_of_models = 5 if max_models <= 5 else max_models
 
@@ -299,7 +298,7 @@ def process_with_controlnet(p, args, anim_args, controlnet_args, root, parseq_ad
         ]
         cnu = {k: getattr(cn_args, f"{prefix}_{k}") for k in keys}
         model_num = int(prefix.split('_')[-1])  # Extract model number from prefix (e.g., "cn_1" -> 1)
-        if 1 <= model_num <= 5:
+        if 1 <= model_num <= num_of_models:
             # if in loopmode and no init image (img_np, after processing in this case) provided, disable CN unit for the very first frame. Will be enabled in the next frame automatically
             if getattr(cn_args, f"cn_{model_num}_loopback_mode") and frame_idx == 0 and img_np is None:
                 cnu['enabled'] = False


### PR DESCRIPTION
If the user sets the max CN unit count to something above 5, then Deforum will respect that and have the same number. If they set it below 5, then we keep the minimum Deforum CN slots at 5, in order to prevent any breakages when importing settings files.
This would close the feature request: https://github.com/deforum-art/sd-webui-deforum/issues/812