### PR TITLE
Allow users to open issues without the webui log if they promise they have a really good reason for doing so.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -94,7 +94,7 @@ body:
     id: logs
     attributes:
       label: Console logs
-      description: Now, it is the most important part which most users fail for the first time! Please provide the **full** cmd/terminal logs from the moment you started the webui (i.e. clicked the launch file or started it from cmd) to the part when your bug happened.
+      description: Now, it is the most important part which most users fail for the first time! Please provide the **full** cmd/terminal logs from the moment you started the webui (i.e. clicked the launch file or started it from cmd) to the part when your bug happened. If you have an **excellent reason** for not being able to include the log, include the string 'I have a good reason for not including the log' and explain why. Try to include at least the webui commit hash, deforum extension commit hash, pyton version and model you are working with.
       render: Shell
     validations:
       required: true

--- a/.github/scripts/issue_checker.py
+++ b/.github/scripts/issue_checker.py
@@ -39,12 +39,14 @@ for issue in repo.get_issues():
 
     # Define the keywords to search for in the issue
     keywords = ['Python', 'Commit hash', 'Launching Web UI with arguments', 'Model loaded', 'deforum']
+    excuse = 'I have a good reason for not including the log'
 
     # Check if ALL of the keywords are present in the issue
     def check_keywords(issue_body, keywords):
         for keyword in keywords:
             if not re.search(r'\b' + re.escape(keyword) + r'\b', issue_body, re.IGNORECASE):
-                return False
+                if not re.search(re.escape(excuse), issue_body, re.IGNORECASE):
+                    return False
         return True
 
     # Check if the issue title has at least a specified number of words


### PR DESCRIPTION
This has been repeatedly requested on Discord, e.g. https://discord.com/channels/1011314943380959313/1157016397789008045/1159148700724101140