### PR TITLE
Use load_file_from_url from modules.modelloader

### DIFF
--- a/scripts/deforum_helpers/general_utils.py
+++ b/scripts/deforum_helpers/general_utils.py
@@ -18,7 +18,7 @@ import os
 import shutil
 import hashlib
 from modules.shared import opts
-from basicsr.utils.download_util import load_file_from_url
+from modules.modelloader import load_file_from_url
 
 def debug_print(message):
     DEBUG_MODE = opts.data.get("deforum_debug_mode_enabled", False)

--- a/scripts/deforum_helpers/upscaling.py
+++ b/scripts/deforum_helpers/upscaling.py
@@ -22,7 +22,7 @@ import subprocess
 from .frame_interpolation import clean_folder_name
 from .general_utils import duplicate_pngs_from_folder, checksum
 from .video_audio_utilities import vid2frames, ffmpeg_stitch_video, extract_number, media_file_has_audio
-from basicsr.utils.download_util import load_file_from_url
+from modules.modelloader import load_file_from_url
 from .rich import console
 
 from modules.shared import opts

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from pkg_resources import resource_filename
 from modules.shared import state, opts
 from .general_utils import checksum, clean_gradio_path_strings, debug_print
-from basicsr.utils.download_util import load_file_from_url
+from modules.modelloader import load_file_from_url
 from .rich import console
 import shutil
 from threading import Thread


### PR DESCRIPTION
basicsr has been removed from a1111 since 1.8.0
use internal a1111 implementation of load_file_from_url instead