### PR TITLE
fix: modify create_output_panel output to match object returned

### DIFF
--- a/scripts/deforum_helpers/ui_right.py
+++ b/scripts/deforum_helpers/ui_right.py
@@ -75,6 +75,7 @@ def on_ui_tabs():
                 with gr.Row(elem_id=f"{id_part}_generate_box", variant='compact'):
                     skip = gr.Button('Pause/Resume', elem_id=f"{id_part}_skip", visible=False)
                     interrupt = gr.Button('Interrupt', elem_id=f"{id_part}_interrupt", visible=True)
+                    interrupting = gr.Button('Interrupting...', elem_id=f"{id_part}_interrupting", elem_classes="generate-box-interrupting", tooltip="Interrupting generation...")
                     submit = gr.Button('Generate', elem_id=f"{id_part}_generate", variant='primary')
 
                     skip.click(
@@ -88,7 +89,13 @@ def on_ui_tabs():
                         inputs=[],
                         outputs=[],
                     )
-                
+                    
+                    interrupting.click(
+                        fn=lambda: state.interrupt(),
+                        inputs=[],
+                        outputs=[],
+                    )
+                    
                 deforum_gallery, generation_info, html_info, _ = create_output_panel("deforum", opts.outdir_img2img_samples)
 
                 with gr.Row(variant='compact'):

--- a/scripts/deforum_helpers/ui_right.py
+++ b/scripts/deforum_helpers/ui_right.py
@@ -89,7 +89,11 @@ def on_ui_tabs():
                         outputs=[],
                     )
                 
-                deforum_gallery, generation_info, html_info, _ = create_output_panel("deforum", opts.outdir_img2img_samples)
+                res = create_output_panel("deforum", opts.outdir_img2img_samples)
+                
+                deforum_gallery = res.gallery
+                generation_info = res.generation_info
+                html_info = res.infotext
 
                 with gr.Row(variant='compact'):
                     settings_path = gr.Textbox("deforum_settings.txt", elem_id='deforum_settings_path', label="Settings File", info="settings file path can be relative to webui folder OR full - absolute")

--- a/scripts/deforum_helpers/ui_right.py
+++ b/scripts/deforum_helpers/ui_right.py
@@ -89,11 +89,11 @@ def on_ui_tabs():
                         outputs=[],
                     )
                 
-                res = create_output_panel("deforum", opts.outdir_img2img_samples)
+                output_panel = create_output_panel("deforum", opts.outdir_img2img_samples)
                 
-                deforum_gallery = res.gallery
-                generation_info = res.generation_info
-                html_info = res.infotext
+                deforum_gallery = output_panel.gallery
+                generation_info = output_panel.generation_info
+                html_info = output_panel.infotext
 
                 with gr.Row(variant='compact'):
                     settings_path = gr.Textbox("deforum_settings.txt", elem_id='deforum_settings_path', label="Settings File", info="settings file path can be relative to webui folder OR full - absolute")


### PR DESCRIPTION
Ever since this commit https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/501993ebf210bf3b55173ec1910f0c84c7e75424#diff-7825c63da20059aa9e36a44157ab1a6b36a02bd71c01f5f30ea5d028320ef263R240

the signature of `create_output_panel` has been a class object which can not be iterated, however `ui_right.py` expects an iterable.

This PR fixes the issue in a similar style to https://github.com/hako-mikan/sd-webui-supermerger/pull/323/files

fixes #949 #948 #934