### PR TITLE
Don't reject URLs that are for valid video formats but where the URL doesn't end with the extension (e.g. if there is a query string).

### DIFF
--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -155,6 +155,13 @@ def is_vid_path_valid(video_path):
     # vid path is actually a URL, check it 
     if video_path.startswith('http://') or video_path.startswith('https://'):
         response = requests.head(video_path, allow_redirects=True)
+        extension = video_path.rsplit('?', 1)[0] # remove query string before checking file format extension.
+        content_disposition = response.headers.get('Content-Disposition')
+        if content_disposition:
+            # Attempt to extract the filename from the Content-Disposition header
+            match = re.search(r'filename="?(?P<filename>[^"]+)"?', content_disposition)
+            if match:
+                extension = match.group('filename').rsplit('.', 1)[-1].lower()
         if response.status_code == 404:
             raise ConnectionError(f"Video URL {video_path} is not valid. Response status code: {response.status_code}")
         elif response.status_code == 302:
@@ -162,7 +169,7 @@ def is_vid_path_valid(video_path):
         if response.status_code != 200:
             raise ConnectionError(f"Video URL {video_path} is not valid. Response status code: {response.status_code}")
         if extension not in file_formats:
-            raise ValueError(f"Video file {video_path} has format '{extension}', which not supported. Supported formats are: {file_formats}")
+            raise ValueError(f"Video file {video_path} has format '{extension}', which is not supported. Supported formats are: {file_formats}")
     else:
         video_path = os.path.realpath(video_path)
         if not os.path.exists(video_path):


### PR DESCRIPTION
**Problem**

Currently using the a link like `https://dl.dropboxusercontent.com/scl/fi/pqwwtnur8agbt8pqlwoy6/Spiral-FAST.mov?rlkey=688h7d0bamtoliwl11qgjpitu&dl=0` for an input video (e.g. hybrid init video) will fail with an error like:

```
Error: Video file https://dl.dropboxusercontent.com/scl/fi/pqwwtnur8agbt8pqlwoy6/Spiral-FAST.mov?rlkey=688h7d0bamtoliwl11qgjpitu&dl=0 has format 'mov?rlkey=688h7d0bamtoliwl11qgjpitu&dl=0', which not supported. Supported formats are: ['mov', 'mpeg', 'mp4', 'm4v', 'avi', 'mpg', 'webm']. Please, check your schedules/ init values.
```

The issue is that the presence of the query string confuses the extension checker.

**Solution**

This PR will use the extension in the filename specified in the `Content-Disposition` header if present (as per rfc2183), else it strips the query string before checking the extension.