### PR TITLE
Fix api positive prompts

### DIFF
--- a/scripts/deforum_api.py
+++ b/scripts/deforum_api.py
@@ -79,6 +79,7 @@ def run_deforum_batch(batch_id: str, job_ids: [str], deforum_settings_files: Lis
             # For some values, defaults don't pass validation...
             run_deforum_args[prefixed_gradio_args + component_names.index('animation_prompts')] = '{"0":"dummy value"}'
             run_deforum_args[prefixed_gradio_args + component_names.index('animation_prompts_negative')] = ''
+            run_deforum_args[prefixed_gradio_args + component_names.index('animation_prompts_positive')] = ''
 
             # Arg 0 is a UID for the batch
             run_deforum_args[0] = batch_id


### PR DESCRIPTION
Hey ! 👋 

I've been playing with deforum api and there is a little "bug". 
When positive_prompts is empty, the settings file contains `"positive_prompts": null` instead of `"positive_prompts": ""` this cause all prompts to start with  `None`.

This was easily fixed by adding one line to `deforum_api.py`

Might not be the best way to fix this but seems fine to me. 