### PR TITLE
Basicsr deprication

### DIFF
--- a/scripts/deforum_helpers/general_utils.py
+++ b/scripts/deforum_helpers/general_utils.py
@@ -18,7 +18,7 @@ import os
 import shutil
 import hashlib
 from modules.shared import opts
-from basicsr.utils.download_util import load_file_from_url
+from modules.modelloader import load_file_from_url
 
 def debug_print(message):
     DEBUG_MODE = opts.data.get("deforum_debug_mode_enabled", False)

--- a/scripts/deforum_helpers/general_utils.py
+++ b/scripts/deforum_helpers/general_utils.py
@@ -18,7 +18,11 @@ import os
 import shutil
 import hashlib
 from modules.shared import opts
-from modules.modelloader import load_file_from_url
+try:
+  from modules.modelloader import load_file_from_url
+except:
+  print("Try to fallback to basicsr with older modules")
+  from basicsr.utils.download_util import load_file_from_url
 
 def debug_print(message):
     DEBUG_MODE = opts.data.get("deforum_debug_mode_enabled", False)

--- a/scripts/deforum_helpers/upscaling.py
+++ b/scripts/deforum_helpers/upscaling.py
@@ -22,7 +22,7 @@ import subprocess
 from .frame_interpolation import clean_folder_name
 from .general_utils import duplicate_pngs_from_folder, checksum
 from .video_audio_utilities import vid2frames, ffmpeg_stitch_video, extract_number, media_file_has_audio
-from basicsr.utils.download_util import load_file_from_url
+from modules.modelloader import load_file_from_url
 from .rich import console
 
 from modules.shared import opts

--- a/scripts/deforum_helpers/upscaling.py
+++ b/scripts/deforum_helpers/upscaling.py
@@ -22,10 +22,15 @@ import subprocess
 from .frame_interpolation import clean_folder_name
 from .general_utils import duplicate_pngs_from_folder, checksum
 from .video_audio_utilities import vid2frames, ffmpeg_stitch_video, extract_number, media_file_has_audio
-from modules.modelloader import load_file_from_url
 from .rich import console
 
 from modules.shared import opts
+
+try:
+  from modules.modelloader import load_file_from_url
+except:
+  print("Try to fallback to basicsr with older modules")
+  from basicsr.utils.download_util import load_file_from_url
 
 # NCNN Upscale section START
 def process_ncnn_upscale_vid_upload_logic(vid_path, in_vid_fps, in_vid_res, out_vid_res, models_path, upscale_model, upscale_factor, keep_imgs, f_location, f_crf, f_preset, current_user_os):

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -29,10 +29,14 @@ from pathlib import Path
 from pkg_resources import resource_filename
 from modules.shared import state, opts
 from .general_utils import checksum, clean_gradio_path_strings, debug_print
-from modules.modelloader import load_file_from_url
 from .rich import console
 import shutil
 from threading import Thread
+try:
+  from modules.modelloader import load_file_from_url
+except:
+  print("Try to fallback to basicsr with older modules")
+  from basicsr.utils.download_util import load_file_from_url
 
 def convert_image(input_path, output_path):
     # Read the input image

--- a/scripts/deforum_helpers/video_audio_utilities.py
+++ b/scripts/deforum_helpers/video_audio_utilities.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from pkg_resources import resource_filename
 from modules.shared import state, opts
 from .general_utils import checksum, clean_gradio_path_strings, debug_print
-from basicsr.utils.download_util import load_file_from_url
+from modules.modelloader import load_file_from_url
 from .rich import console
 import shutil
 from threading import Thread


### PR DESCRIPTION
basicsr has been removed from a1111 since 1.8.0
use internal a1111 implementation of load_file_from_url instead
added fallback to basicsr